### PR TITLE
MatZ Vector: Norms + Dot Product

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -44,8 +44,12 @@ use thiserror::Error;
 /// construct a [`Zq`](crate::integer_mod_q::Zq)
 /// - `MismatchingModulus` is thrown if any function is called on two
 /// objects with different modulus where equal modulus is required
+/// - `MismatchingVectorDimensions` is thrown if an operation of two vectors is
+/// called for which their dimensions do not match
 /// - `NotPrime` is thrown if a provided integer is not prime
 /// - `OutOfBounds` is thrown if a provided index is not in a desired range
+/// - `VectorFunctionCalledOnNonVector` is thrown if a function defined
+/// on vectors was called on a matrix instance that is not a vector
 ///
 /// # Example
 /// ```
@@ -62,24 +66,30 @@ pub enum MathError {
     /// division by zero error
     #[error("the division by zero is not possible {0}")]
     DivisionByZeroError(String),
+
     /// parse int to modulus error
     #[error(
         "invalid integer input to parse to a modulus {0}. \
         The value must be larger than 0."
     )]
     InvalidIntToModulus(String),
+
     /// invalid Matrix input error
     #[error("invalid Matrix. {0}")]
     InvalidMatrix(String),
+
     /// parse string to [`CString`](std::ffi::CString) error
     #[error("invalid string input to parse to CString {0}")]
     InvalidStringToCStringInput(#[from] NulError),
+
     /// parse string to int error
     #[error("invalid string input to parse to int {0}")]
     InvalidStringToIntInput(#[from] ParseIntError),
+
     /// parse string to [`MatZq`](crate::integer_mod_q::MatZq) error
     #[error("invalid string input to parse to MatZq {0}")]
     InvalidStringToMatZqInput(String),
+
     /// parse string to poly error
     #[error(
         "invalid string input to parse to polynomial {0}\nThe format must 
@@ -88,6 +98,7 @@ pub enum MathError {
         whitespace."
     )]
     InvalidStringToPolyInput(String),
+
     /// parse string to poly error with missing whitespace
     #[error(
         "invalid string input to parse to polynomial {0}
@@ -96,6 +107,7 @@ pub enum MathError {
         and the first coefficient"
     )]
     InvalidStringToPolyMissingWhitespace(String),
+
     /// parse string to poly with modulus error
     #[error(
         "invalid string input to parse to polynomial mod q {0}.
@@ -106,25 +118,42 @@ pub enum MathError {
         whitespaces."
     )]
     InvalidStringToPolyModulusInput(String),
+
     /// parse string to [`Q`](crate::rational::Q) error
     #[error("invalid string input to parse to Q {0}")]
     InvalidStringToQInput(String),
+
     /// parse string to [`Z`](crate::integer::Z) error
     #[error("invalid string input to parse to Z {0}")]
     InvalidStringToZInput(String),
+
     /// parse string to [`Zq`](crate::integer_mod_q::Zq) error
     #[error("invalid string input to parse to Zq {0}")]
     InvalidStringToZqInput(String),
+
     /// mismatching modulus error
     #[error("mismatching modulus.{0}")]
     MismatchingModulus(String),
+
+    /// mismatching dimensions of vectors
+    #[error("mismatching vector dimensions. {0}")]
+    MismatchingVectorDimensions(String),
+
     /// if an integer or modulus is not prime
     #[error("invalid integer. The integer has to be prime and the provided value is {0}")]
     NotPrime(String),
+
     /// if a provided index is out of bounds
     #[error(
         "invalid index submitted. The index is out of bounds.
         The index has to {0}, and the provided value is {1}"
     )]
     OutOfBounds(String, String),
+
+    /// if a function defined on vectors is called on a matrix that is not a vector
+    #[error(
+        "Function named {0} is only defined for vectors and 
+        was called on a matrix of dimension {1}x{2}"
+    )]
+    VectorFunctionCalledOnNonVector(String, i64, i64),
 }

--- a/src/integer/mat_z.rs
+++ b/src/integer/mat_z.rs
@@ -29,7 +29,7 @@ mod vector;
 ///     of the [`Z`](crate::integer::Z) matrix
 ///
 /// # Examples
-/// Matrix usage
+/// ## Matrix usage
 /// ```
 /// use math::{
 ///     integer::{MatZ, Z},
@@ -56,7 +56,7 @@ mod vector;
 /// );
 /// ```
 ///
-/// Vector usage
+/// ## Vector usage
 /// ```
 /// use math::{
 ///     integer::{MatZ, Z},

--- a/src/integer/mat_z.rs
+++ b/src/integer/mat_z.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //
@@ -29,6 +29,54 @@ mod vector;
 ///     of the [`Z`](crate::integer::Z) matrix
 ///
 /// # Examples
+/// Matrix usage
+/// ```
+/// use math::{
+///     integer::{MatZ, Z},
+///     traits::{GetEntry, SetEntry},
+/// };
+/// use std::str::FromStr;
+///
+/// // instantiate new matrix
+/// let id_mat = MatZ::from_str("[[1,0],[0,1]]").unwrap();
+///
+/// // clone object, set and get entry
+/// let mut clone = id_mat.clone();
+/// clone.set_entry(0, 0, 2);
+/// assert_eq!(clone.get_entry(1, 1).unwrap(), Z::ONE);
+///
+/// // multiplication, transposition and comparison
+/// assert_eq!(id_mat.transpose() * &clone, clone);
+///
+/// // to_string incl. (de-)serialization
+/// assert_eq!("[[1, 0],[0, 1]]", &id_mat.to_string());
+/// assert_eq!(
+///     "{\"matrix\":\"[[1, 0],[0, 1]]\"}",
+///     serde_json::to_string(&id_mat).unwrap()
+/// );
+/// ```
+///
+/// Vector usage
+/// ```
+/// use math::{
+///     integer::{MatZ, Z},
+/// };
+/// use std::str::FromStr;
+///
+/// let row_vec = MatZ::from_str("[[1,1,1]]").unwrap();
+/// let col_vec = MatZ::from_str("[[1],[-1],[0]]").unwrap();
+///
+/// // check if matrix instance is vector
+/// assert!(row_vec.is_row_vector());
+/// assert!(col_vec.is_column_vector());
+///
+/// // dot product
+/// assert_eq!(row_vec.dot_product(&col_vec).unwrap(), Z::ZERO);
+///
+/// // norm calculation
+/// assert_eq!(col_vec.norm_sqrd_eucl().unwrap(), Z::from(2));
+/// assert_eq!(row_vec.norm_infty().unwrap(), Z::ONE);
+/// ```
 #[derive(Debug)]
 pub struct MatZ {
     pub(crate) matrix: fmpz_mat_struct,

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -98,6 +98,10 @@ impl GetEntry<Z> for MatZ {
 impl MatZ {
     /// Efficiently collects all [`fmpz`]s in a [`MatZ`] without cloning them.
     ///
+    /// Hence, the values on the returned [`Vec`] are intended for short-term use
+    /// as the access to [`fmpz`] values could lead to memory leaks or modified values
+    /// once the [`MatZ`] instance was modified or dropped.
+    ///
     /// # Example
     /// ```compile_fail
     /// use math::intger::MatZ;

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -95,6 +95,33 @@ impl GetEntry<Z> for MatZ {
     }
 }
 
+impl MatZ {
+    /// Efficiently collects all [`fmpz`]s in a [`MatZ`] without cloning them.
+    ///
+    /// # Example
+    /// ```compile_fail
+    /// use math::intger::MatZ;
+    /// use std::str::FromStr;
+    ///
+    /// let mat = MatZ::from_str("[[1,2],[3,4],[5,6]]").unwrap();
+    ///
+    /// let fmpz_entries = mat.collect_entries();
+    /// ```
+    pub(crate) fn collect_entries(&self) -> Vec<fmpz> {
+        let mut entries: Vec<fmpz> = vec![];
+
+        for row in 0..self.get_num_rows() {
+            for col in 0..self.get_num_columns() {
+                // efficiently get entry without cloning the entry itself
+                let entry = unsafe { *fmpz_mat_entry(&self.matrix, row, col) };
+                entries.push(entry);
+            }
+        }
+
+        entries
+    }
+}
+
 #[cfg(test)]
 mod test_get_entry {
 
@@ -219,5 +246,33 @@ mod test_get_num {
         let matrix = MatZ::new(5, 10).unwrap();
 
         assert_eq!(matrix.get_num_columns(), 10);
+    }
+}
+
+#[cfg(test)]
+mod test_collect_entries {
+    use super::MatZ;
+    use std::str::FromStr;
+
+    #[test]
+    fn all_entries_collected() {
+        let mat_1 = MatZ::from_str(&format!("[[1,2],[{},{}],[3,4]]", i64::MAX, i64::MIN)).unwrap();
+        let mat_2 = MatZ::from_str("[[-1,2]]").unwrap();
+
+        let entries_1 = mat_1.collect_entries();
+        let entries_2 = mat_2.collect_entries();
+
+        assert_eq!(entries_1.len(), 6);
+        assert_eq!(entries_1[0].0, 1);
+        assert_eq!(entries_1[1].0, 2);
+        // 4611686018427387904 = 2^62, i.e. value is stored on stack
+        assert!(entries_1[2].0 >= 4611686018427387904);
+        assert!(entries_1[3].0 >= 4611686018427387904);
+        assert_eq!(entries_1[4].0, 3);
+        assert_eq!(entries_1[5].0, 4);
+
+        assert_eq!(entries_2.len(), 2);
+        assert_eq!(entries_2[0].0, -1);
+        assert_eq!(entries_2[1].0, 2);
     }
 }

--- a/src/integer/mat_z/vector.rs
+++ b/src/integer/mat_z/vector.rs
@@ -9,4 +9,6 @@
 //! The `vector` module contains functions that are implemented for matrices
 //! that have one column or one row and hence represent a vector.
 
+mod dot_product;
 mod is_vector;
+mod norm;

--- a/src/integer/mat_z/vector/dot_product.rs
+++ b/src/integer/mat_z/vector/dot_product.rs
@@ -1,0 +1,164 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module includes functionality to compute the dot product of two vectors.
+
+use crate::error::MathError;
+use crate::integer::{MatZ, Z};
+use crate::traits::{GetNumColumns, GetNumRows};
+use flint_sys::fmpz::{fmpz, fmpz_addmul};
+
+impl MatZ {
+    /// Returns the dot product of two vectors of type [`MatZ`].
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer::MatZ;
+    /// use std::str::FromStr;
+    /// # use math::integer::Z;
+    ///
+    /// let vec_1 = MatZ::from_str("[[1],[2],[3]]").unwrap();
+    /// let vec_2 = MatZ::from_str("[[1,3,2]]").unwrap();
+    ///
+    /// let dot_prod = vec_1.dot_product(&vec_2).unwrap();
+    ///
+    /// assert_eq!(Z::from_i64(13), dot_prod);
+    /// ```
+    ///
+    /// Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
+    /// the given [`MatZ`] instance is not a (row or column) vector.
+    /// - Returns a [`MathError`] of type [`MathError::MismatchingVectorDimensions`] if
+    /// the given vectors have different lengths.
+    pub fn dot_product(&self, other: &Self) -> Result<Z, MathError> {
+        if !self.is_vector() {
+            return Err(MathError::VectorFunctionCalledOnNonVector(
+                String::from("dot_product"),
+                self.get_num_rows(),
+                self.get_num_columns(),
+            ));
+        } else if !other.is_vector() {
+            return Err(MathError::VectorFunctionCalledOnNonVector(
+                String::from("dot_product"),
+                other.get_num_rows(),
+                other.get_num_columns(),
+            ));
+        }
+
+        let self_entries = self.collect_entries();
+        let other_entries = other.collect_entries();
+
+        if self_entries.len() != other_entries.len() {
+            return Err(MathError::MismatchingVectorDimensions(format!(
+                "You called the function 'dot_product' for vectors of different lengths: {} and {}",
+                self_entries.len(),
+                other_entries.len()
+            )));
+        }
+
+        // calculate dot product of vectors
+        let mut result = fmpz(0);
+        for i in 0..self_entries.len() {
+            // sets result = result + self.entry[i] * other.entry[i] without cloned Z element
+            unsafe { fmpz_addmul(&mut result, &self_entries[i], &other_entries[i]) }
+        }
+
+        Ok(Z { value: result })
+    }
+}
+
+#[cfg(test)]
+mod test_dot_product {
+
+    use super::{MatZ, Z};
+    use std::str::FromStr;
+
+    /// Check whether the dot product is calculated correctly for the combination:
+    /// `self`: row vector, `other`: row vector
+    #[test]
+    fn row_with_row() {
+        let vec_1 = MatZ::from_str("[[1,2,-3]]").unwrap();
+        let vec_2 = MatZ::from_str("[[1,3,2]]").unwrap();
+
+        let dot_prod = vec_1.dot_product(&vec_2).unwrap();
+
+        assert_eq!(dot_prod, Z::ONE);
+    }
+
+    /// Check whether the dot product is calculated correctly for the combination:
+    /// `self`: column vector, `other`: column vector
+    #[test]
+    fn column_with_column() {
+        let vec_1 = MatZ::from_str("[[1],[2],[-3]]").unwrap();
+        let vec_2 = MatZ::from_str("[[1],[3],[2]]").unwrap();
+
+        let dot_prod = vec_1.dot_product(&vec_2).unwrap();
+
+        assert_eq!(dot_prod, Z::ONE);
+    }
+
+    /// Check whether the dot product is calculated correctly for the combination:
+    /// `self`: row vector, `other`: column vector
+    #[test]
+    fn row_with_column() {
+        let vec_1 = MatZ::from_str("[[1,2,-3]]").unwrap();
+        let vec_2 = MatZ::from_str("[[1],[3],[2]]").unwrap();
+
+        let dot_prod = vec_1.dot_product(&vec_2).unwrap();
+
+        assert_eq!(dot_prod, Z::ONE);
+    }
+
+    /// Check whether the dot product is calculated correctly for the combination:
+    /// `self`: column vector, `other`: row vector
+    #[test]
+    fn column_with_row() {
+        let vec_1 = MatZ::from_str("[[1],[2],[-3]]").unwrap();
+        let vec_2 = MatZ::from_str("[[1,3,2]]").unwrap();
+
+        let dot_prod = vec_1.dot_product(&vec_2).unwrap();
+
+        assert_eq!(dot_prod, Z::ONE);
+    }
+
+    /// Check whether the dot product is calculated correctly with large numbers
+    #[test]
+    fn large_numbers() {
+        let vec_1 = MatZ::from_str(&format!("[[1,-1,{}]]", i64::MAX)).unwrap();
+        let vec_2 = MatZ::from_str(&format!("[[1,{},1]]", i64::MIN)).unwrap();
+        let cmp = Z::from(-1) * Z::from(i64::MIN) + Z::from(i64::MAX) + Z::ONE;
+
+        let dot_prod = vec_1.dot_product(&vec_2).unwrap();
+
+        assert_eq!(dot_prod, cmp);
+    }
+
+    /// Check whether the dot product calculation on
+    /// non vector instances yield an error
+    #[test]
+    fn non_vector_yield_error() {
+        let vec = MatZ::from_str("[[1,3,2]]").unwrap();
+        let mat = MatZ::from_str("[[1,2],[2,3],[-3,4]]").unwrap();
+
+        assert!(vec.dot_product(&mat).is_err());
+        assert!(mat.dot_product(&vec).is_err());
+        assert!(mat.dot_product(&mat).is_err());
+        assert!(vec.dot_product(&vec).is_ok());
+    }
+
+    /// Check whether the dot product calculation on
+    /// vectors of different lengths yield an error
+    #[test]
+    fn different_lengths_yield_error() {
+        let vec_1 = MatZ::from_str("[[1,2,3]]").unwrap();
+        let vec_2 = MatZ::from_str("[[1,2,3,4]]").unwrap();
+
+        assert!(vec_1.dot_product(&vec_2).is_err());
+        assert!(vec_2.dot_product(&vec_1).is_err());
+    }
+}

--- a/src/integer/mat_z/vector/dot_product.rs
+++ b/src/integer/mat_z/vector/dot_product.rs
@@ -11,10 +11,17 @@
 use crate::error::MathError;
 use crate::integer::{MatZ, Z};
 use crate::traits::{GetNumColumns, GetNumRows};
-use flint_sys::fmpz::{fmpz, fmpz_addmul};
+use flint_sys::fmpz::fmpz_addmul;
 
 impl MatZ {
     /// Returns the dot product of two vectors of type [`MatZ`].
+    ///
+    /// Paramters:
+    /// - `other`: specifies the other vector the dot product is calculated over
+    ///
+    /// Returns the resulting `dot_product` as a [`Z`] or an error,
+    /// if the given [`MatZ`] instances aren't vectors or have different
+    /// numbers of entries.
     ///
     /// # Example
     /// ```
@@ -62,13 +69,13 @@ impl MatZ {
         }
 
         // calculate dot product of vectors
-        let mut result = fmpz(0);
+        let mut result = Z::ZERO;
         for i in 0..self_entries.len() {
             // sets result = result + self.entry[i] * other.entry[i] without cloned Z element
-            unsafe { fmpz_addmul(&mut result, &self_entries[i], &other_entries[i]) }
+            unsafe { fmpz_addmul(&mut result.value, &self_entries[i], &other_entries[i]) }
         }
 
-        Ok(Z { value: result })
+        Ok(result)
     }
 }
 

--- a/src/integer/mat_z/vector/is_vector.rs
+++ b/src/integer/mat_z/vector/is_vector.rs
@@ -113,6 +113,8 @@ mod test_is_vector {
         let mat_1 = MatZ::from_str(&format!("[[1,{}],[2,3]]", i64::MIN)).unwrap();
         let mat_2 = MatZ::from_str(&format!("[[1,{},3],[4,5,6]]", i64::MAX)).unwrap();
         let mat_3 = MatZ::from_str(&format!("[[1,{}],[2,3],[4,5]]", i64::MIN)).unwrap();
+        let mat_4 = MatZ::from_str("[[1,0],[2,0],[4,0]]").unwrap();
+        let mat_5 = MatZ::from_str("[[1,2,4],[0,0,0]]").unwrap();
 
         assert!(!mat_1.is_column_vector());
         assert!(!mat_1.is_row_vector());
@@ -125,6 +127,14 @@ mod test_is_vector {
         assert!(!mat_3.is_column_vector());
         assert!(!mat_3.is_row_vector());
         assert!(!mat_3.is_vector());
+
+        assert!(!mat_4.is_column_vector());
+        assert!(!mat_4.is_row_vector());
+        assert!(!mat_4.is_vector());
+
+        assert!(!mat_5.is_column_vector());
+        assert!(!mat_5.is_row_vector());
+        assert!(!mat_5.is_vector());
     }
 
     /// Check whether matrices with only one entry get recognized as single entry matrices

--- a/src/integer/mat_z/vector/norm.rs
+++ b/src/integer/mat_z/vector/norm.rs
@@ -15,7 +15,7 @@ use crate::{
     integer::Z,
     traits::{GetNumColumns, GetNumRows},
 };
-use flint_sys::fmpz::{fmpz, fmpz_abs, fmpz_addmul, fmpz_cmpabs, fmpz_set};
+use flint_sys::fmpz::{fmpz, fmpz_abs, fmpz_addmul, fmpz_cmpabs};
 
 impl MatZ {
     /// Returns the squared Euclidean norm or 2-norm of the given (row or column) vector.
@@ -52,14 +52,14 @@ impl MatZ {
         let entries = self.collect_entries();
 
         // sum squared entries in result
-        let mut result = fmpz(0);
+        let mut result = Z::ZERO;
         for entry in entries {
             // sets result = result + entry * entry without cloned Z element
-            unsafe { fmpz_addmul(&mut result, &entry, &entry) }
+            unsafe { fmpz_addmul(&mut result.value, &entry, &entry) }
         }
 
         // TODO: Add sqrt function here
-        Ok(Z { value: result })
+        Ok(result)
     }
 
     /// Returns the infinity norm or ∞-norm of the given (row or column) vector.
@@ -101,11 +101,10 @@ impl MatZ {
         }
 
         // clone value and ensure that absolute maximum value is absolute
-        let mut clone_max = fmpz(0);
-        unsafe { fmpz_set(&mut clone_max, &max) };
-        unsafe { fmpz_abs(&mut clone_max, &clone_max) }
+        let mut result = Z::ZERO;
+        unsafe { fmpz_abs(&mut result.value, &max) }
 
-        Ok(Z { value: clone_max })
+        Ok(result)
     }
 }
 

--- a/src/integer/mat_z/vector/norm.rs
+++ b/src/integer/mat_z/vector/norm.rs
@@ -1,0 +1,230 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module includes functionality to compute several norms
+//! defined on vectors.
+
+use super::super::MatZ;
+use crate::{
+    error::MathError,
+    integer::Z,
+    traits::{GetNumColumns, GetNumRows},
+};
+use flint_sys::fmpz::{fmpz, fmpz_abs, fmpz_addmul, fmpz_cmpabs, fmpz_set};
+
+impl MatZ {
+    /// Returns the squared Euclidean norm or 2-norm of the given (row or column) vector.
+    ///
+    /// WARNING: This function may be renamed and changed in the future,
+    /// once we integrate a sqrt function for [`Z`] values.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer::MatZ;
+    /// use std::str::FromStr;
+    /// # use math::integer::Z;
+    ///
+    /// let vec = MatZ::from_str("[[1],[2],[3]]").unwrap();
+    ///
+    /// let sqrd_2_norm = vec.norm_sqrd_eucl().unwrap();
+    ///
+    /// assert_eq!(Z::from_i64(14), sqrd_2_norm);
+    /// ```
+    ///
+    /// Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
+    /// the given [`MatZ`] instance is not a (row or column) vector.
+    pub fn norm_sqrd_eucl(&self) -> Result<Z, MathError> {
+        if !self.is_vector() {
+            return Err(MathError::VectorFunctionCalledOnNonVector(
+                String::from("norm_sqrd_eucl"),
+                self.get_num_rows(),
+                self.get_num_columns(),
+            ));
+        }
+
+        // collect all entries in vector
+        let entries = self.collect_entries();
+
+        // sum squared entries in result
+        let mut result = fmpz(0);
+        for entry in entries {
+            // sets result = result + entry * entry without cloned Z element
+            unsafe { fmpz_addmul(&mut result, &entry, &entry) }
+        }
+
+        // TODO: Add sqrt function here
+        Ok(Z { value: result })
+    }
+
+    /// Returns the infinity norm or ∞-norm of the given (row or column) vector.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer::MatZ;
+    /// use std::str::FromStr;
+    /// # use math::integer::Z;
+    ///
+    /// let vec = MatZ::from_str("[[1],[2],[3]]").unwrap();
+    ///
+    /// let infty_norm = vec.norm_infty().unwrap();
+    ///
+    /// assert_eq!(Z::from_i64(3), infty_norm);
+    /// ```
+    ///
+    /// Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
+    /// the given [`MatZ`] instance is not a (row or column) vector.
+    pub fn norm_infty(&self) -> Result<Z, MathError> {
+        if !self.is_vector() {
+            return Err(MathError::VectorFunctionCalledOnNonVector(
+                String::from("norm_infty"),
+                self.get_num_rows(),
+                self.get_num_columns(),
+            ));
+        }
+
+        // collect all entries in vector
+        let entries = self.collect_entries();
+
+        // find maximum of absolute fmpz entries
+        let mut max = fmpz(0);
+        for entry in entries {
+            if unsafe { fmpz_cmpabs(&max, &entry) } < 0 {
+                max = entry;
+            }
+        }
+
+        // clone value and ensure that absolute maximum value is absolute
+        let mut clone_max = fmpz(0);
+        unsafe { fmpz_set(&mut clone_max, &max) };
+        unsafe { fmpz_abs(&mut clone_max, &clone_max) }
+
+        Ok(Z { value: clone_max })
+    }
+}
+
+#[cfg(test)]
+mod test_norm_sqrd_eucl {
+    use super::{MatZ, Z};
+    use std::str::FromStr;
+
+    /// Check whether the squared euclidean norm for row vectors
+    /// with small entries is calculated correctly
+    #[test]
+    fn row_vector_small_entries() {
+        let vec_1 = MatZ::from_str("[[1]]").unwrap();
+        let vec_2 = MatZ::from_str("[[1,10,100]]").unwrap();
+        let vec_3 = MatZ::from_str("[[1,10,100, 1000]]").unwrap();
+
+        assert_eq!(vec_1.norm_sqrd_eucl().unwrap(), Z::ONE);
+        assert_eq!(vec_2.norm_sqrd_eucl().unwrap(), Z::from_i64(10101));
+        assert_eq!(vec_3.norm_sqrd_eucl().unwrap(), Z::from_i64(1010101));
+    }
+
+    /// Check whether the squared euclidean norm for row vectors
+    /// with large entries is calculated correctly
+    #[test]
+    fn row_vector_large_entries() {
+        let vec = MatZ::from_str(&format!("[[{},{}, 2]]", i64::MAX, i64::MIN)).unwrap();
+        let max = Z::from(i64::MAX);
+        let min = Z::from(i64::MIN);
+        let cmp = &min * &min + &max * &max + Z::from(4);
+
+        assert_eq!(vec.norm_sqrd_eucl().unwrap(), cmp);
+    }
+
+    /// Check whether the squared euclidean norm for column vectors
+    /// with small entries is calculated correctly
+    #[test]
+    fn column_vector_small_entries() {
+        let vec_1 = MatZ::from_str("[[1],[10],[100]]").unwrap();
+        let vec_2 = MatZ::from_str("[[1],[10],[100],[1000]]").unwrap();
+
+        assert_eq!(vec_1.norm_sqrd_eucl().unwrap(), Z::from_i64(10101));
+        assert_eq!(vec_2.norm_sqrd_eucl().unwrap(), Z::from_i64(1010101));
+    }
+
+    /// Check whether the squared euclidean norm for column vectors
+    /// with large entries is calculated correctly
+    #[test]
+    fn column_vector_large_entries() {
+        let vec = MatZ::from_str(&format!("[[{}],[{}],[2]]", i64::MAX, i64::MIN)).unwrap();
+        let max = Z::from(i64::MAX);
+        let min = Z::from(i64::MIN);
+        let cmp = &min * &min + &max * &max + Z::from(4);
+
+        assert_eq!(vec.norm_sqrd_eucl().unwrap(), cmp);
+    }
+
+    /// Check whether euclidean norm calculations of non vectors yield an error
+    #[test]
+    fn non_vector_yield_error() {
+        let mat = MatZ::from_str("[[1,1],[10,2]]").unwrap();
+
+        assert!(mat.norm_sqrd_eucl().is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_norm_infty {
+    use super::{MatZ, Z};
+    use std::str::FromStr;
+
+    /// Check whether the infinity norm for row vectors
+    /// with small entries is calculated correctly
+    #[test]
+    fn row_vector_small_entries() {
+        let vec_1 = MatZ::from_str("[[1]]").unwrap();
+        let vec_2 = MatZ::from_str("[[1,10,100]]").unwrap();
+        let vec_3 = MatZ::from_str("[[1,10,100, 1000]]").unwrap();
+
+        assert_eq!(vec_1.norm_infty().unwrap(), Z::ONE);
+        assert_eq!(vec_2.norm_infty().unwrap(), Z::from_i64(100));
+        assert_eq!(vec_3.norm_infty().unwrap(), Z::from_i64(1000));
+    }
+
+    /// Check whether the infinity norm for row vectors
+    /// with large entries is calculated correctly
+    #[test]
+    fn row_vector_large_entries() {
+        let vec = MatZ::from_str(&format!("[[{},{}, 2]]", i64::MAX, i64::MIN)).unwrap();
+        let cmp = Z::from(-1) * Z::from(i64::MIN);
+
+        assert_eq!(vec.norm_infty().unwrap(), cmp);
+    }
+
+    /// Check whether the infinity norm for column vectors
+    /// with small entries is calculated correctly
+    #[test]
+    fn column_vector_small_entries() {
+        let vec_1 = MatZ::from_str("[[1],[10],[100]]").unwrap();
+        let vec_2 = MatZ::from_str("[[1],[10],[100],[1000]]").unwrap();
+
+        assert_eq!(vec_1.norm_infty().unwrap(), Z::from_i64(100));
+        assert_eq!(vec_2.norm_infty().unwrap(), Z::from_i64(1000));
+    }
+
+    /// Check whether the infinity norm for column vectors
+    /// with large entries is calculated correctly
+    #[test]
+    fn column_vector_large_entries() {
+        let vec = MatZ::from_str(&format!("[[{}],[{}],[2]]", i64::MAX, i64::MIN)).unwrap();
+        let cmp = Z::from(-1) * Z::from(i64::MIN);
+
+        assert_eq!(vec.norm_infty().unwrap(), cmp);
+    }
+
+    /// Check whether infinity norm calculations of non vectors yield an error
+    #[test]
+    fn non_vector_yield_error() {
+        let mat = MatZ::from_str("[[1,1],[10,2]]").unwrap();
+
+        assert!(mat.norm_infty().is_err());
+    }
+}


### PR DESCRIPTION
This PR implements...
- [X] `dot_product`
- [X] `norm_sqrd_eucl`, `norm_infty`

incl. tests for `MatZ`. Furthermore, it adds a function that efficiently collects all `fmpz` values of a `MatZ` instance without cloning and adds doc tests to `MatZ`.