### PR TITLE
add Display trait for modulus

### DIFF
--- a/src/integer_mod_q/modulus/to_string.rs
+++ b/src/integer_mod_q/modulus/to_string.rs
@@ -42,7 +42,7 @@ impl fmt::Display for Modulus {
         // instantiated object
         let msg = "We expect the pointer to point to a real value and the c_string 
         not to be null. Hence we expect that this error does not occur";
-        let return_str = unsafe { CStr::from_ptr(c_str_ptr).to_str().expect(msg) };
+        let return_str = unsafe { CStr::from_ptr(c_str_ptr).to_str().expect(msg).to_owned() };
 
         unsafe { libc::free(c_str_ptr as *mut libc::c_void) };
 


### PR DESCRIPTION
This PR introduces an implementation of the Display trait for the Modulus object.

Alongside with the implementation, we have to consider a special case, where we have a case of where we have to decide, if we want to include a direct unwrap() in our code. I think, that it should work here, but I would like the reviewers to check, if this is actually the case.