### PR TITLE
MatQ is_vector

### DIFF
--- a/src/rational/mat_q.rs
+++ b/src/rational/mat_q.rs
@@ -26,7 +26,7 @@ mod vector;
 ///     of the [`Q`](crate::rational::Q) matrix
 ///
 /// # Examples
-/// Matrix usage
+/// ## Matrix usage
 /// ```
 /// use math::{
 ///     rational::{Q, MatQ},
@@ -35,7 +35,7 @@ mod vector;
 /// use std::str::FromStr;
 ///
 /// // instantiate new matrix
-/// let id_mat = MatQ::from_str("[[1/1,0],[0,1]]").unwrap();
+/// let id_mat = MatQ::from_str("[[1/2,0/1],[0,1]]").unwrap();
 ///
 /// // clone object, set and get entry
 /// let mut clone = id_mat.clone();
@@ -46,18 +46,18 @@ mod vector;
 /// );
 ///
 /// // to_string
-/// assert_eq!("[[1, 0],[0, 1]]", &id_mat.to_string());
+/// assert_eq!("[[1/2, 0],[0, 1]]", &id_mat.to_string());
 /// ```
 ///
-/// Vector usage
+/// ## Vector usage
 /// ```
 /// use math::{
 ///     rational::{Q, MatQ},
 /// };
 /// use std::str::FromStr;
 ///
-/// let row_vec = MatQ::from_str("[[1,1,1]]").unwrap();
-/// let col_vec = MatQ::from_str("[[1],[-1],[0]]").unwrap();
+/// let row_vec = MatQ::from_str("[[1/3, 1/4, 1/5]]").unwrap();
+/// let col_vec = MatQ::from_str("[[-1/-5],[-1],[0]]").unwrap();
 ///
 /// // check if matrix instance is vector
 /// assert!(row_vec.is_row_vector());

--- a/src/rational/mat_q.rs
+++ b/src/rational/mat_q.rs
@@ -17,6 +17,7 @@ mod get;
 mod ownership;
 mod set;
 mod to_string;
+mod vector;
 
 /// [`MatQ`] is a matrix with entries of type [`Q`](crate::rational::Q).
 ///
@@ -25,6 +26,43 @@ mod to_string;
 ///     of the [`Q`](crate::rational::Q) matrix
 ///
 /// # Examples
+/// Matrix usage
+/// ```
+/// use math::{
+///     rational::{Q, MatQ},
+///     traits::{GetEntry, SetEntry},
+/// };
+/// use std::str::FromStr;
+///
+/// // instantiate new matrix
+/// let id_mat = MatQ::from_str("[[1/1,0],[0,1]]").unwrap();
+///
+/// // clone object, set and get entry
+/// let mut clone = id_mat.clone();
+/// clone.set_entry(0, 0, Q::try_from((&2, &1)).unwrap());
+/// assert_eq!(
+///     clone.get_entry(1, 1).unwrap(),
+///     Q::try_from((&1, &1)).unwrap()
+/// );
+///
+/// // to_string
+/// assert_eq!("[[1, 0],[0, 1]]", &id_mat.to_string());
+/// ```
+///
+/// Vector usage
+/// ```
+/// use math::{
+///     rational::{Q, MatQ},
+/// };
+/// use std::str::FromStr;
+///
+/// let row_vec = MatQ::from_str("[[1,1,1]]").unwrap();
+/// let col_vec = MatQ::from_str("[[1],[-1],[0]]").unwrap();
+///
+/// // check if matrix instance is vector
+/// assert!(row_vec.is_row_vector());
+/// assert!(col_vec.is_column_vector());
+/// ```
 #[derive(Debug)]
 pub struct MatQ {
     pub(crate) matrix: fmpq_mat_struct,

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -96,6 +96,10 @@ impl MatQ {
     #[allow(dead_code)]
     /// Efficiently collects all [`fmpz`]s in a [`MatQ`] without cloning them.
     ///
+    /// Hence, the values on the returned [`Vec`] are intended for short-term use
+    /// as the access to [`fmpq`] values could lead to memory leaks or modified values
+    /// once the [`MatQ`] instance was modified or dropped.
+    ///
     /// # Example
     /// ```compile_fail
     /// use math::intger::MatQ;

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -94,7 +94,7 @@ impl GetNumColumns for MatQ {
 
 impl MatQ {
     #[allow(dead_code)]
-    /// Efficiently collects all [`fmpz`]s in a [`MatQ`] without cloning them.
+    /// Efficiently collects all [`fmpq`]s in a [`MatQ`] without cloning them.
     ///
     /// Hence, the values on the returned [`Vec`] are intended for short-term use
     /// as the access to [`fmpq`] values could lead to memory leaks or modified values
@@ -102,7 +102,7 @@ impl MatQ {
     ///
     /// # Example
     /// ```compile_fail
-    /// use math::intger::MatQ;
+    /// use math::rational::MatQ;
     /// use std::str::FromStr;
     ///
     /// let mat = MatQ::from_str("[[1/1,2],[3/1,4],[5/1,6]]").unwrap();

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -12,7 +12,10 @@ use super::MatQ;
 use crate::traits::{GetEntry, GetNumColumns, GetNumRows};
 use crate::utils::coordinate::evaluate_coordinates;
 use crate::{error::MathError, rational::Q};
-use flint_sys::{fmpq::fmpq_set, fmpq_mat::fmpq_mat_entry};
+use flint_sys::{
+    fmpq::{fmpq, fmpq_set},
+    fmpq_mat::fmpq_mat_entry,
+};
 use std::fmt::Display;
 
 impl GetEntry<Q> for MatQ {
@@ -86,6 +89,34 @@ impl GetNumColumns for MatQ {
     /// ```
     fn get_num_columns(&self) -> i64 {
         self.matrix.c
+    }
+}
+
+impl MatQ {
+    #[allow(dead_code)]
+    /// Efficiently collects all [`fmpz`]s in a [`MatQ`] without cloning them.
+    ///
+    /// # Example
+    /// ```compile_fail
+    /// use math::intger::MatQ;
+    /// use std::str::FromStr;
+    ///
+    /// let mat = MatQ::from_str("[[1/1,2],[3/1,4],[5/1,6]]").unwrap();
+    ///
+    /// let fmpz_entries = mat.collect_entries();
+    /// ```
+    pub(crate) fn collect_entries(&self) -> Vec<fmpq> {
+        let mut entries: Vec<fmpq> = vec![];
+
+        for row in 0..self.get_num_rows() {
+            for col in 0..self.get_num_columns() {
+                // efficiently get entry without cloning the entry itself
+                let entry = unsafe { *fmpq_mat_entry(&self.matrix, row, col) };
+                entries.push(entry);
+            }
+        }
+
+        entries
     }
 }
 
@@ -226,5 +257,47 @@ mod test_get_num {
         let matrix = MatQ::new(5, 10).unwrap();
 
         assert_eq!(matrix.get_num_columns(), 10);
+    }
+}
+
+#[cfg(test)]
+mod test_collect_entries {
+    use super::MatQ;
+    use std::str::FromStr;
+
+    #[test]
+    fn all_entries_collected() {
+        let mat_1 = MatQ::from_str(&format!(
+            "[[1/{},2],[{},{}],[-3/-4,4]]",
+            i64::MAX,
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+        let mat_2 = MatQ::from_str("[[-1/1,2/-4]]").unwrap();
+
+        let entries_1 = mat_1.collect_entries();
+        let entries_2 = mat_2.collect_entries();
+
+        assert_eq!(entries_1.len(), 6);
+        // 4611686018427387904 = 2^62, i.e. value is stored on stack
+        assert_eq!(entries_1[0].num.0, 1);
+        assert!(entries_1[0].den.0 > 4611686018427387904);
+        assert_eq!(entries_1[1].num.0, 2);
+        assert_eq!(entries_1[1].den.0, 1);
+        assert!(entries_1[2].num.0 >= 4611686018427387904);
+        assert_eq!(entries_1[2].den.0, 1);
+        assert!(entries_1[3].num.0 >= 4611686018427387904);
+        assert_eq!(entries_1[3].den.0, 1);
+        assert_eq!(entries_1[4].num.0, 3);
+        assert_eq!(entries_1[4].den.0, 4);
+        assert_eq!(entries_1[5].num.0, 4);
+        assert_eq!(entries_1[5].den.0, 1);
+
+        assert_eq!(entries_2.len(), 2);
+        assert_eq!(entries_2[0].num.0, -1);
+        assert_eq!(entries_2[0].den.0, 1);
+        assert_eq!(entries_2[1].num.0, -1);
+        assert_eq!(entries_2[1].den.0, 2);
     }
 }

--- a/src/rational/mat_q/vector.rs
+++ b/src/rational/mat_q/vector.rs
@@ -1,0 +1,12 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! The `vector` module contains functions that are implemented for matrices
+//! that have one column or one row and hence represent a vector.
+
+mod is_vector;

--- a/src/rational/mat_q/vector/is_vector.rs
+++ b/src/rational/mat_q/vector/is_vector.rs
@@ -116,6 +116,8 @@ mod test_is_vector {
         let mat_1 = MatQ::from_str(&format!("[[1,{}/1],[2,3]]", i64::MIN)).unwrap();
         let mat_2 = MatQ::from_str(&format!("[[1,{},3/3],[4/1,5/1,6/1]]", i64::MAX)).unwrap();
         let mat_3 = MatQ::from_str(&format!("[[1/1,{}/1],[2/1,3/1],[4/1,5/1]]", i64::MIN)).unwrap();
+        let mat_4 = MatQ::from_str("[[1/1,0],[2,0],[4,0]]").unwrap();
+        let mat_5 = MatQ::from_str("[[1,2/1,4],[0,0,0]]").unwrap();
 
         assert!(!mat_1.is_column_vector());
         assert!(!mat_1.is_row_vector());
@@ -128,6 +130,14 @@ mod test_is_vector {
         assert!(!mat_3.is_column_vector());
         assert!(!mat_3.is_row_vector());
         assert!(!mat_3.is_vector());
+
+        assert!(!mat_4.is_column_vector());
+        assert!(!mat_4.is_row_vector());
+        assert!(!mat_4.is_vector());
+
+        assert!(!mat_5.is_column_vector());
+        assert!(!mat_5.is_row_vector());
+        assert!(!mat_5.is_vector());
     }
 
     /// Check whether matrices with only one entry get recognized as single entry matrices

--- a/src/rational/mat_q/vector/is_vector.rs
+++ b/src/rational/mat_q/vector/is_vector.rs
@@ -1,0 +1,165 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module includes all functionality to check
+//! whether a matrix represents a vector, i.e. has only one row
+//! or one column.
+//! These methods should be used to ensure that vector functions
+//! can only be called on suitably formed vector/matrices.
+
+use super::super::MatQ;
+use crate::traits::{GetNumColumns, GetNumRows};
+
+impl MatQ {
+    /// Returns `true` if the provided [`MatQ`] has only one row,
+    /// i.e. is a row vector. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::rational::MatQ;
+    /// use std::str::FromStr;
+    ///
+    /// let row_vec = MatQ::from_str("[[1,2,3/2]]").unwrap();
+    /// let col_vec = MatQ::from_str("[[1/4],[2],[3]]").unwrap();
+    ///
+    /// assert!(row_vec.is_row_vector());
+    /// assert!(!col_vec.is_row_vector());
+    /// ```
+    pub fn is_row_vector(&self) -> bool {
+        self.get_num_rows() == 1
+    }
+
+    /// Returns `true` if the provided [`MatQ`] has only one column,
+    /// i.e. is a column vector. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::rational::MatQ;
+    /// use std::str::FromStr;
+    ///
+    /// let row_vec = MatQ::from_str("[[1/1,2,3]]").unwrap();
+    /// let col_vec = MatQ::from_str("[[1],[2/3],[3]]").unwrap();
+    ///
+    /// assert!(col_vec.is_column_vector());
+    /// assert!(!row_vec.is_column_vector());
+    /// ```
+    pub fn is_column_vector(&self) -> bool {
+        self.get_num_columns() == 1
+    }
+
+    /// Returns `true` if the provided [`MatQ`] has only one column or one row,
+    /// i.e. is a vector. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::rational::MatQ;
+    /// use std::str::FromStr;
+    ///
+    /// let row_vec = MatQ::from_str("[[1,2/2,3/1]]").unwrap();
+    /// let col_vec = MatQ::from_str("[[1],[2],[3/2]]").unwrap();
+    ///
+    /// assert!(row_vec.is_vector());
+    /// assert!(col_vec.is_vector());
+    /// ```
+    pub fn is_vector(&self) -> bool {
+        self.is_column_vector() || self.is_row_vector()
+    }
+
+    /// Returns `true` if the provided [`MatQ`] has only one entry,
+    /// i.e. is a 1x1 matrix. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::rational::MatQ;
+    /// use std::str::FromStr;
+    ///
+    /// let vec = MatQ::from_str("[[1/2]]").unwrap();
+    ///
+    /// assert!(vec.has_single_entry());
+    /// ```
+    pub fn has_single_entry(&self) -> bool {
+        self.is_column_vector() && self.is_row_vector()
+    }
+}
+
+#[cfg(test)]
+mod test_is_vector {
+
+    use super::*;
+    use std::str::FromStr;
+
+    /// Check whether matrices with one row or one column
+    /// get recognized as (row or column) vectors
+    #[test]
+    fn vectors_detected() {
+        let row = MatQ::from_str(&format!("[[1/1,{}]]", i64::MIN)).unwrap();
+        let col = MatQ::from_str(&format!("[[1/1],[2/1],[{}/1],[4/1]]", i64::MAX)).unwrap();
+
+        assert!(row.is_row_vector());
+        assert!(!row.is_column_vector());
+        assert!(row.is_vector());
+
+        assert!(!col.is_row_vector());
+        assert!(col.is_column_vector());
+        assert!(col.is_vector());
+    }
+
+    /// Check whether matrices with more than one row or column
+    /// don't get recognized as (row or column) vector
+    #[test]
+    fn non_vectors_detected() {
+        let mat_1 = MatQ::from_str(&format!("[[1,{}/1],[2,3]]", i64::MIN)).unwrap();
+        let mat_2 = MatQ::from_str(&format!("[[1,{},3/3],[4/1,5/1,6/1]]", i64::MAX)).unwrap();
+        let mat_3 = MatQ::from_str(&format!("[[1/1,{}/1],[2/1,3/1],[4/1,5/1]]", i64::MIN)).unwrap();
+
+        assert!(!mat_1.is_column_vector());
+        assert!(!mat_1.is_row_vector());
+        assert!(!mat_1.is_vector());
+
+        assert!(!mat_2.is_column_vector());
+        assert!(!mat_2.is_row_vector());
+        assert!(!mat_2.is_vector());
+
+        assert!(!mat_3.is_column_vector());
+        assert!(!mat_3.is_row_vector());
+        assert!(!mat_3.is_vector());
+    }
+
+    /// Check whether matrices with only one entry get recognized as single entry matrices
+    #[test]
+    fn single_entry_detected() {
+        let small = MatQ::from_str("[[1]]").unwrap();
+        let large = MatQ::from_str(&format!("[[{}/1]]", i64::MIN)).unwrap();
+
+        // check whether single entry is correctly detected
+        assert!(small.has_single_entry());
+        assert!(large.has_single_entry());
+
+        // check whether single entry is correctly detected as row and column vector
+        assert!(small.is_row_vector());
+        assert!(small.is_column_vector());
+        assert!(small.is_vector());
+
+        assert!(large.is_row_vector());
+        assert!(large.is_column_vector());
+        assert!(large.is_vector());
+    }
+
+    /// Check whether matrices with more than one entry
+    /// don't get recognized as single entry matrices
+    #[test]
+    fn non_single_entry_detected() {
+        let row = MatQ::from_str(&format!("[[1,{}]]", i64::MIN)).unwrap();
+        let col = MatQ::from_str(&format!("[[1],[{}],[3/1]]", i64::MIN)).unwrap();
+        let mat = MatQ::from_str("[[1/1,2],[3,4],[5,6]]").unwrap();
+
+        assert!(!row.has_single_entry());
+        assert!(!col.has_single_entry());
+        assert!(!mat.has_single_entry());
+    }
+}


### PR DESCRIPTION
This PR implements 
- [X] `is_vector` including tests for `MatQ`. 
- [X] `collect_entries` for `MatQ`, which efficiently collects all `fmpq` entries from the matrix without cloning elements.
- [X] doc tests for `MatQ`