### PR TITLE
MatPolyOverZ is_vector

### DIFF
--- a/src/integer/mat_poly_over_z.rs
+++ b/src/integer/mat_poly_over_z.rs
@@ -18,6 +18,7 @@ mod ownership;
 mod properties;
 mod set;
 mod to_string;
+mod vector;
 
 /// [`MatPolyOverZ`] is a matrix with entries of type [`PolyOverZ`](crate::integer::PolyOverZ).
 ///
@@ -26,6 +27,43 @@ mod to_string;
 ///     of the [`PolyOverZ`](crate::integer::PolyOverZ) matrix
 ///
 /// # Examples
+/// ## Matrix usage
+/// ```
+/// use math::{
+///     integer::{PolyOverZ, MatPolyOverZ},
+///     traits::{GetEntry, SetEntry},
+/// };
+/// use std::str::FromStr;
+///
+/// // instantiate new matrix
+/// let id_mat = MatPolyOverZ::from_str("[[1  1, 0],[0, 1  1]]").unwrap();
+///
+/// // clone object, set and get entry
+/// let mut clone = id_mat.clone();
+/// clone.set_entry(0, 0, PolyOverZ::from_str("1  2").unwrap());
+/// assert_eq!(
+///     clone.get_entry(1, 1).unwrap(),
+///     PolyOverZ::from_str("1  1").unwrap(),
+/// );
+///
+/// // to_string
+/// assert_eq!("[[1  1, 0],[0, 1  1]]", &id_mat.to_string());
+/// ```
+///
+/// ## Vector usage
+/// ```
+/// use math::{
+///     integer::{PolyOverZ, MatPolyOverZ},
+/// };
+/// use std::str::FromStr;
+///
+/// let row_vec = MatPolyOverZ::from_str("[[1  1, 0, 1  1]]").unwrap();
+/// let col_vec = MatPolyOverZ::from_str("[[1  -5],[1  -1],[0]]").unwrap();
+///
+/// // check if matrix instance is vector
+/// assert!(row_vec.is_row_vector());
+/// assert!(col_vec.is_column_vector());
+/// ```
 #[derive(Debug)]
 pub struct MatPolyOverZ {
     pub(crate) matrix: fmpz_poly_mat_struct,

--- a/src/integer/mat_poly_over_z.rs
+++ b/src/integer/mat_poly_over_z.rs
@@ -20,8 +20,8 @@ mod properties;
 mod serialize;
 mod set;
 mod to_string;
-mod vector;
 mod transpose;
+mod vector;
 
 /// [`MatPolyOverZ`] is a matrix with entries of type [`PolyOverZ`](crate::integer::PolyOverZ).
 ///

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -285,10 +285,9 @@ mod test_collect_entries {
         let entries_2 = mat_2.collect_entries();
 
         assert_eq!(entries_1.len(), 6);
-        // 4611686018427387904 = 2^62, i.e. value is stored on stack
         assert_eq!(unsafe { *entries_1[0].coeffs }.0, 1);
-        assert!(unsafe { *entries_1[2].coeffs }.0 >= 4611686018427387904);
-        assert!(unsafe { *entries_1[3].coeffs }.0 >= 4611686018427387904);
+        assert!(unsafe { *entries_1[2].coeffs }.0 >= 2_i64.pow(62));
+        assert!(unsafe { *entries_1[3].coeffs }.0 >= 2_i64.pow(62));
         assert_eq!(unsafe { *entries_1[4].coeffs }.0, -3);
 
         assert_eq!(entries_2.len(), 2);

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -15,7 +15,10 @@ use crate::{
     traits::{GetEntry, GetNumColumns, GetNumRows},
     utils::coordinate::evaluate_coordinates,
 };
-use flint_sys::{fmpz_poly::fmpz_poly_set, fmpz_poly_mat::fmpz_poly_mat_entry};
+use flint_sys::{
+    fmpz_poly::{fmpz_poly_set, fmpz_poly_struct},
+    fmpz_poly_mat::fmpz_poly_mat_entry,
+};
 use std::fmt::Display;
 
 impl GetNumRows for MatPolyOverZ {
@@ -89,6 +92,38 @@ impl GetEntry<PolyOverZ> for MatPolyOverZ {
         unsafe { fmpz_poly_set(&mut copy.poly, entry) };
 
         Ok(copy)
+    }
+}
+
+impl MatPolyOverZ {
+    #[allow(dead_code)]
+    /// Efficiently collects all [`fmpz_poly_struct`]s in a [`MatPolyOverZ`] without cloning them.
+    ///
+    /// Hence, the values on the returned [`Vec`] are intended for short-term use
+    /// as the access to [`fmpz_poly_struct`] values could lead to memory leaks or
+    /// modified values once the [`MatPolyOverZ`] instance was modified or dropped.
+    ///
+    /// # Example
+    /// ```compile_fail
+    /// use math::intger::MatPolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let mat = MatPolyOverZ::from_str("[[1  1, 0],[1  3, 1  4],[0,1  6]]").unwrap();
+    ///
+    /// let fmpz_entries = mat.collect_entries();
+    /// ```
+    pub(crate) fn collect_entries(&self) -> Vec<fmpz_poly_struct> {
+        let mut entries: Vec<fmpz_poly_struct> = vec![];
+
+        for row in 0..self.get_num_rows() {
+            for col in 0..self.get_num_columns() {
+                // efficiently get entry without cloning the entry itself
+                let entry = unsafe { *fmpz_poly_mat_entry(&self.matrix, row, col) };
+                entries.push(entry);
+            }
+        }
+
+        entries
     }
 }
 
@@ -228,5 +263,39 @@ mod test_get_num {
         let matrix = MatPolyOverZ::new(5, 10).unwrap();
 
         assert_eq!(matrix.get_num_columns(), 10);
+    }
+}
+
+#[cfg(test)]
+mod test_collect_entries {
+    use super::MatPolyOverZ;
+    use std::str::FromStr;
+
+    #[test]
+    fn all_entries_collected() {
+        let mat_1 = MatPolyOverZ::from_str(&format!(
+            "[[1  1,0],[1  {},1  {}],[1  -3, 0]]",
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+        let mat_2 = MatPolyOverZ::from_str("[[1  -1, 2  1 2]]").unwrap();
+
+        let entries_1 = mat_1.collect_entries();
+        let entries_2 = mat_2.collect_entries();
+
+        assert_eq!(entries_1.len(), 6);
+        // 4611686018427387904 = 2^62, i.e. value is stored on stack
+        assert_eq!(unsafe { *entries_1[0].coeffs }.0, 1);
+        assert!(unsafe { *entries_1[2].coeffs }.0 >= 4611686018427387904);
+        assert!(unsafe { *entries_1[3].coeffs }.0 >= 4611686018427387904);
+        assert_eq!(unsafe { *entries_1[4].coeffs }.0, -3);
+
+        assert_eq!(entries_2.len(), 2);
+        assert_eq!(unsafe { *entries_2[0].coeffs.offset(0) }.0, -1);
+        assert_eq!(entries_2[0].length, 1);
+        assert_eq!(unsafe { *entries_2[1].coeffs.offset(0) }.0, 1);
+        assert_eq!(unsafe { *entries_2[1].coeffs.offset(1) }.0, 2);
+        assert_eq!(entries_2[1].length, 2);
     }
 }

--- a/src/integer/mat_poly_over_z/vector.rs
+++ b/src/integer/mat_poly_over_z/vector.rs
@@ -1,0 +1,12 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! The `vector` module contains functions that are implemented for matrices
+//! that have one column or one row and hence represent a vector.
+
+mod is_vector;

--- a/src/integer/mat_poly_over_z/vector/is_vector.rs
+++ b/src/integer/mat_poly_over_z/vector/is_vector.rs
@@ -1,0 +1,178 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module includes all functionality to check
+//! whether a matrix represents a vector, i.e. has only one row
+//! or one column.
+//! These methods should be used to ensure that vector functions
+//! can only be called on suitably formed vector/matrices.
+
+use super::super::MatPolyOverZ;
+use crate::traits::{GetNumColumns, GetNumRows};
+
+impl MatPolyOverZ {
+    /// Returns `true` if the provided [`MatPolyOverZ`] has only one row,
+    /// i.e. is a row vector. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer::MatPolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let row_vec = MatPolyOverZ::from_str("[[1  1, 1  2, 1  3]]").unwrap();
+    /// let col_vec = MatPolyOverZ::from_str("[[1  1],[0],[1  3]]").unwrap();
+    ///
+    /// assert!(row_vec.is_row_vector());
+    /// assert!(!col_vec.is_row_vector());
+    /// ```
+    pub fn is_row_vector(&self) -> bool {
+        self.get_num_rows() == 1
+    }
+
+    /// Returns `true` if the provided [`MatPolyOverZ`] has only one column,
+    /// i.e. is a column vector. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer::MatPolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let row_vec = MatPolyOverZ::from_str("[[1  1, 1  2, 1  3]]").unwrap();
+    /// let col_vec = MatPolyOverZ::from_str("[[1  1],[0],[1  3]]").unwrap();
+    ///
+    /// assert!(col_vec.is_column_vector());
+    /// assert!(!row_vec.is_column_vector());
+    /// ```
+    pub fn is_column_vector(&self) -> bool {
+        self.get_num_columns() == 1
+    }
+
+    /// Returns `true` if the provided [`MatPolyOverZ`] has only one column or one row,
+    /// i.e. is a vector. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer::MatPolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let row_vec = MatPolyOverZ::from_str("[[1  1, 1  2, 1  3]]").unwrap();
+    /// let col_vec = MatPolyOverZ::from_str("[[1  1],[0],[1  3]]").unwrap();
+    ///
+    /// assert!(row_vec.is_vector());
+    /// assert!(col_vec.is_vector());
+    /// ```
+    pub fn is_vector(&self) -> bool {
+        self.is_column_vector() || self.is_row_vector()
+    }
+
+    /// Returns `true` if the provided [`MatPolyOverZ`] has only one entry,
+    /// i.e. is a 1x1 matrix. Otherwise, returns `false`.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer::MatPolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let vec = MatPolyOverZ::from_str("[[1  1]]").unwrap();
+    ///
+    /// assert!(vec.has_single_entry());
+    /// ```
+    pub fn has_single_entry(&self) -> bool {
+        self.is_column_vector() && self.is_row_vector()
+    }
+}
+
+#[cfg(test)]
+mod test_is_vector {
+
+    use super::*;
+    use std::str::FromStr;
+
+    /// Check whether matrices with one row or one column
+    /// get recognized as (row or column) vectors
+    #[test]
+    fn vectors_detected() {
+        let row = MatPolyOverZ::from_str(&format!("[[0, 1  {}]]", i64::MIN)).unwrap();
+        let col =
+            MatPolyOverZ::from_str(&format!("[[0],[ 1  2],[1  {}],[1  4]]", i64::MAX)).unwrap();
+
+        assert!(row.is_row_vector());
+        assert!(!row.is_column_vector());
+        assert!(row.is_vector());
+
+        assert!(!col.is_row_vector());
+        assert!(col.is_column_vector());
+        assert!(col.is_vector());
+    }
+
+    /// Check whether matrices with more than one row or column
+    /// don't get recognized as (row or column) vector
+    #[test]
+    fn non_vectors_detected() {
+        let mat_1 = MatPolyOverZ::from_str(&format!("[[0, 1  {}],[1  2, 0]]", i64::MIN)).unwrap();
+        let mat_2 =
+            MatPolyOverZ::from_str(&format!("[[1  1, 1  {}, 0],[0,0,0]]", i64::MAX)).unwrap();
+        let mat_3 =
+            MatPolyOverZ::from_str(&format!("[[0,1  {}],[1  2,0],[1  4,1  5]]", i64::MIN)).unwrap();
+        let mat_4 = MatPolyOverZ::from_str("[[1  1,0],[1  2,0],[1  4,0]]").unwrap();
+        let mat_5 = MatPolyOverZ::from_str("[[1  1,1  2,1  4],[0,0,0]]").unwrap();
+
+        assert!(!mat_1.is_column_vector());
+        assert!(!mat_1.is_row_vector());
+        assert!(!mat_1.is_vector());
+
+        assert!(!mat_2.is_column_vector());
+        assert!(!mat_2.is_row_vector());
+        assert!(!mat_2.is_vector());
+
+        assert!(!mat_3.is_column_vector());
+        assert!(!mat_3.is_row_vector());
+        assert!(!mat_3.is_vector());
+
+        assert!(!mat_4.is_column_vector());
+        assert!(!mat_4.is_row_vector());
+        assert!(!mat_4.is_vector());
+
+        assert!(!mat_5.is_column_vector());
+        assert!(!mat_5.is_row_vector());
+        assert!(!mat_5.is_vector());
+    }
+
+    /// Check whether matrices with only one entry get recognized as single entry matrices
+    #[test]
+    fn single_entry_detected() {
+        let small = MatPolyOverZ::from_str("[[1  1]]").unwrap();
+        let large = MatPolyOverZ::from_str(&format!("[[1  {}]]", i64::MIN)).unwrap();
+
+        // check whether single entry is correctly detected
+        assert!(small.has_single_entry());
+        assert!(large.has_single_entry());
+
+        // check whether single entry is correctly detected as row and column vector
+        assert!(small.is_row_vector());
+        assert!(small.is_column_vector());
+        assert!(small.is_vector());
+
+        assert!(large.is_row_vector());
+        assert!(large.is_column_vector());
+        assert!(large.is_vector());
+    }
+
+    /// Check whether matrices with more than one entry
+    /// don't get recognized as single entry matrices
+    #[test]
+    fn non_single_entry_detected() {
+        let row = MatPolyOverZ::from_str(&format!("[[0,1  {}]]", i64::MIN)).unwrap();
+        let col = MatPolyOverZ::from_str(&format!("[[0],[1  {}],[1  3]]", i64::MIN)).unwrap();
+        let mat = MatPolyOverZ::from_str("[[1  1,1  2],[1  3,1  4],[1  5,1  6]]").unwrap();
+
+        assert!(!row.has_single_entry());
+        assert!(!col.has_single_entry());
+        assert!(!mat.has_single_entry());
+    }
+}


### PR DESCRIPTION
This PR implements 
- [X] `is_vector` including tests for `MatPolyOverZ`. 
- [X] `collect_entries` for `MatPolyOverZ`, which efficiently collects all `fmpz_poly_struct` entries from the matrix without cloning elements.
- [X] doc tests for `MatPolyOverZ`

At first, I did not want to implement this. But as the `vector` part probably get's added to the `Matrix` trait, it should be implemented. Additionally, with a norm defined for polynomials (see [here](https://mathworld.wolfram.com/PolynomialNorm.html)), it seems realistic, that we will need this in the future.