### PR TITLE
rework for others macro

### DIFF
--- a/src/integer/poly_over_z/evaluate.rs
+++ b/src/integer/poly_over_z/evaluate.rs
@@ -12,53 +12,12 @@
 
 use super::PolyOverZ;
 use crate::{
-    integer::Z, macros::for_others::implement_for_others_evaluate, rational::Q, traits::Evaluate,
+    integer::Z,
+    macros::for_others::{implement_for_others, implement_for_owned},
+    rational::Q,
+    traits::Evaluate,
 };
 use flint_sys::fmpz_poly::{fmpz_poly_evaluate_fmpq, fmpz_poly_evaluate_fmpz};
-
-impl Evaluate<Z, Z> for PolyOverZ {
-    /// Evaluates a [`PolyOverZ`] on a given input.
-    ///
-    /// Parameters:
-    /// - `value`: the value with which to evaluate the polynomial.
-    ///
-    /// Returns the evaluation of the polynomial as a [`Z`].
-    ///
-    /// # Examples
-    /// ```
-    /// use math::traits::Evaluate;
-    /// use math::integer::Z;
-    /// use math::integer::PolyOverZ;
-    /// use std::str::FromStr;
-    ///
-    /// let poly = PolyOverZ::from_str("5  0 1 2 -3 1").unwrap();
-    /// let value = Z::from(3);
-    /// let res = poly.evaluate(value);
-    /// ```
-    ///
-    /// ```
-    /// use math::traits::Evaluate;
-    /// use math::integer::PolyOverZ;
-    /// use std::str::FromStr;
-    ///
-    /// let poly = PolyOverZ::from_str("5  0 1 2 -3 1").unwrap();
-    /// let value = 3;
-    /// let res = poly.evaluate(value);
-    /// ```
-    ///
-    /// ```
-    /// use math::traits::Evaluate;
-    /// use math::integer::PolyOverZ;
-    /// use std::str::FromStr;
-    ///
-    /// let poly = PolyOverZ::from_str("5  0 1 2 -3 1").unwrap();
-    /// let value = i64::MAX;
-    /// let res = poly.evaluate(value);
-    /// ```
-    fn evaluate(&self, value: Z) -> Z {
-        self.evaluate(&value)
-    }
-}
 
 impl Evaluate<&Z, Z> for PolyOverZ {
     /// Evaluates a [`PolyOverZ`] on a given input of [`Z`]. Note that the
@@ -86,30 +45,6 @@ impl Evaluate<&Z, Z> for PolyOverZ {
         unsafe { fmpz_poly_evaluate_fmpz(&mut res.value, &self.poly, &value.value) };
 
         res
-    }
-}
-
-impl Evaluate<Q, Q> for PolyOverZ {
-    /// Evaluates a [`PolyOverZ`] on a given input of [`Q`].
-    ///
-    /// Parameters:
-    /// - `value`: the value with which to evaluate the polynomial.
-    ///
-    /// Returns the evaluation of the polynomial as a [`Q`].
-    ///
-    /// # Example
-    /// ```
-    /// use math::traits::Evaluate;
-    /// use math::rational::Q;
-    /// use math::integer::PolyOverZ;
-    /// use std::str::FromStr;
-    ///
-    /// let poly = PolyOverZ::from_str("5  0 1 2 -3 1").unwrap();
-    /// let value = Q::from_str("3/2").unwrap();
-    /// let res = poly.evaluate(value);
-    /// ```
-    fn evaluate(&self, value: Q) -> Q {
-        self.evaluate(&value)
     }
 }
 
@@ -142,14 +77,9 @@ impl Evaluate<&Q, Q> for PolyOverZ {
     }
 }
 
-implement_for_others_evaluate!(i64, Z, Z, PolyOverZ);
-implement_for_others_evaluate!(i32, Z, Z, PolyOverZ);
-implement_for_others_evaluate!(i16, Z, Z, PolyOverZ);
-implement_for_others_evaluate!(i8, Z, Z, PolyOverZ);
-implement_for_others_evaluate!(u64, Z, Z, PolyOverZ);
-implement_for_others_evaluate!(u32, Z, Z, PolyOverZ);
-implement_for_others_evaluate!(u16, Z, Z, PolyOverZ);
-implement_for_others_evaluate!(u8, Z, Z, PolyOverZ);
+implement_for_others!(Z, Z, PolyOverZ, Evaluate for u8 u16 u32 u64 i8 i16 i32 i64);
+implement_for_owned!(Z, Z, PolyOverZ, Evaluate);
+implement_for_owned!(Q, Q, PolyOverZ, Evaluate);
 
 #[cfg(test)]
 mod test_evaluate_z {

--- a/src/integer/poly_over_z/set.rs
+++ b/src/integer/poly_over_z/set.rs
@@ -11,64 +11,14 @@
 
 use super::PolyOverZ;
 use crate::{
-    error::MathError, integer::Z, macros::for_others::implement_for_others_set_coeff,
-    traits::SetCoefficient, utils::coordinate::evaluate_coordinate,
+    error::MathError,
+    integer::Z,
+    macros::for_others::{implement_for_others, implement_for_owned},
+    traits::SetCoefficient,
+    utils::coordinate::evaluate_coordinate,
 };
 use flint_sys::fmpz_poly::fmpz_poly_set_coeff_fmpz;
 use std::fmt::Display;
-
-impl SetCoefficient<Z> for PolyOverZ {
-    // It is limited to i16, because an i32 as a coefficient would simply take far too
-    // much memory to be allocated:
-    // #number of coefficients * # minimum size of an entry =
-    // 2^32*64 = 274.877.906.944 Bits ≈ 34 GB since every entry
-    // is saved on their own
-    /// Sets the coefficient of a polynomial [`PolyOverZ`].
-    /// We advise to use small coefficients, since already 2^32 coefficients take space
-    /// of roughly 34 GB. If not careful, be prepared that memory problems can occur, if
-    /// the coordinate is very high.
-    ///
-    /// All entries which are not directly addressed are automatically treated as `0`.
-    ///
-    /// Parameters:
-    /// - `coordinate`: the coordinate of the coefficient to set (has to be positive)
-    /// - `value`: the new value the coordinate should have
-    ///
-    /// # Examples
-    /// ```
-    /// use math::integer::PolyOverZ;
-    /// use math::traits::SetCoefficient;
-    /// use std::str::FromStr;
-    ///
-    /// let mut poly = PolyOverZ::from_str("4  0 1 2 3").unwrap();
-    /// let value = 1000;
-    ///
-    /// assert!(poly.set_coeff(4, value).is_ok());
-    /// ```
-    ///
-    /// ```
-    /// use math::integer::PolyOverZ;
-    /// use math::integer::Z;
-    /// use math::traits::SetCoefficient;
-    /// use std::str::FromStr;
-    ///
-    /// let mut poly = PolyOverZ::from_str("4  0 1 2 3").unwrap();
-    /// let value = Z::from(100);
-    ///
-    /// assert!(poly.set_coeff(4, value).is_ok());
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the coordinate is negative or it does not fit into an [`i64`].
-    fn set_coeff(
-        &mut self,
-        coordinate: impl TryInto<i64> + Display + Copy,
-        value: Z,
-    ) -> Result<(), MathError> {
-        self.set_coeff(coordinate, &value)
-    }
-}
 
 impl SetCoefficient<&Z> for PolyOverZ {
     /// Sets the coefficient of a polynomial [`PolyOverZ`].
@@ -112,14 +62,8 @@ impl SetCoefficient<&Z> for PolyOverZ {
     }
 }
 
-implement_for_others_set_coeff!(i64, Z, PolyOverZ);
-implement_for_others_set_coeff!(i32, Z, PolyOverZ);
-implement_for_others_set_coeff!(i16, Z, PolyOverZ);
-implement_for_others_set_coeff!(i8, Z, PolyOverZ);
-implement_for_others_set_coeff!(u64, Z, PolyOverZ);
-implement_for_others_set_coeff!(u32, Z, PolyOverZ);
-implement_for_others_set_coeff!(u16, Z, PolyOverZ);
-implement_for_others_set_coeff!(u8, Z, PolyOverZ);
+implement_for_others!(Z, PolyOverZ, SetCoefficient for i8 i16 i32 i64 u8 u16 u32 u64);
+implement_for_owned!(Z, PolyOverZ, SetCoefficient);
 
 #[cfg(test)]
 mod test_set_coeff {

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -17,21 +17,38 @@
 //! pass the value to other functions taking in a [`Z`](crate::integer::Z). These macros
 //! shall implement the traits for the other types as well.
 
-/// Implements the [`SetCoefficient`](crate::traits::SetCoefficient) for [`*type*`] using the conversions from the
-/// [`*bridge_type*`] for [`*type*`].
+/// Implements a specified trait using implicit conversions to a bridge type.
+/// Several traits are already supported:
 ///
-/// Parameters:
-/// - `source_type`: the type of the input (e.g. [`i32`], [`i64`])
-/// - `bridge_type`: the type in which the input is converted
-/// - `type`: the type for which the [`SetCoefficient`](crate::traits::SetCoefficient) is implemented (e.g. [`PolyOverZ`](crate::integer::PolyOverZ), [`PolyOverQ`](crate::rational::PolyOverQ))
+/// - [`Evaluate`](crate::traits::Evaluate) with the signature
+/// `($bridge_type, $output_type, $type, Evaluate for $source_type:ident)`
+/// - [`SetCoefficient`](crate::traits::SetCoefficient) with the signature
+/// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
 ///
-/// Returns the owned Implementation code for the specified
-/// trait with the signature:
-///
-/// ```impl *specified trait*<*&source_type*> for *type*```
-macro_rules! implement_for_others_set_coeff {
-    ($source_type:ident, $bridge_type:ident, $type:ident) => {
-        impl SetCoefficient<$source_type> for $type {
+/// # Examples
+/// ```compile_fail
+/// implement_for_others!(Z, Z, PolyOverZ, Evaluate for u8 u16 u32 u64 i8 i16 i32 i64);
+/// implement_for_others!(Z, PolyOverZ, SetCoefficient for i8 i16 i32 i64 u8 u16 u32 u64);
+/// ```
+macro_rules! implement_for_others {
+    // [`Evaluate`] trait
+    ($bridge_type:ident, $output_type:ident, $type:ident, Evaluate for $($source_type:ident)*) => {
+        $(impl Evaluate<$source_type, $output_type> for $type {
+            paste::paste! {
+                #[doc = "Documentation can be found at [`" $type "::evaluate`]. Implicitly converts [`" $source_type "`] into [`" $bridge_type "`]."]
+            fn evaluate(
+                &self,
+                other: $source_type
+            ) -> $output_type {
+                self.evaluate(&$bridge_type::from(other))
+            }
+            }
+        })*
+    };
+
+    // [`SetCoefficient`] trait
+    ($bridge_type:ident, $type:ident, SetCoefficient for $($source_type:ident)*) => {
+        $(impl SetCoefficient<$source_type> for $type {
             paste::paste! {
                 #[doc = "Documentation can be found at [`" $type "::set_coeff`]. Implicitly converts [`" $source_type "`] into [`" $bridge_type "`]."]
             fn set_coeff(
@@ -42,26 +59,57 @@ macro_rules! implement_for_others_set_coeff {
                 self.set_coeff(coordinate, $bridge_type::from(value))
             }
             }
-        }
+        })*
     };
 }
 
-pub(crate) use implement_for_others_set_coeff;
+pub(crate) use implement_for_others;
 
-macro_rules! implement_for_others_evaluate {
-    ($source_type:ident, $bridge_type:ident, $output_type:ident, $type:ident) => {
+/// Implements a specified trait for a owned input using the traits
+/// implementation for a borrowed input.
+/// Several traits are already supported:
+///
+/// - [`Evaluate`](crate::traits::Evaluate) with the signature
+/// `($bridge_type, $output_type, $type, Evaluate for $source_type:ident)`
+/// - [`SetCoefficient`](crate::traits::SetCoefficient) with the signature
+/// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
+///
+/// # Examples
+/// ```compile_fail
+/// implement_for_owned!(Q, Q, PolyOverQ, Evaluate);
+/// implement_for_owned!(Z, PolyOverZ, SetCoefficient);
+/// ```
+macro_rules! implement_for_owned {
+    // [`Evaluate`] trait
+    ($source_type:ident, $output_type:ident, $type:ident, Evaluate) => {
         impl Evaluate<$source_type, $output_type> for $type {
             paste::paste! {
-                #[doc = "Documentation can be found at [`" $type "::evaluate`]. Implicitly converts [`" $source_type "`] into [`" $bridge_type "`]."]
+                #[doc = "Documentation can be found at [`" $type "::evaluate`]."]
             fn evaluate(
                 &self,
-                value: $source_type,
+                value: $source_type
             ) -> $output_type {
-                self.evaluate($bridge_type::from(value))
+                self.evaluate(&value)
+            }
+            }
+        }
+    };
+
+    // [`SetCoefficient`] trait
+    ($source_type:ident, $type:ident, SetCoefficient) => {
+        impl SetCoefficient<$source_type> for $type {
+            paste::paste! {
+                #[doc = "Documentation can be found at [`" $type "::set_coeff`]."]
+            fn set_coeff(
+                &mut self,
+                coordinate: impl TryInto<i64> + Display + Copy,
+                value: $source_type,
+            ) -> Result<(), MathError> {
+                self.set_coeff(coordinate, &value)
             }
             }
         }
     };
 }
 
-pub(crate) use implement_for_others_evaluate;
+pub(crate) use implement_for_owned;

--- a/src/rational/poly_over_q/evaluate.rs
+++ b/src/rational/poly_over_q/evaluate.rs
@@ -12,34 +12,12 @@
 
 use super::PolyOverQ;
 use crate::{
-    integer::Z, macros::for_others::implement_for_others_evaluate, rational::Q, traits::Evaluate,
+    integer::Z,
+    macros::for_others::{implement_for_others, implement_for_owned},
+    rational::Q,
+    traits::Evaluate,
 };
 use flint_sys::fmpq_poly::{fmpq_poly_evaluate_fmpq, fmpq_poly_evaluate_fmpz};
-
-impl Evaluate<Q, Q> for PolyOverQ {
-    /// Evaluates a [`PolyOverQ`] on a given input.
-    ///
-    /// Parameters:
-    /// - `value`: the value with which to evaluate the polynomial. TODO: Currently supported
-    /// are all pairs of [`i8`], [`i16`],[`i32`],[`i64`],[`u8`],[`u16`],[`u32`],[`u64`] and separately [`Q`]
-    ///
-    /// Returns the evaluation of the polynomial as a [`Q`].
-    ///
-    /// # Examples
-    /// ```
-    /// use math::traits::Evaluate;
-    /// use math::rational::Q;
-    /// use math::rational::PolyOverQ;
-    /// use std::str::FromStr;
-    ///
-    /// let poly = PolyOverQ::from_str("5  0 1 2/3 -3/2 1").unwrap();
-    /// let value = Q::from_str("3/2").unwrap();
-    /// let res = poly.evaluate(value);
-    /// ```
-    fn evaluate(&self, value: Q) -> Q {
-        self.evaluate(&value)
-    }
-}
 
 impl Evaluate<&Q, Q> for PolyOverQ {
     /// Evaluates a [`PolyOverQ`] on a given input of [`Q`]. Note that the
@@ -67,30 +45,6 @@ impl Evaluate<&Q, Q> for PolyOverQ {
         unsafe { fmpq_poly_evaluate_fmpq(&mut res.value, &self.poly, &value.value) };
 
         res
-    }
-}
-
-impl Evaluate<Z, Q> for PolyOverQ {
-    /// Evaluates a [`PolyOverQ`] on a given input of [`Z`].
-    ///
-    /// Parameters:
-    /// - `value`: the value with which to evaluate the polynomial.
-    ///
-    /// Returns the evaluation of the polynomial as a [`Q`].
-    ///
-    /// # Example
-    /// ```
-    /// use math::traits::Evaluate;
-    /// use math::rational::Q;
-    /// use math::rational::PolyOverQ;
-    /// use std::str::FromStr;
-    ///
-    /// let poly = PolyOverQ::from_str("5  0 1 2/3 -3/2 1").unwrap();
-    /// let value = Q::from_str("3/2").unwrap();
-    /// let res = poly.evaluate(&value);
-    /// ```
-    fn evaluate(&self, value: Z) -> Q {
-        self.evaluate(&value)
     }
 }
 
@@ -123,14 +77,9 @@ impl Evaluate<&Z, Q> for PolyOverQ {
     }
 }
 
-implement_for_others_evaluate!(i64, Z, Q, PolyOverQ);
-implement_for_others_evaluate!(i32, Z, Q, PolyOverQ);
-implement_for_others_evaluate!(i16, Z, Q, PolyOverQ);
-implement_for_others_evaluate!(i8, Z, Q, PolyOverQ);
-implement_for_others_evaluate!(u64, Z, Q, PolyOverQ);
-implement_for_others_evaluate!(u32, Z, Q, PolyOverQ);
-implement_for_others_evaluate!(u16, Z, Q, PolyOverQ);
-implement_for_others_evaluate!(u8, Z, Q, PolyOverQ);
+implement_for_others!(Z, Q, PolyOverQ, Evaluate for u8 u16 u32 u64 i8 i16 i32 i64);
+implement_for_owned!(Z, Q, PolyOverQ, Evaluate);
+implement_for_owned!(Q, Q, PolyOverQ, Evaluate);
 
 // TODO: add traits for TryInto with other values, once the corresponding functions are
 // implemented.


### PR DESCRIPTION
This PR reworks the macro `implement_for_others` which is specifically designed to implement a certain trait for other inputs using implicit conversions. Additionally a macro is added which implements a trait with owned input using the trait with borrowed input.

Generally it reduces complexity in our macros and reduced loc.