### PR TITLE
Serialize and Deserialize for all basic types excluding matrices

### DIFF
--- a/src/integer/poly_over_z.rs
+++ b/src/integer/poly_over_z.rs
@@ -19,6 +19,7 @@ mod evaluate;
 mod from;
 mod get;
 mod ownership;
+mod serialize;
 mod set;
 mod to_string;
 

--- a/src/integer/poly_over_z/serialize.rs
+++ b/src/integer/poly_over_z/serialize.rs
@@ -1,0 +1,140 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains implementations of functions
+//! important for serialization such as the [`Serialize`] and [`Deserialize`] trait.
+//!
+//! The explicit functions contain the documentation.
+
+use super::PolyOverZ;
+use crate::macros::serialize::{deserialize, serialize};
+use core::fmt;
+use serde::{
+    de::{Error, MapAccess, Unexpected, Visitor},
+    ser::SerializeStruct,
+    Deserialize, Serialize,
+};
+use std::str::FromStr;
+
+serialize!("poly", PolyOverZ);
+deserialize!("poly", Poly, PolyOverZ);
+
+#[cfg(test)]
+mod test_serialize {
+    use crate::integer::PolyOverZ;
+    use std::str::FromStr;
+
+    /// tests whether the serialization of a positive [`PolyOverZ`] works.
+    #[test]
+    fn serialize_output_positive() {
+        let poly_str = "2  17 42";
+        let poly_z = PolyOverZ::from_str(poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a negative [`PolyOverZ`] works.
+    #[test]
+    fn serialize_output_negative() {
+        let poly_str = "3  -17 -42 1";
+        let poly_z = PolyOverZ::from_str(poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a positive large [`PolyOverZ`] works.
+    #[test]
+    fn serialize_output_positive_large() {
+        let poly_str = format!("3  -17 {} 1", u64::MAX);
+        let poly_z = PolyOverZ::from_str(&poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a positive [`PolyOverZ`] works.
+    #[test]
+    fn serialize_output_negative_large() {
+        let poly_str = format!("3  -17 -{} 1", u64::MAX);
+        let poly_z = PolyOverZ::from_str(&poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod test_deserialize {
+    use crate::integer::PolyOverZ;
+    use std::str::FromStr;
+
+    /// tests whether the deserialization of a positive [`PolyOverZ`] works.
+    #[test]
+    fn deserialize_positive() {
+        let poly_str = "2  17 42";
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverZ::from_str(poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive [`PolyOverZ`] works.
+    #[test]
+    fn deserialize_negative() {
+        let poly_str = "3  -17 -42 1";
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverZ::from_str(poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive [`PolyOverZ`] works.
+    #[test]
+    fn deserialize_positive_large() {
+        let poly_str = format!("3  -17 {} 1", u64::MAX);
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverZ::from_str(&poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive [`PolyOverZ`] works.
+    #[test]
+    fn deserialize_negative_large() {
+        let poly_str = format!("3  -17 -{} 1", u64::MAX);
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverZ::from_str(&poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether no fields 'poly' provided yield an error
+    #[test]
+    fn no_field_value() {
+        let a: Result<PolyOverZ, serde_json::Error> =
+            serde_json::from_str("{{\"tree\":\"{2  17 42}\"}}");
+        assert!(a.is_err());
+
+        let b: Result<PolyOverZ, serde_json::Error> = serde_json::from_str("{{}}");
+        assert!(b.is_err());
+    }
+
+    /// tests whether too many fields yield an error
+    #[test]
+    fn too_many_fields() {
+        let a: Result<PolyOverZ, serde_json::Error> =
+            serde_json::from_str("{{\"tree\":\"{2  17 42}\", \"poly\":\"{2  17 42}\"}}");
+        assert!(a.is_err());
+
+        let b: Result<PolyOverZ, serde_json::Error> =
+            serde_json::from_str("{{\"poly\":\"{}\", \"poly\":\"{2  17 42}\"}}");
+        assert!(b.is_err());
+    }
+}

--- a/src/integer/poly_over_z/serialize.rs
+++ b/src/integer/poly_over_z/serialize.rs
@@ -59,7 +59,7 @@ mod test_serialize {
         assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
     }
 
-    /// tests whether the serialization of a positive [`PolyOverZ`] works.
+    /// tests whether the serialization of a negative [`PolyOverZ`] works.
     #[test]
     fn serialize_output_negative_large() {
         let poly_str = format!("3  -17 -{} 1", u64::MAX);
@@ -85,7 +85,7 @@ mod test_deserialize {
         assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`PolyOverZ`] works.
+    /// tests whether the deserialization of a negative [`PolyOverZ`] works.
     #[test]
     fn deserialize_negative() {
         let poly_str = "3  -17 -42 1";
@@ -95,7 +95,7 @@ mod test_deserialize {
         assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`PolyOverZ`] works.
+    /// tests whether the deserialization of a positive large [`PolyOverZ`] works.
     #[test]
     fn deserialize_positive_large() {
         let poly_str = format!("3  -17 {} 1", u64::MAX);
@@ -105,7 +105,7 @@ mod test_deserialize {
         assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`PolyOverZ`] works.
+    /// tests whether the deserialization of a negative large [`PolyOverZ`] works.
     #[test]
     fn deserialize_negative_large() {
         let poly_str = format!("3  -17 -{} 1", u64::MAX);

--- a/src/integer/z/serialize.rs
+++ b/src/integer/z/serialize.rs
@@ -22,7 +22,7 @@ use serde::{
 use std::str::FromStr;
 
 serialize!("value", Z);
-deserialize!("value", Z);
+deserialize!("value", Value, Z);
 
 #[cfg(test)]
 mod test_serialize {

--- a/src/integer/z/serialize.rs
+++ b/src/integer/z/serialize.rs
@@ -57,7 +57,7 @@ mod test_serialize {
         assert_eq!(cmp_string, serde_json::to_string(&z).unwrap())
     }
 
-    /// tests whether the serialization of a positive [`Z`] works.
+    /// tests whether the serialization of a negative large [`Z`] works.
     #[test]
     fn serialize_output_negative_large() {
         let val_str = format!("-{}", u64::MAX);
@@ -80,14 +80,14 @@ mod test_deserialize {
         assert_eq!(Z::from(17), serde_json::from_str(z_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`Z`] works.
+    /// tests whether the deserialization of a negative [`Z`] works.
     #[test]
     fn deserialize_negative() {
         let z_string = "{\"value\":\"-17\"}";
         assert_eq!(Z::from(-17), serde_json::from_str(z_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`Z`] works.
+    /// tests whether the deserialization of a positive large [`Z`] works.
     #[test]
     fn deserialize_positive_large() {
         let val_str = u64::MAX.to_string();
@@ -99,7 +99,7 @@ mod test_deserialize {
         )
     }
 
-    /// tests whether the deserialization of a positive [`Z`] works.
+    /// tests whether the deserialization of a negative large [`Z`] works.
     #[test]
     fn deserialize_negative_large() {
         let val_str = format!("-{}", u64::MAX);

--- a/src/integer_mod_q/modulus.rs
+++ b/src/integer_mod_q/modulus.rs
@@ -20,6 +20,7 @@ mod from;
 mod get;
 mod ownership;
 mod properties;
+mod serialize;
 mod to_string;
 
 /// [`Modulus`] is a type of a positive non-zero integer that is used

--- a/src/integer_mod_q/modulus/serialize.rs
+++ b/src/integer_mod_q/modulus/serialize.rs
@@ -1,0 +1,119 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains implementations of functions
+//! important for serialization such as the [`Serialize`] and [`Deserialize`] trait.
+//!
+//! The explicit functions contain the documentation.
+
+use super::Modulus;
+use crate::macros::serialize::{deserialize, serialize};
+use core::fmt;
+use serde::{
+    de::{Error, MapAccess, Unexpected, Visitor},
+    ser::SerializeStruct,
+    Deserialize, Serialize,
+};
+use std::str::FromStr;
+
+serialize!("modulus", Modulus);
+deserialize!("modulus", Modulus, Modulus);
+
+#[cfg(test)]
+mod test_serialize {
+    use crate::{integer::Z, integer_mod_q::Modulus};
+    use std::str::FromStr;
+
+    /// tests whether the serialization of a positive [`Modulus`] works.
+    #[test]
+    fn serialize_output_positive() {
+        let z = Modulus::try_from(&Z::from(17)).unwrap();
+        let cmp_string = "{\"modulus\":\"17\"}";
+
+        assert_eq!(cmp_string, serde_json::to_string(&z).unwrap())
+    }
+
+    /// tests whether the serialization of a positive large [`Modulus`] works.
+    #[test]
+    fn serialize_output_positive_large() {
+        let val_str = u64::MAX.to_string();
+        let z = Modulus::from_str(&val_str).unwrap();
+        let cmp_string = format!("{{\"modulus\":\"{}\"}}", val_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&z).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod test_deserialize {
+    use crate::{integer::Z, integer_mod_q::Modulus};
+    use std::str::FromStr;
+
+    /// tests whether the deserialization of a positive [`Modulus`] works.
+    #[test]
+    fn deserialize_positive() {
+        let z_string = "{\"modulus\":\"17\"}";
+        assert_eq!(
+            Modulus::try_from(&Z::from(17)).unwrap(),
+            serde_json::from_str(z_string).unwrap()
+        )
+    }
+
+    /// tests whether the deserialization of a negative [`Modulus`] fails.
+    #[test]
+    fn deserialize_negative() {
+        let z_string = "{\"modulus\":\"-17\"}";
+
+        let a: Result<Modulus, serde_json::Error> = serde_json::from_str(z_string);
+        assert!(a.is_err())
+    }
+
+    /// tests whether the deserialization of a positive [`Modulus`] works.
+    #[test]
+    fn deserialize_positive_large() {
+        let val_str = u64::MAX.to_string();
+        let z_string = format!("{{\"modulus\":\"{}\"}}", val_str);
+
+        assert_eq!(
+            Modulus::from_str(&val_str).unwrap(),
+            serde_json::from_str(&z_string).unwrap()
+        )
+    }
+
+    /// tests whether the deserialization of a large negative [`Modulus`] fails.
+    #[test]
+    fn deserialize_negative_large() {
+        let val_str = format!("-{}", u64::MAX);
+        let z_string = format!("{{\"modulus\":\"{}\"}}", val_str);
+
+        let a: Result<Modulus, serde_json::Error> = serde_json::from_str(&z_string);
+        assert!(a.is_err())
+    }
+
+    /// tests whether no fields 'value' provided yield an error
+    #[test]
+    fn no_field_value() {
+        let a: Result<Modulus, serde_json::Error> = serde_json::from_str("{{\"tree\":\"{17}\"}}");
+        assert!(a.is_err());
+
+        let b: Result<Modulus, serde_json::Error> = serde_json::from_str("{{}}");
+        assert!(b.is_err());
+    }
+
+    /// tests whether too many fields yield an error
+    #[test]
+    fn too_many_fields() {
+        let a: Result<Modulus, serde_json::Error> =
+            serde_json::from_str("{{\"tree\":\"{17}\", \"modulus\":\"{17}\"}}");
+        assert!(a.is_err());
+
+        let b: Result<Modulus, serde_json::Error> =
+            serde_json::from_str("{{\"modulus\":\"{}\", \"modulus\":\"{17}\"}}");
+        assert!(b.is_err());
+    }
+}

--- a/src/integer_mod_q/modulus_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq.rs
@@ -17,6 +17,7 @@ mod cmp;
 mod from;
 mod get;
 mod ownership;
+mod serialize;
 mod to_string;
 
 /// [`ModulusPolynomialRingZq`] represents the modulus object for

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/serialize.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/serialize.rs
@@ -1,0 +1,165 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains implementations of functions
+//! important for serialization such as the [`Serialize`] and [`Deserialize`] trait.
+//!
+//! The explicit functions contain the documentation.
+
+use super::ModulusPolynomialRingZq;
+use crate::macros::serialize::{deserialize, serialize};
+use core::fmt;
+use serde::{
+    de::{Error, MapAccess, Unexpected, Visitor},
+    ser::SerializeStruct,
+    Deserialize, Serialize,
+};
+use std::str::FromStr;
+
+serialize!("poly", ModulusPolynomialRingZq);
+deserialize!("poly", Poly, ModulusPolynomialRingZq);
+
+#[cfg(test)]
+mod test_serialize {
+    use crate::integer_mod_q::ModulusPolynomialRingZq;
+    use std::str::FromStr;
+
+    /// tests whether the serialization of a positive [`ModulusPolynomialRingZq`] works.
+    #[test]
+    fn serialize_output_positive() {
+        let poly_str = "2  17 42 mod 331";
+        let poly_z = ModulusPolynomialRingZq::from_str(poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a negative [`ModulusPolynomialRingZq`] works.
+    #[test]
+    fn serialize_output_negative() {
+        let poly_str = "3  -17 -42 1 mod 331";
+        let poly_z = ModulusPolynomialRingZq::from_str(poly_str).unwrap();
+        let cmp_string = "{\"poly\":\"3  314 289 1 mod 331\"}";
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a positive large [`ModulusPolynomialRingZq`] works.
+    #[test]
+    fn serialize_output_positive_large() {
+        let poly_str = format!("3  1 {} 1 mod {}", u64::MAX, u64::MAX - 58);
+        let poly_z = ModulusPolynomialRingZq::from_str(&poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"3  1 58 1 mod {}\"}}", u64::MAX - 58);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a negative large [`ModulusPolynomialRingZq`] works.
+    #[test]
+    fn serialize_output_negative_large() {
+        let poly_str = format!("3  1 -{} 1 mod {}", u64::MAX, u64::MAX - 58);
+        let poly_z = ModulusPolynomialRingZq::from_str(&poly_str).unwrap();
+        let cmp_string = format!(
+            "{{\"poly\":\"3  1 {} 1 mod {}\"}}",
+            u64::MAX - 2 * 58,
+            u64::MAX - 58
+        );
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod test_deserialize {
+    use crate::integer_mod_q::ModulusPolynomialRingZq;
+    use std::str::FromStr;
+
+    /// tests whether the deserialization of a positive [`ModulusPolynomialRingZq`] works.
+    #[test]
+    fn deserialize_positive() {
+        let poly_str = "2  17 42 mod 331";
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = ModulusPolynomialRingZq::from_str(poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a negative [`ModulusPolynomialRingZq`] works.
+    #[test]
+    fn deserialize_negative() {
+        let poly_str = "3  -17 -42 1 mod 331";
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = ModulusPolynomialRingZq::from_str(poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive large [`ModulusPolynomialRingZq`] works.
+    #[test]
+    fn deserialize_positive_large() {
+        let poly_str = format!("3  -17 {} 1 mod {}", u64::MAX, u64::MAX - 58);
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = ModulusPolynomialRingZq::from_str(&poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a negative large [`ModulusPolynomialRingZq`] works.
+    #[test]
+    fn deserialize_negative_large() {
+        let poly_str = format!("3  -17 -{} 1 mod {}", u64::MAX, u64::MAX - 58);
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = ModulusPolynomialRingZq::from_str(&poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether deserialization of a non-prime large `q` [`ModulusPolynomialRingZq`] fails.
+    #[test]
+    fn non_prime_q() {
+        let a: Result<ModulusPolynomialRingZq, serde_json::Error> =
+            serde_json::from_str(&format!("{{\"poly\":\"2  17 42 mod {}\"}}", u64::MAX));
+        assert!(a.is_err());
+    }
+
+    /// tests whether deserialization of a negative `q` [`ModulusPolynomialRingZq`] fails.
+    #[test]
+    fn negative_q() {
+        let a: Result<ModulusPolynomialRingZq, serde_json::Error> =
+            serde_json::from_str(&format!("{{\"poly\":\"2  17 42 mod -{}\"}}", u64::MAX));
+        assert!(a.is_err());
+
+        let b: Result<ModulusPolynomialRingZq, serde_json::Error> =
+            serde_json::from_str("{{\"poly\":\"2  17 42 mod -17\"}}");
+        assert!(b.is_err());
+    }
+
+    /// tests whether no fields 'poly' provided yield an error [`ModulusPolynomialRingZq`] works.
+    #[test]
+    fn no_field_value() {
+        let a: Result<ModulusPolynomialRingZq, serde_json::Error> =
+            serde_json::from_str("{{\"tree\":\"{2  17 42 mod 331}\"}}");
+        assert!(a.is_err());
+
+        let b: Result<ModulusPolynomialRingZq, serde_json::Error> = serde_json::from_str("{{}}");
+        assert!(b.is_err());
+    }
+
+    /// tests whether too many fields yield an error
+    #[test]
+    fn too_many_fields() {
+        let a: Result<ModulusPolynomialRingZq, serde_json::Error> = serde_json::from_str(
+            "{{\"tree\":\"{2  17 42 mod 331}\", \"poly\":\"{2  17 42 mod 331}\"}}",
+        );
+        assert!(a.is_err());
+
+        let b: Result<ModulusPolynomialRingZq, serde_json::Error> =
+            serde_json::from_str("{{\"poly\":\"{}\", \"poly\":\"{2  17 42 mod 331}\"}}");
+        assert!(b.is_err());
+    }
+}

--- a/src/integer_mod_q/poly_over_zq.rs
+++ b/src/integer_mod_q/poly_over_zq.rs
@@ -18,6 +18,7 @@ mod from;
 mod get;
 mod ownership;
 mod properties;
+mod serialize;
 mod to_string;
 
 /// [`PolyOverZq`] is a type of polynomial with arbitrarily many coefficients of type

--- a/src/integer_mod_q/poly_over_zq/serialize.rs
+++ b/src/integer_mod_q/poly_over_zq/serialize.rs
@@ -1,0 +1,145 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains implementations of functions
+//! important for serialization such as the [`Serialize`] and [`Deserialize`] trait.
+//!
+//! The explicit functions contain the documentation.
+
+use super::PolyOverZq;
+use crate::macros::serialize::{deserialize, serialize};
+use core::fmt;
+use serde::{
+    de::{Error, MapAccess, Unexpected, Visitor},
+    ser::SerializeStruct,
+    Deserialize, Serialize,
+};
+use std::str::FromStr;
+
+serialize!("poly", PolyOverZq);
+deserialize!("poly", Poly, PolyOverZq);
+
+#[cfg(test)]
+mod test_serialize {
+    use crate::integer_mod_q::PolyOverZq;
+    use std::str::FromStr;
+
+    /// tests whether the serialization of a positive [`PolyOverZq`] works.
+    #[test]
+    fn serialize_output_positive() {
+        let poly_str = "2  17 42 mod 81";
+        let poly_z = PolyOverZq::from_str(poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a negative [`PolyOverZq`] works.
+    #[test]
+    fn serialize_output_negative() {
+        let poly_str = "3  -17 -42 1 mod 81";
+        let poly_z = PolyOverZq::from_str(poly_str).unwrap();
+        let cmp_string = "{\"poly\":\"3  64 39 1 mod 81\"}";
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a positive large [`PolyOverZq`] works.
+    #[test]
+    fn serialize_output_positive_large() {
+        let poly_str = format!("3  1 {} 1 mod {}", u64::MAX, u64::MAX - 58);
+        let poly_z = PolyOverZq::from_str(&poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"3  1 58 1 mod {}\"}}", u64::MAX - 58);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a positive [`PolyOverZq`] works.
+    #[test]
+    fn serialize_output_negative_large() {
+        let poly_str = format!("3  1 -{} 1 mod {}", u64::MAX, u64::MAX - 58);
+        let poly_z = PolyOverZq::from_str(&poly_str).unwrap();
+        let cmp_string = format!(
+            "{{\"poly\":\"3  1 {} 1 mod {}\"}}",
+            u64::MAX - 2 * 58,
+            u64::MAX - 58
+        );
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod test_deserialize {
+    use crate::integer_mod_q::PolyOverZq;
+    use std::str::FromStr;
+
+    /// tests whether the deserialization of a positive [`PolyOverZq`] works.
+    #[test]
+    fn deserialize_positive() {
+        let poly_str = "2  17 42 mod 81";
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverZq::from_str(poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive [`PolyOverZq`] works.
+    #[test]
+    fn deserialize_negative() {
+        let poly_str = "3  -17 -42 1 mod 81";
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverZq::from_str(poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive [`PolyOverZq`] works.
+    #[test]
+    fn deserialize_positive_large() {
+        let poly_str = format!("3  -17 {} 1 mod {}", u64::MAX, u64::MAX - 58);
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverZq::from_str(&poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive [`PolyOverZq`] works.
+    #[test]
+    fn deserialize_negative_large() {
+        let poly_str = format!("3  -17 -{} 1 mod {}", u64::MAX, u64::MAX - 58);
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverZq::from_str(&poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether no fields 'poly' provided yield an error
+    #[test]
+    fn no_field_value() {
+        let a: Result<PolyOverZq, serde_json::Error> =
+            serde_json::from_str("{{\"tree\":\"{2  17 42 mod 81}\"}}");
+        assert!(a.is_err());
+
+        let b: Result<PolyOverZq, serde_json::Error> = serde_json::from_str("{{}}");
+        assert!(b.is_err());
+    }
+
+    /// tests whether too many fields yield an error
+    #[test]
+    fn too_many_fields() {
+        let a: Result<PolyOverZq, serde_json::Error> = serde_json::from_str(
+            "{{\"tree\":\"{2  17 42 mod 81}\", \"poly\":\"{2  17 42 mod 81}\"}}",
+        );
+        assert!(a.is_err());
+
+        let b: Result<PolyOverZq, serde_json::Error> =
+            serde_json::from_str("{{\"poly\":\"{}\", \"poly\":\"{2  17 42 mod 81}\"}}");
+        assert!(b.is_err());
+    }
+}

--- a/src/integer_mod_q/poly_over_zq/serialize.rs
+++ b/src/integer_mod_q/poly_over_zq/serialize.rs
@@ -59,7 +59,7 @@ mod test_serialize {
         assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
     }
 
-    /// tests whether the serialization of a positive [`PolyOverZq`] works.
+    /// tests whether the serialization of a negative large [`PolyOverZq`] works.
     #[test]
     fn serialize_output_negative_large() {
         let poly_str = format!("3  1 -{} 1 mod {}", u64::MAX, u64::MAX - 58);
@@ -89,7 +89,7 @@ mod test_deserialize {
         assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`PolyOverZq`] works.
+    /// tests whether the deserialization of a negative [`PolyOverZq`] works.
     #[test]
     fn deserialize_negative() {
         let poly_str = "3  -17 -42 1 mod 81";
@@ -99,7 +99,7 @@ mod test_deserialize {
         assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`PolyOverZq`] works.
+    /// tests whether the deserialization of a positive large [`PolyOverZq`] works.
     #[test]
     fn deserialize_positive_large() {
         let poly_str = format!("3  -17 {} 1 mod {}", u64::MAX, u64::MAX - 58);
@@ -109,7 +109,7 @@ mod test_deserialize {
         assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`PolyOverZq`] works.
+    /// tests whether the deserialization of a negative large [`PolyOverZq`] works.
     #[test]
     fn deserialize_negative_large() {
         let poly_str = format!("3  -17 -{} 1 mod {}", u64::MAX, u64::MAX - 58);

--- a/src/integer_mod_q/polynomial_ring_zq.rs
+++ b/src/integer_mod_q/polynomial_ring_zq.rs
@@ -19,6 +19,7 @@
 
 use super::ModulusPolynomialRingZq;
 use crate::integer::PolyOverZ;
+use serde::{Deserialize, Serialize};
 
 mod from;
 mod reduce;
@@ -31,7 +32,7 @@ mod reduce;
 /// - `modulus`: holds the prime `q` and f(X)
 ///
 /// # Example
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct PolynomialRingZq {
     poly: PolyOverZ,
     modulus: ModulusPolynomialRingZq,

--- a/src/integer_mod_q/z_q.rs
+++ b/src/integer_mod_q/z_q.rs
@@ -19,12 +19,12 @@
 
 use super::Modulus;
 use crate::integer::Z;
+use serde::{Deserialize, Serialize};
 
 mod from;
 mod reduce;
 mod to_string;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// [`Zq`] is a type for integers of arbitrary length modulo `q`.
 /// This means, integer in `[0..q)` (`0` inclusive, `q` exclusive).
 ///
@@ -42,6 +42,7 @@ mod to_string;
 /// Attributes:
 /// - `value`: holds a [`Z`] value for an integer value
 /// - `modulus`: holds a [`Modulus`] above which the value is reduced
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Zq {
     pub(crate) value: Z,
     pub(crate) modulus: Modulus,

--- a/src/macros/serialize.rs
+++ b/src/macros/serialize.rs
@@ -44,7 +44,7 @@ macro_rules! serialize {
 ///
 /// ```impl Deserialize for *type*```
 macro_rules! deserialize {
-    ($field_identifier:tt, $type:ident) => {
+    ($field_identifier:tt, $field_identifier_enum:ident, $type:ident) => {
         impl<'de> Deserialize<'de> for $type {
         paste::paste! {
             #[doc = "Implements the deserialize option. This allows to create a [`" $type "`] from a given Json-object."]
@@ -52,11 +52,13 @@ macro_rules! deserialize {
             where
                 D: serde::Deserializer<'de>,
             {
-                const FIELDS: &[&str] = &[$field_identifier];
+
+                /// This enum defines the content of the struct to be generated using [`Deserialize`]
+                const FIELDS: &[&str] = &["value"];
                 #[derive(Deserialize)]
                 #[serde(field_identifier, rename_all = "lowercase")]
                 enum Field {
-                    Value,
+                    $field_identifier_enum,
                 }
 
                 /// This visitor iterates over the strings content and collects all possible fields.
@@ -76,7 +78,7 @@ macro_rules! deserialize {
                         let mut value = None;
                         while let Some(key) = map.next_key()? {
                             match key {
-                                Field::Value => {
+                                Field::$field_identifier_enum => {
                                     if value.is_some() {
                                         return Err(Error::duplicate_field($field_identifier));
                                     }

--- a/src/rational/poly_over_q.rs
+++ b/src/rational/poly_over_q.rs
@@ -18,6 +18,7 @@ mod evaluate;
 mod from;
 mod get;
 mod ownership;
+mod serialize;
 mod to_string;
 
 /// [`PolyOverQ`] is a type of polynomial with arbitrarily many coefficients of type

--- a/src/rational/poly_over_q/serialize.rs
+++ b/src/rational/poly_over_q/serialize.rs
@@ -61,7 +61,7 @@ mod test_serialize {
         assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
     }
 
-    /// tests whether the serialization of a positive [`PolyOverQ`] works.
+    /// tests whether the serialization of a negative large [`PolyOverQ`] works.
     #[test]
     fn serialize_output_negative_large() {
         let poly_str = format!("3  -17/3 -{}/2 1", u64::MAX);
@@ -87,7 +87,7 @@ mod test_deserialize {
         assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`PolyOverQ`] works.
+    /// tests whether the deserialization of a negative [`PolyOverQ`] works.
     #[test]
     fn deserialize_negative() {
         let poly_str = "3  -17/3 -42/17 1";
@@ -97,7 +97,7 @@ mod test_deserialize {
         assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`PolyOverQ`] works.
+    /// tests whether the deserialization of a positive large [`PolyOverQ`] works.
     #[test]
     fn deserialize_positive_large() {
         let poly_str = format!("3  -17/3 {}/2 1", u64::MAX);
@@ -107,7 +107,7 @@ mod test_deserialize {
         assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
     }
 
-    /// tests whether the deserialization of a positive [`PolyOverQ`] works.
+    /// tests whether the deserialization of a negative large [`PolyOverQ`] works.
     #[test]
     fn deserialize_negative_large() {
         let poly_str = format!("3  -17/3 -{}/2 1", u64::MAX);

--- a/src/rational/poly_over_q/serialize.rs
+++ b/src/rational/poly_over_q/serialize.rs
@@ -1,0 +1,142 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains implementations of functions
+//! important for serialization such as the [`Serialize`] and [`Deserialize`] trait.
+//!
+//! The explicit functions contain the documentation.
+
+use crate::{
+    macros::serialize::{deserialize, serialize},
+    rational::PolyOverQ,
+};
+use core::fmt;
+use serde::{
+    de::{Error, MapAccess, Unexpected, Visitor},
+    ser::SerializeStruct,
+    Deserialize, Serialize,
+};
+use std::str::FromStr;
+
+serialize!("poly", PolyOverQ);
+deserialize!("poly", Poly, PolyOverQ);
+
+#[cfg(test)]
+mod test_serialize {
+    use crate::rational::PolyOverQ;
+    use std::str::FromStr;
+
+    /// tests whether the serialization of a positive [`PolyOverQ`] works.
+    #[test]
+    fn serialize_output_positive() {
+        let poly_str = "2  17/3 42/17";
+        let poly_z = PolyOverQ::from_str(poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a negative [`PolyOverQ`] works.
+    #[test]
+    fn serialize_output_negative() {
+        let poly_str = "3  -17/3 -42/17 1";
+        let poly_z = PolyOverQ::from_str(poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a positive large [`PolyOverQ`] works.
+    #[test]
+    fn serialize_output_positive_large() {
+        let poly_str = format!("3  -17/3 {}/2 1", u64::MAX);
+        let poly_z = PolyOverQ::from_str(&poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+
+    /// tests whether the serialization of a positive [`PolyOverQ`] works.
+    #[test]
+    fn serialize_output_negative_large() {
+        let poly_str = format!("3  -17/3 -{}/2 1", u64::MAX);
+        let poly_z = PolyOverQ::from_str(&poly_str).unwrap();
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        assert_eq!(cmp_string, serde_json::to_string(&poly_z).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod test_deserialize {
+    use crate::rational::PolyOverQ;
+    use std::str::FromStr;
+
+    /// tests whether the deserialization of a positive [`PolyOverQ`] works.
+    #[test]
+    fn deserialize_positive() {
+        let poly_str = "2  17/3 42/17";
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverQ::from_str(poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive [`PolyOverQ`] works.
+    #[test]
+    fn deserialize_negative() {
+        let poly_str = "3  -17/3 -42/17 1";
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverQ::from_str(poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive [`PolyOverQ`] works.
+    #[test]
+    fn deserialize_positive_large() {
+        let poly_str = format!("3  -17/3 {}/2 1", u64::MAX);
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverQ::from_str(&poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether the deserialization of a positive [`PolyOverQ`] works.
+    #[test]
+    fn deserialize_negative_large() {
+        let poly_str = format!("3  -17/3 -{}/2 1", u64::MAX);
+        let cmp_string = format!("{{\"poly\":\"{}\"}}", poly_str);
+
+        let poly_z = PolyOverQ::from_str(&poly_str).unwrap();
+        assert_eq!(poly_z, serde_json::from_str(&cmp_string).unwrap())
+    }
+
+    /// tests whether no fields 'poly' provided yield an error
+    #[test]
+    fn no_field_value() {
+        let a: Result<PolyOverQ, serde_json::Error> =
+            serde_json::from_str("{{\"tree\":\"{2  17/3 42/17}\"}}");
+        assert!(a.is_err());
+
+        let b: Result<PolyOverQ, serde_json::Error> = serde_json::from_str("{{}}");
+        assert!(b.is_err());
+    }
+
+    /// tests whether too many fields yield an error
+    #[test]
+    fn too_many_fields() {
+        let a: Result<PolyOverQ, serde_json::Error> =
+            serde_json::from_str("{{\"tree\":\"{2  17/3 42/17}\", \"poly\":\"{2  17/3 42/17}\"}}");
+        assert!(a.is_err());
+
+        let b: Result<PolyOverQ, serde_json::Error> =
+            serde_json::from_str("{{\"poly\":\"{}\", \"poly\":\"{2  17/3 42/17}\"}}");
+        assert!(b.is_err());
+    }
+}

--- a/src/rational/q/serialize.rs
+++ b/src/rational/q/serialize.rs
@@ -57,7 +57,7 @@ mod test_serialize {
         assert_eq!(cmp_string, serde_json::to_string(&q).unwrap())
     }
 
-    /// tests whether the serialization of a positive [`Q`] works.
+    /// tests whether the serialization of a negative large [`Q`] works.
     #[test]
     fn serialize_output_negative_large() {
         let val_str = format!("-{}/2", u64::MAX);
@@ -83,7 +83,7 @@ mod test_deserialize {
         )
     }
 
-    /// tests whether the deserialization of a positive [`Q`] works.
+    /// tests whether the deserialization of a negative [`Q`] works.
     #[test]
     fn deserialize_negative() {
         let q_string = "{\"value\":\"-17/3\"}";
@@ -93,7 +93,7 @@ mod test_deserialize {
         )
     }
 
-    /// tests whether the deserialization of a positive [`Q`] works.
+    /// tests whether the deserialization of a positive large [`Q`] works.
     #[test]
     fn deserialize_positive_large() {
         let val_str = format!("{}/2", u64::MAX);
@@ -105,7 +105,7 @@ mod test_deserialize {
         )
     }
 
-    /// tests whether the deserialization of a positive [`Q`] works.
+    /// tests whether the deserialization of a negative large [`Q`] works.
     #[test]
     fn deserialize_negative_large() {
         let val_str = format!("-{}/2", u64::MAX);

--- a/src/rational/q/serialize.rs
+++ b/src/rational/q/serialize.rs
@@ -22,7 +22,7 @@ use serde::{
 use std::str::FromStr;
 
 serialize!("value", Q);
-deserialize!("value", Q);
+deserialize!("value", Value, Q);
 
 #[cfg(test)]
 mod test_serialize {


### PR DESCRIPTION
This PR implements the `Serialize `and `Deserialize` trait for

- [x] PolyOverZ
- [x] PolyOverQ
- [x] Modulus
- [x] ModulusPolynomailRingZq
- [x] PolyOverZq
- [x] PolynomialRingZq (derivable)
- [x] Zq (derivable)