### PR TITLE
Resolve TODO in From_str Modulus

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,8 +29,6 @@ use thiserror::Error;
 /// construct an integer.
 /// - `InvalidStringToMatZInput` is thrown if an invalid string is given to
 /// construct a Matrix of [`MatZ`](crate::integer::MatZ)
-/// - `InvalidStringToModulusInput` is thrown if an invalid string is given to
-/// construct a modulus.
 /// - `InvalidStringToPolyInput` is thrown if an invalid string is given to
 /// construct a polynomial
 /// - `InvalidStringToPolyMissingWhiteSpace` is thrown if an invalid string
@@ -80,12 +78,6 @@ pub enum MathError {
     /// parse string to [`MatZ`](crate::integer::MatZ) error
     #[error("invalid string input to parse to MatZ {0}")]
     InvalidStringToMatZInput(String),
-    /// parse string to modulus error
-    #[error(
-        "invalid string input to parse to a modulus {0}. \
-        The format must be '[0-9]+' and not all zeros."
-    )]
-    InvalidStringToModulusInput(String),
     /// parse string to poly error
     #[error(
         "invalid string input to parse to polynomial {0}\nThe format must 

--- a/src/integer/poly_over_z/get.rs
+++ b/src/integer/poly_over_z/get.rs
@@ -67,7 +67,7 @@ mod test_get_coeff {
 
         let zero_coeff = poly.get_coeff(4).unwrap();
 
-        assert_eq!(Z::from(0), zero_coeff)
+        assert_eq!(Z::ZERO, zero_coeff)
     }
 
     /// tests if negative coefficients are returned correctly

--- a/src/integer/z/default.rs
+++ b/src/integer/z/default.rs
@@ -37,6 +37,18 @@ impl Z {
     pub const ONE: Z = Z {
         value: flint_sys::fmpz::fmpz(1),
     };
+
+    /// Returns an instantiation of [`Z`] with value `0`.
+    ///
+    /// # Example:
+    /// ```
+    /// use math::integer::Z;
+    ///  
+    /// let a: Z = Z::ZERO;
+    /// ```
+    pub const ZERO: Z = Z {
+        value: flint_sys::fmpz::fmpz(0),
+    };
 }
 
 #[cfg(test)]
@@ -46,8 +58,14 @@ mod tests_init {
 
     /// Ensure that [`Default`] initializes [`Z`] with `0`.
     #[test]
+    fn init_default() {
+        assert_eq!(Z::ZERO, Z::default());
+    }
+
+    /// Ensure that ZERO initializes [`Z`] with `0`.
+    #[test]
     fn init_0() {
-        assert_eq!(Z::from(0), Z::default());
+        assert_eq!(Z::from(0), Z::ZERO);
     }
 
     /// Ensure that ONE initializes [`Z`] with `1`.

--- a/src/integer/z/ownership.rs
+++ b/src/integer/z/ownership.rs
@@ -89,7 +89,7 @@ mod test_clone {
     #[test]
     fn small_int() {
         let pos_1 = Z::from(16);
-        let zero_1 = Z::from(0);
+        let zero_1 = Z::ZERO;
         let neg_1 = Z::from(-16);
 
         let pos_2 = pos_1.clone();

--- a/src/integer_mod_q/modulus/from.rs
+++ b/src/integer_mod_q/modulus/from.rs
@@ -102,7 +102,7 @@ impl FromStr for Modulus {
 /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
 /// if the provided value is not greater than `0`.
 fn ctx_init(n: &Z) -> Result<fmpz_mod_ctx, MathError> {
-    if n <= &Z::from(0) {
+    if n <= &Z::ZERO {
         return Err(MathError::InvalidIntToModulus(n.to_string()));
     }
     let mut ctx = MaybeUninit::uninit();
@@ -189,7 +189,7 @@ mod test_ctx_init {
     /// tests whether a zero as input value returns an error
     #[test]
     fn zero_modulus() {
-        assert!(ctx_init(&Z::from(0)).is_err())
+        assert!(ctx_init(&Z::ZERO).is_err())
     }
 }
 

--- a/src/integer_mod_q/modulus/from.rs
+++ b/src/integer_mod_q/modulus/from.rs
@@ -74,7 +74,7 @@ impl FromStr for Modulus {
     /// # Errors and Failures
     ///
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZ`](MathError::InvalidStringToZInput) if the
+    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput) if the
     /// provided string was not formatted correctly, e.g. not a correctly
     /// formatted [`Z`].
     /// - Returns a [`MathError`] of type

--- a/src/integer_mod_q/modulus/from.rs
+++ b/src/integer_mod_q/modulus/from.rs
@@ -90,10 +90,10 @@ impl FromStr for Modulus {
     }
 }
 
-/// Initializes the FLINT-context object using a [`fmpz`]-value as input
+/// Initializes the FLINT-context object using a [`Z`]-value as input
 ///
 /// Parameters:
-/// - `s`: the value the modulus should have as [`fmpz`]
+/// - `s`: the value the modulus should have as [`Z`]
 ///
 /// Returns an initialized context object [`fmpz_mod_ctx`] or an error, if the
 /// provided value was not greater than `0`.

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -51,9 +51,9 @@ impl FromStr for PolyOverZq {
     /// if the provided half of the string was not formatted correctly to
     /// create a polynomial.
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToModulusInput`](MathError::InvalidStringToModulusInput)
+    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
     /// if the provided half of the
-    /// string was not formatted correctly to create a [`Modulus`].
+    /// string was not formatted correctly to create a [`Z`].
     /// - Returns a [`MathError`] of type
     /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
     /// if the provided modulus is not greater than `0`.

--- a/src/integer_mod_q/poly_over_zq/get.rs
+++ b/src/integer_mod_q/poly_over_zq/get.rs
@@ -146,7 +146,7 @@ mod test_get_coeff_z {
 
         let zero_coeff = poly.get_coeff(4).unwrap();
 
-        assert_eq!(Z::from(0), zero_coeff)
+        assert_eq!(Z::ZERO, zero_coeff)
     }
 
     /// tests if positive coefficients are returned correctly
@@ -179,7 +179,7 @@ mod test_get_coeff_z {
         let large_string = format!("2  -{} {} mod {}", u64::MAX, i64::MAX, modulus_str);
         let poly = PolyOverZq::from_str(&large_string).unwrap();
 
-        assert_eq!(Z::from(0), poly.get_coeff(0).unwrap());
+        assert_eq!(Z::ZERO, poly.get_coeff(0).unwrap());
         assert_eq!(Z::from(i64::MAX), poly.get_coeff(1).unwrap());
     }
 }

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -216,8 +216,8 @@ impl FromStr for Zq {
     /// [`InvalidStringToZqInput`](MathError::InvalidStringToZqInput)
     /// if the provided string was not formatted correctly.
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToModulusInput`](MathError::InvalidStringToModulusInput)
-    /// if the provided modulus was not formatted correctly
+    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
+    /// if the provided modulus was not formatted correctly to create a [`Z`]
     /// - Returns a [`MathError`] of type
     /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
     /// if the provided value is not greater than `0`.

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -301,7 +301,7 @@ mod test_try_from_z_z {
     #[test]
     fn modulus_zero() {
         let value = Z::from(10);
-        let modulus = Z::from(0);
+        let modulus = Z::ZERO;
 
         let new_zq = Zq::try_from_z_z(&value, &modulus);
 


### PR DESCRIPTION
This PR resolves a TODO in from_str for Modulus that remained since Z did not had to_string() nad from_str() at the time of implementation.
Additionally this PR introduces the constant ZERO for Z, which is especially useful for comparisons and increases readability.
This can be seen as separate from the default value, since we expect that the constant ZERO will not change, whereas the Default could potentially be changed.

- [x] resolve TODO
- [x] remove leftover error InvalidStringToModulus
- [x] add ZERO constant