### PR TITLE
add basic polyQ instantiation

### DIFF
--- a/src/rational.rs
+++ b/src/rational.rs
@@ -1,2 +1,5 @@
 pub mod mat_q;
+mod poly_q;
 pub mod q;
+
+pub use poly_q::PolyQ;

--- a/src/rational/poly_q.rs
+++ b/src/rational/poly_q.rs
@@ -1,0 +1,26 @@
+//! [`PolyQ`] is a type of polynomial with arbitrarily many coefficients of type
+//! [`Q`](crate::rational::q::Q).
+//! This implementation uses the [FLINT](https://flintlib.org/) library.
+
+use flint_sys::fmpq_poly::fmpq_poly_struct;
+
+pub mod from;
+pub mod to_string;
+
+#[derive(Debug)]
+/// [`PolyQ`] is a type of polynomial with arbitrarily many coefficients of type
+/// [`Q`](crate::rational::q::Q).
+///
+// Attributes:
+// - `poly`: holds the content of the polynomial
+//
+/// # Example
+/// ```rust
+/// use math::rational::PolyQ;
+/// use std::str::FromStr;
+///
+/// let poly = PolyQ::from_str("5  0 1/3 2/10 -3/2 1").unwrap();
+/// ```
+pub struct PolyQ {
+    pub(crate) poly: fmpq_poly_struct,
+}

--- a/src/rational/poly_q/from.rs
+++ b/src/rational/poly_q/from.rs
@@ -1,0 +1,120 @@
+//! Implementations to create a [`PolyQ`] value from other types..
+//! For each reasonable type, an explicit function with the format
+//! `from_<type_name>` and the [`From`] trait should be implemented.
+//!
+//! The explicit functions contain the documentation.
+
+use super::PolyQ;
+use crate::error::MathError;
+use flint_sys::fmpq_poly::{fmpq_poly_init, fmpq_poly_set_str};
+use std::{ffi::CString, mem::MaybeUninit, str::FromStr};
+
+impl PolyQ {
+    /// Initializes a [`PolyQ`].
+    /// This method is used to first construct a [`PolyQ`] and then later assign
+    /// the corresponding efficients with methods from FLINT.
+    ///
+    /// Returns an inititialized [`PolyQ`].
+    fn init() -> Self {
+        let mut poly = MaybeUninit::uninit();
+        unsafe {
+            fmpq_poly_init(poly.as_mut_ptr());
+            let poly = poly.assume_init();
+            Self { poly }
+        }
+    }
+}
+
+impl FromStr for PolyQ {
+    type Err = MathError;
+
+    // TODO: the second whitespace is not shown in tthe Rust-docu
+    /// Create a new polynomial with arbitrarily many coefficients of type
+    /// [`Q`](crate::rational::q::Q).
+    ///
+    /// Parameters:
+    /// - `s`: the polynomial of form: "`[#number of coefficients]  [0th coefficient] [1st coefficient] ...`"
+    /// Note that the `[#number of coefficients]` and `[0th coefficient]`
+    /// are devided by two spaces.
+    ///
+    /// Returns a [`PolyQ`] or an error, if the provided string was not formatted
+    /// correctly.
+    ///
+    /// # Example
+    /// ```rust
+    /// use math::rational::PolyQ;
+    /// use std::str::FromStr;
+    ///
+    /// let poly = PolyQ::from_str("5  0 1/3 2/10 -3/2 1").unwrap();
+    /// ```
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`InvalidStringToPolyInput`](MathError::InvalidStringToPolyInput)
+    /// if the provided string was not formatted correctly or the number of
+    /// coefficients was smaller than the number provided at the start of the
+    /// provided string.
+    /// - Returns a [`MathError`] of type
+    /// [`InvalidStringToPolyMissingWhitespace`](`MathError::InvalidStringToPolyMissingWhitespace`)
+    /// if the provided value did not contain two whitespaces.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut res = Self::init();
+
+        // TODO use the C_String error, once it is included
+        let c_string = match CString::new(s) {
+            Ok(c_string) => c_string,
+            Err(_) => return Err(MathError::InvalidStringToPolyInput(s.to_owned())),
+        };
+
+        // 0 is returned if the string is a valid input
+        // additionally if it was not succesfull, test if the provided value 's' actually
+        // contains two whitespaces, since this might be a common error
+        match unsafe { fmpq_poly_set_str(&mut res.poly, c_string.as_ptr()) } {
+            0 => Ok(res),
+            _ if !s.contains("  ") => Err(MathError::InvalidStringToPolyMissingWhitespace(
+                s.to_owned(),
+            )),
+            _ => Err(MathError::InvalidStringToPolyInput(s.to_owned())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_from_str {
+    use std::str::FromStr;
+
+    use super::PolyQ;
+
+    // tests whether a correctly formatted string outputs an instantiation of a
+    // polynomial, i.e. does not return an error
+    #[test]
+    fn working_example() {
+        assert!(PolyQ::from_str("3  1 2/5 -3/2").is_ok());
+    }
+
+    // tests whether a falsely formatted string (missing double-space) returns
+    // an error
+    #[test]
+    fn missing_whitespace() {
+        assert!(PolyQ::from_str("3 1 2/5 -3/2").is_err());
+    }
+
+    // tests whether a falsely formatted string (too many whitespaces) returns
+    // an error
+    #[test]
+    fn too_many_whitespaces() {
+        assert!(PolyQ::from_str("3  1  2/5  -3/2").is_err());
+    }
+
+    // tests whether a falsely formatted string (wrong number of total
+    // coefficients) returns an error
+    #[test]
+    fn false_number_of_coefficient() {
+        assert!(PolyQ::from_str("4  1 2/5 -3/2").is_err());
+    }
+
+    // tests whether a falsely formatted string (too many divisors) returns
+    // an error
+    #[test]
+    fn too_many_divisors() {
+        assert!(PolyQ::from_str("3  1 2/5 -3/2/3").is_err());
+    }
+}

--- a/src/rational/poly_q/to_string.rs
+++ b/src/rational/poly_q/to_string.rs
@@ -1,0 +1,68 @@
+//! This module contains all options to convert a polynomial of type
+//! [`PolyQ`] into a [`String`].
+//!
+//! This includes the [`Display`](std::fmt::Display) trait.
+
+use super::PolyQ;
+use core::fmt;
+use flint_sys::fmpq_poly::fmpq_poly_get_str;
+use std::ffi::CStr;
+
+impl fmt::Display for PolyQ {
+    /// Allows to convert a polynomial of type [`PolyQ`] into a [`String`].
+    ///
+    /// # Example 1
+    /// ```rust
+    /// use math::rational::PolyQ;
+    /// use std::str::FromStr;
+    /// use core::fmt;
+    ///
+    /// let poly = PolyQ::from_str("5  0 1 2/5 -3/2 1").unwrap();
+    /// println!("{}", poly);
+    /// ```
+    ///
+    /// # Example 2
+    /// ```rust
+    /// use math::rational::PolyQ;
+    /// use std::str::FromStr;
+    ///
+    /// let poly = PolyQ::from_str("5  0 1 2/5 -3/2 1").unwrap();
+    /// let poly_string = poly.to_string();
+    /// ```
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let c_str_ptr = unsafe { fmpq_poly_get_str(&self.poly) };
+        let return_str = unsafe { CStr::from_ptr(c_str_ptr).to_str().unwrap().to_owned() };
+        // free the space allocated by the pointer
+        unsafe { libc::free(c_str_ptr as *mut libc::c_void) };
+        write!(f, "{}", return_str)
+    }
+}
+
+#[cfg(test)]
+mod test_to_string {
+    use std::str::FromStr;
+
+    use super::PolyQ;
+
+    // tests whether a polynomial that is created using a string, returns the
+    // same string, when it is converted back to a string
+    #[test]
+    fn working_keeps_same_string() {
+        let cmp_string = "5  0 1 2/5 -3/2 1";
+        let cmp = PolyQ::from_str(cmp_string).unwrap();
+
+        assert_eq!(cmp_string, cmp.to_string())
+    }
+
+    // tests whether a polynomial that is created using a string, returns a
+    // string that can be used to create a polynomial
+    #[test]
+    fn working_use_result_of_to_string_as_input() {
+        let cmp_string = "5  0 1 2/5 -3/2 1";
+        let cmp = PolyQ::from_str(cmp_string).unwrap();
+
+        let cmp_string2 = cmp.to_string();
+
+        assert!(PolyQ::from_str(&cmp_string2).is_ok())
+    }
+}


### PR DESCRIPTION
This PR introduces the new type PolyQ, which can be initialized using a string, and transformed back to a string.

- [x]  typedef
- [x]  from_str
- [x]  display-tait