### PR TITLE
MatZq is_vector

### DIFF
--- a/src/integer_mod_q/mat_zq.rs
+++ b/src/integer_mod_q/mat_zq.rs
@@ -26,7 +26,7 @@ mod vector;
 ///     of the [`Zq`](crate::integer_mod_q::Zq) matrix
 ///
 /// # Examples
-/// Matrix usage
+/// ## Matrix usage
 /// ```
 /// use math::{
 ///     integer::Z,
@@ -47,7 +47,7 @@ mod vector;
 /// assert_eq!("[[1, 0],[0, 1]] mod 2", &id_mat.to_string());
 /// ```
 ///
-/// Vector usage
+/// ## Vector usage
 /// ```
 /// use math::{
 ///     integer::Z,

--- a/src/integer_mod_q/mat_zq.rs
+++ b/src/integer_mod_q/mat_zq.rs
@@ -6,7 +6,7 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! `MatZq` is a type of matrix with integer entries of arbitrary length modulo `q`.
+//! [`MatZq`] is a type of matrix with integer entries of arbitrary length modulo `q`.
 //! This implementation uses the [FLINT](https://flintlib.org/) library.
 
 use flint_sys::fmpz_mod_mat::fmpz_mod_mat_struct;
@@ -17,6 +17,7 @@ mod get;
 mod ownership;
 mod set;
 mod to_string;
+mod vector;
 
 /// [`MatZq`] is a matrix with entries of type [`Zq`](crate::integer_mod_q::Zq).
 ///
@@ -25,6 +26,42 @@ mod to_string;
 ///     of the [`Zq`](crate::integer_mod_q::Zq) matrix
 ///
 /// # Examples
+/// Matrix usage
+/// ```
+/// use math::{
+///     integer::Z,
+///     integer_mod_q::MatZq,
+///     traits::{GetEntry, SetEntry},
+/// };
+/// use std::str::FromStr;
+///
+/// // instantiate new matrix
+/// let id_mat = MatZq::from_str("[[1,0],[0,1]] mod 2").unwrap();
+///
+/// // clone object, set and get entry
+/// let mut clone = id_mat.clone();
+/// clone.set_entry(0, 0, 2);
+/// assert_eq!(GetEntry::<Z>::get_entry(&clone, 1, 1).unwrap(), Z::ONE);
+///
+/// // to_string incl. (de-)serialization
+/// assert_eq!("[[1, 0],[0, 1]] mod 2", &id_mat.to_string());
+/// ```
+///
+/// Vector usage
+/// ```
+/// use math::{
+///     integer::Z,
+///     integer_mod_q::MatZq,
+/// };
+/// use std::str::FromStr;
+///
+/// let row_vec = MatZq::from_str("[[1,1,1]] mod 2").unwrap();
+/// let col_vec = MatZq::from_str("[[1],[-1],[0]] mod 2").unwrap();
+///
+/// // check if matrix instance is vector
+/// assert!(row_vec.is_row_vector());
+/// assert!(col_vec.is_column_vector());
+/// ```
 #[derive(Debug)]
 pub struct MatZq {
     pub(crate) matrix: fmpz_mod_mat_struct,

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -148,6 +148,10 @@ impl MatZq {
     #[allow(dead_code)]
     /// Efficiently collects all [`fmpz`]s in a [`MatZq`] without cloning them.
     ///
+    /// Hence, the values on the returned [`Vec`] are intended for short-term use
+    /// as the access to [`fmpz`] values could lead to memory leaks or modified values
+    /// once the [`MatZq`] instance was modified or dropped.
+    ///
     /// # Example
     /// ```compile_fail
     /// use math::intger_mod_q::MatZq;

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -14,8 +14,10 @@ use crate::integer_mod_q::Modulus;
 use crate::traits::{GetEntry, GetNumColumns, GetNumRows};
 use crate::utils::coordinate::evaluate_coordinates;
 use crate::{error::MathError, integer_mod_q::Zq};
-use flint_sys::fmpz::fmpz_set;
-use flint_sys::fmpz_mod_mat::fmpz_mod_mat_entry;
+use flint_sys::{
+    fmpz::{fmpz, fmpz_set},
+    fmpz_mod_mat::fmpz_mod_mat_entry,
+};
 use std::fmt::Display;
 
 impl MatZq {
@@ -139,6 +141,34 @@ impl GetEntry<Zq> for MatZq {
         let modulus = self.get_mod();
 
         Ok(Zq::from_z_modulus(&value, &modulus))
+    }
+}
+
+impl MatZq {
+    #[allow(dead_code)]
+    /// Efficiently collects all [`fmpz`]s in a [`MatZq`] without cloning them.
+    ///
+    /// # Example
+    /// ```compile_fail
+    /// use math::intger_mod_q::MatZq;
+    /// use std::str::FromStr;
+    ///
+    /// let mat = MatZq::from_str("[[1,2],[3,4],[5,6]] mod 3").unwrap();
+    ///
+    /// let fmpz_entries = mat.collect_entries();
+    /// ```
+    pub(crate) fn collect_entries(&self) -> Vec<fmpz> {
+        let mut entries: Vec<fmpz> = vec![];
+
+        for row in 0..self.get_num_rows() {
+            for col in 0..self.get_num_columns() {
+                // efficiently get entry without cloning the entry itself
+                let entry = unsafe { *fmpz_mod_mat_entry(&self.matrix, row, col) };
+                entries.push(entry);
+            }
+        }
+
+        entries
     }
 }
 
@@ -347,5 +377,39 @@ mod test_mod {
         let modulus = matrix.get_mod();
 
         assert_eq!(modulus, Modulus::try_from_z(&Z::from(u64::MAX)).unwrap());
+    }
+}
+
+#[cfg(test)]
+mod test_collect_entries {
+    use super::MatZq;
+    use std::str::FromStr;
+
+    #[test]
+    fn all_entries_collected() {
+        let mat_1 = MatZq::from_str(&format!(
+            "[[1,2],[{},{}],[3,4]] mod {}",
+            i64::MAX,
+            i64::MIN,
+            u64::MAX
+        ))
+        .unwrap();
+        let mat_2 = MatZq::from_str("[[-1,2]] mod 2").unwrap();
+
+        let entries_1 = mat_1.collect_entries();
+        let entries_2 = mat_2.collect_entries();
+
+        assert_eq!(entries_1.len(), 6);
+        assert_eq!(entries_1[0].0, 1);
+        assert_eq!(entries_1[1].0, 2);
+        // 4611686018427387904 = 2^62, i.e. value is stored on stack
+        assert!(entries_1[2].0 >= 4611686018427387904);
+        assert!(entries_1[3].0 >= 4611686018427387904);
+        assert_eq!(entries_1[4].0, 3);
+        assert_eq!(entries_1[5].0, 4);
+
+        assert_eq!(entries_2.len(), 2);
+        assert_eq!(entries_2[0].0, 1);
+        assert_eq!(entries_2[1].0, 0);
     }
 }

--- a/src/integer_mod_q/mat_zq/vector.rs
+++ b/src/integer_mod_q/mat_zq/vector.rs
@@ -1,0 +1,12 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! The `vector` module contains functions that are implemented for matrices
+//! that have one column or one row and hence represent a vector.
+
+mod is_vector;

--- a/src/integer_mod_q/mat_zq/vector/is_vector.rs
+++ b/src/integer_mod_q/mat_zq/vector/is_vector.rs
@@ -119,6 +119,8 @@ mod test_is_vector {
             MatZq::from_str(&format!("[[1,{},3],[4,5,6]] mod {}", i64::MAX, u64::MAX)).unwrap();
         let mat_3 =
             MatZq::from_str(&format!("[[1,{}],[2,3],[4,5]] mod {}", i64::MIN, u64::MAX)).unwrap();
+        let mat_4 = MatZq::from_str("[[1,0],[2,0],[4,0]] mod 6").unwrap();
+        let mat_5 = MatZq::from_str("[[1,2,4],[0,0,0]] mod 6").unwrap();
 
         assert!(!mat_1.is_column_vector());
         assert!(!mat_1.is_row_vector());
@@ -131,6 +133,14 @@ mod test_is_vector {
         assert!(!mat_3.is_column_vector());
         assert!(!mat_3.is_row_vector());
         assert!(!mat_3.is_vector());
+
+        assert!(!mat_4.is_column_vector());
+        assert!(!mat_4.is_row_vector());
+        assert!(!mat_4.is_vector());
+
+        assert!(!mat_5.is_column_vector());
+        assert!(!mat_5.is_row_vector());
+        assert!(!mat_5.is_vector());
     }
 
     /// Check whether matrices with only one entry get recognized as single entry matrices

--- a/src/integer_mod_q/mat_zq/vector/is_vector.rs
+++ b/src/integer_mod_q/mat_zq/vector/is_vector.rs
@@ -1,0 +1,168 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module includes all functionality to check
+//! whether a matrix represents a vector, i.e. has only one row
+//! or one column.
+//! These methods should be used to ensure that vector functions
+//! can only be called on suitably formed vector/matrices.
+
+use super::super::MatZq;
+use crate::traits::{GetNumColumns, GetNumRows};
+
+impl MatZq {
+    /// Returns `true` if the provided [`MatZq`] has only one row,
+    /// i.e. is a row vector. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer_mod_q::MatZq;
+    /// use std::str::FromStr;
+    ///
+    /// let col_vec = MatZq::from_str("[[1],[2],[3]] mod 4").unwrap();
+    /// let row_vec = MatZq::from_str("[[1,2,3]] mod 4").unwrap();
+    ///
+    /// assert!(row_vec.is_row_vector());
+    /// assert!(!col_vec.is_row_vector());
+    /// ```
+    pub fn is_row_vector(&self) -> bool {
+        self.get_num_rows() == 1
+    }
+
+    /// Returns `true` if the provided [`MatZq`] has only one column,
+    /// i.e. is a column vector. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer_mod_q::MatZq;
+    /// use std::str::FromStr;
+    ///
+    /// let col_vec = MatZq::from_str("[[1],[2],[3]] mod 4").unwrap();
+    /// let row_vec = MatZq::from_str("[[1,2,3]] mod 4").unwrap();
+    ///
+    /// assert!(col_vec.is_column_vector());
+    /// assert!(!row_vec.is_column_vector());
+    /// ```
+    pub fn is_column_vector(&self) -> bool {
+        self.get_num_columns() == 1
+    }
+
+    /// Returns `true` if the provided [`MatZq`] has only one column or one row,
+    /// i.e. is a vector. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer_mod_q::MatZq;
+    /// use std::str::FromStr;
+    ///
+    /// let col_vec = MatZq::from_str("[[1],[2],[3]] mod 4").unwrap();
+    /// let row_vec = MatZq::from_str("[[1,2,3]] mod 4").unwrap();
+    ///
+    /// assert!(col_vec.is_vector());
+    /// assert!(row_vec.is_vector());
+    /// ```
+    pub fn is_vector(&self) -> bool {
+        self.is_column_vector() || self.is_row_vector()
+    }
+
+    /// Returns `true` if the provided [`MatZq`] has only one entry,
+    /// i.e. is a 1x1 matrix. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer_mod_q::MatZq;
+    /// use std::str::FromStr;
+    ///
+    /// let vec = MatZq::from_str("[[1]] mod 2").unwrap();
+    ///
+    /// assert!(vec.has_single_entry());
+    /// ```
+    pub fn has_single_entry(&self) -> bool {
+        self.is_column_vector() && self.is_row_vector()
+    }
+}
+
+#[cfg(test)]
+mod test_is_vector {
+
+    use super::*;
+    use std::str::FromStr;
+
+    /// Check whether matrices with one row or one column
+    /// get recognized as (row or column) vectors
+    #[test]
+    fn vectors_detected() {
+        let row = MatZq::from_str(&format!("[[1,{}]] mod {}", i64::MIN, u64::MAX)).unwrap();
+        let col =
+            MatZq::from_str(&format!("[[1],[2],[{}],[4]] mod {}", i64::MAX, u64::MAX)).unwrap();
+
+        assert!(row.is_row_vector());
+        assert!(!row.is_column_vector());
+        assert!(row.is_vector());
+
+        assert!(!col.is_row_vector());
+        assert!(col.is_column_vector());
+        assert!(col.is_vector());
+    }
+
+    /// Check whether matrices with more than one row or column
+    /// don't get recognized as (row or column) vector
+    #[test]
+    fn non_vectors_detected() {
+        let mat_1 = MatZq::from_str(&format!("[[1,{}],[2,3]] mod {}", i64::MIN, u64::MAX)).unwrap();
+        let mat_2 =
+            MatZq::from_str(&format!("[[1,{},3],[4,5,6]] mod {}", i64::MAX, u64::MAX)).unwrap();
+        let mat_3 =
+            MatZq::from_str(&format!("[[1,{}],[2,3],[4,5]] mod {}", i64::MIN, u64::MAX)).unwrap();
+
+        assert!(!mat_1.is_column_vector());
+        assert!(!mat_1.is_row_vector());
+        assert!(!mat_1.is_vector());
+
+        assert!(!mat_2.is_column_vector());
+        assert!(!mat_2.is_row_vector());
+        assert!(!mat_2.is_vector());
+
+        assert!(!mat_3.is_column_vector());
+        assert!(!mat_3.is_row_vector());
+        assert!(!mat_3.is_vector());
+    }
+
+    /// Check whether matrices with only one entry get recognized as single entry matrices
+    #[test]
+    fn single_entry_detected() {
+        let small = MatZq::from_str("[[1]] mod 4").unwrap();
+        let large = MatZq::from_str(&format!("[[{}]] mod {}", i64::MIN, u64::MAX)).unwrap();
+
+        // check whether single entry is correctly detected
+        assert!(small.has_single_entry());
+        assert!(large.has_single_entry());
+
+        // check whether single entry is correctly detected as row and column vector
+        assert!(small.is_row_vector());
+        assert!(small.is_column_vector());
+        assert!(small.is_vector());
+
+        assert!(large.is_row_vector());
+        assert!(large.is_column_vector());
+        assert!(large.is_vector());
+    }
+
+    /// Check whether matrices with more than one entry
+    /// don't get recognized as single entry matrices
+    #[test]
+    fn non_single_entry_detected() {
+        let row = MatZq::from_str(&format!("[[1,{}]] mod {}", i64::MIN, u64::MAX)).unwrap();
+        let col = MatZq::from_str(&format!("[[1],[{}],[3]] mod {}", i64::MIN, u64::MAX)).unwrap();
+        let mat = MatZq::from_str("[[1,2],[3,4],[5,6]] mod 4").unwrap();
+
+        assert!(!row.has_single_entry());
+        assert!(!col.has_single_entry());
+        assert!(!mat.has_single_entry());
+    }
+}


### PR DESCRIPTION
This PR implements 
- [X] `is_vector` including tests for `MatZq`. 
- [X] `collect_entries` for `MatZq`, which efficiently collects all `fmpz` entries from the matrix without cloning elements.
- [X] doc tests for `MatZq`