### PR TITLE
Norm MatZq

### DIFF
--- a/src/integer.rs
+++ b/src/integer.rs
@@ -17,4 +17,5 @@ mod z;
 pub use mat_poly_over_z::MatPolyOverZ;
 pub use mat_z::MatZ;
 pub use poly_over_z::PolyOverZ;
+pub(crate) use z::fmpz_helpers;
 pub use z::Z;

--- a/src/integer/mat_z.rs
+++ b/src/integer/mat_z.rs
@@ -74,7 +74,7 @@ mod vector;
 /// assert_eq!(row_vec.dot_product(&col_vec).unwrap(), Z::ZERO);
 ///
 /// // norm calculation
-/// assert_eq!(col_vec.norm_sqrd_eucl().unwrap(), Z::from(2));
+/// assert_eq!(col_vec.norm_eucl_sqrd().unwrap(), Z::from(2));
 /// assert_eq!(row_vec.norm_infty().unwrap(), Z::ONE);
 /// ```
 #[derive(Debug)]

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -268,9 +268,8 @@ mod test_collect_entries {
         assert_eq!(entries_1.len(), 6);
         assert_eq!(entries_1[0].0, 1);
         assert_eq!(entries_1[1].0, 2);
-        // 4611686018427387904 = 2^62, i.e. value is stored on stack
-        assert!(entries_1[2].0 >= 4611686018427387904);
-        assert!(entries_1[3].0 >= 4611686018427387904);
+        assert!(entries_1[2].0 >= 2_i64.pow(62));
+        assert!(entries_1[3].0 >= 2_i64.pow(62));
         assert_eq!(entries_1[4].0, 3);
         assert_eq!(entries_1[5].0, 4);
 

--- a/src/integer/mat_z/vector/dot_product.rs
+++ b/src/integer/mat_z/vector/dot_product.rs
@@ -34,6 +34,7 @@ impl MatZ {
     ///
     /// let dot_prod = vec_1.dot_product(&vec_2).unwrap();
     ///
+    /// // 1*1 + 2*3 + 3*2 = 13
     /// assert_eq!(Z::from_i64(13), dot_prod);
     /// ```
     ///

--- a/src/integer/mat_z/vector/norm.rs
+++ b/src/integer/mat_z/vector/norm.rs
@@ -20,18 +20,14 @@ use flint_sys::fmpz::fmpz_addmul;
 impl MatZ {
     /// Returns the squared Euclidean norm or 2-norm of the given (row or column) vector.
     ///
-    /// WARNING: This function may be renamed and changed in the future,
-    /// once we integrate a sqrt function for [`Z`] values.
-    ///
     /// # Example
     /// ```
-    /// use qfall_math::integer::MatZ;
+    /// use qfall_math::integer::{MatZ, Z};
     /// use std::str::FromStr;
-    /// # use qfall_math::integer::Z;
     ///
     /// let vec = MatZ::from_str("[[1],[2],[3]]").unwrap();
     ///
-    /// let sqrd_2_norm = vec.norm_sqrd_eucl().unwrap();
+    /// let sqrd_2_norm = vec.norm_eucl_sqrd().unwrap();
     ///
     /// // 1*1 + 2*2 + 3*3 = 14
     /// assert_eq!(Z::from(14), sqrd_2_norm);
@@ -40,16 +36,15 @@ impl MatZ {
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
     /// the given [`MatZ`] instance is not a (row or column) vector.
-    pub fn norm_sqrd_eucl(&self) -> Result<Z, MathError> {
+    pub fn norm_eucl_sqrd(&self) -> Result<Z, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(
-                String::from("norm_sqrd_eucl"),
+                String::from("norm_eucl_sqrd"),
                 self.get_num_rows(),
                 self.get_num_columns(),
             ));
         }
 
-        // collect all entries in vector
         let entries = self.collect_entries();
 
         // sum squared entries in result
@@ -59,7 +54,6 @@ impl MatZ {
             unsafe { fmpz_addmul(&mut result.value, &entry, &entry) }
         }
 
-        // TODO: Add sqrt function here
         Ok(result)
     }
 
@@ -67,9 +61,8 @@ impl MatZ {
     ///
     /// # Example
     /// ```
-    /// use qfall_math::integer::MatZ;
+    /// use qfall_math::integer::{MatZ, Z};
     /// use std::str::FromStr;
-    /// # use qfall_math::integer::Z;
     ///
     /// let vec = MatZ::from_str("[[1],[2],[3]]").unwrap();
     ///
@@ -101,7 +94,7 @@ impl MatZ {
 }
 
 #[cfg(test)]
-mod test_norm_sqrd_eucl {
+mod test_norm_eucl_sqrd {
     use super::{MatZ, Z};
     use std::str::FromStr;
 
@@ -113,9 +106,9 @@ mod test_norm_sqrd_eucl {
         let vec_2 = MatZ::from_str("[[1,10,100]]").unwrap();
         let vec_3 = MatZ::from_str("[[1,10,100, 1000]]").unwrap();
 
-        assert_eq!(vec_1.norm_sqrd_eucl().unwrap(), Z::ONE);
-        assert_eq!(vec_2.norm_sqrd_eucl().unwrap(), Z::from_i64(10101));
-        assert_eq!(vec_3.norm_sqrd_eucl().unwrap(), Z::from_i64(1010101));
+        assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::ONE);
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from_i64(10101));
+        assert_eq!(vec_3.norm_eucl_sqrd().unwrap(), Z::from_i64(1010101));
     }
 
     /// Check whether the squared euclidean norm for row vectors
@@ -127,7 +120,7 @@ mod test_norm_sqrd_eucl {
         let min = Z::from(i64::MIN);
         let cmp = &min * &min + &max * &max + Z::from(4);
 
-        assert_eq!(vec.norm_sqrd_eucl().unwrap(), cmp);
+        assert_eq!(vec.norm_eucl_sqrd().unwrap(), cmp);
     }
 
     /// Check whether the squared euclidean norm for column vectors
@@ -137,8 +130,8 @@ mod test_norm_sqrd_eucl {
         let vec_1 = MatZ::from_str("[[1],[10],[100]]").unwrap();
         let vec_2 = MatZ::from_str("[[1],[10],[100],[1000]]").unwrap();
 
-        assert_eq!(vec_1.norm_sqrd_eucl().unwrap(), Z::from_i64(10101));
-        assert_eq!(vec_2.norm_sqrd_eucl().unwrap(), Z::from_i64(1010101));
+        assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::from_i64(10101));
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from_i64(1010101));
     }
 
     /// Check whether the squared euclidean norm for column vectors
@@ -150,7 +143,7 @@ mod test_norm_sqrd_eucl {
         let min = Z::from(i64::MIN);
         let cmp = &min * &min + &max * &max + Z::from(4);
 
-        assert_eq!(vec.norm_sqrd_eucl().unwrap(), cmp);
+        assert_eq!(vec.norm_eucl_sqrd().unwrap(), cmp);
     }
 
     /// Check whether euclidean norm calculations of non vectors yield an error
@@ -158,7 +151,7 @@ mod test_norm_sqrd_eucl {
     fn non_vector_yield_error() {
         let mat = MatZ::from_str("[[1,1],[10,2]]").unwrap();
 
-        assert!(mat.norm_sqrd_eucl().is_err());
+        assert!(mat.norm_eucl_sqrd().is_err());
     }
 }
 

--- a/src/integer/mat_z/vector/norm.rs
+++ b/src/integer/mat_z/vector/norm.rs
@@ -33,7 +33,8 @@ impl MatZ {
     ///
     /// let sqrd_2_norm = vec.norm_sqrd_eucl().unwrap();
     ///
-    /// assert_eq!(Z::from_i64(14), sqrd_2_norm);
+    /// // 1*1 + 2*2 + 3*3 = 14
+    /// assert_eq!(Z::from(14), sqrd_2_norm);
     /// ```
     ///
     /// Errors and Failures
@@ -74,6 +75,7 @@ impl MatZ {
     ///
     /// let infty_norm = vec.norm_infty().unwrap();
     ///
+    /// // max{1, 2, 3} = 3
     /// assert_eq!(Z::from_i64(3), infty_norm);
     /// ```
     ///

--- a/src/integer/mat_z/vector/norm.rs
+++ b/src/integer/mat_z/vector/norm.rs
@@ -69,7 +69,7 @@ impl MatZ {
     /// let infty_norm = vec.norm_infty().unwrap();
     ///
     /// // max{1, 2, 3} = 3
-    /// assert_eq!(Z::from_i64(3), infty_norm);
+    /// assert_eq!(Z::from(3), infty_norm);
     /// ```
     ///
     /// Errors and Failures
@@ -107,8 +107,8 @@ mod test_norm_eucl_sqrd {
         let vec_3 = MatZ::from_str("[[1,10,100, 1000]]").unwrap();
 
         assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::ONE);
-        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from_i64(10101));
-        assert_eq!(vec_3.norm_eucl_sqrd().unwrap(), Z::from_i64(1010101));
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from(10101));
+        assert_eq!(vec_3.norm_eucl_sqrd().unwrap(), Z::from(1010101));
     }
 
     /// Check whether the squared euclidean norm for row vectors
@@ -130,8 +130,8 @@ mod test_norm_eucl_sqrd {
         let vec_1 = MatZ::from_str("[[1],[10],[100]]").unwrap();
         let vec_2 = MatZ::from_str("[[1],[10],[100],[1000]]").unwrap();
 
-        assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::from_i64(10101));
-        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from_i64(1010101));
+        assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::from(10101));
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from(1010101));
     }
 
     /// Check whether the squared euclidean norm for column vectors
@@ -169,8 +169,8 @@ mod test_norm_infty {
         let vec_3 = MatZ::from_str("[[1,10,100, 1000]]").unwrap();
 
         assert_eq!(vec_1.norm_infty().unwrap(), Z::ONE);
-        assert_eq!(vec_2.norm_infty().unwrap(), Z::from_i64(100));
-        assert_eq!(vec_3.norm_infty().unwrap(), Z::from_i64(1000));
+        assert_eq!(vec_2.norm_infty().unwrap(), Z::from(100));
+        assert_eq!(vec_3.norm_infty().unwrap(), Z::from(1000));
     }
 
     /// Check whether the infinity norm for row vectors
@@ -190,8 +190,8 @@ mod test_norm_infty {
         let vec_1 = MatZ::from_str("[[1],[10],[100]]").unwrap();
         let vec_2 = MatZ::from_str("[[1],[10],[100],[1000]]").unwrap();
 
-        assert_eq!(vec_1.norm_infty().unwrap(), Z::from_i64(100));
-        assert_eq!(vec_2.norm_infty().unwrap(), Z::from_i64(1000));
+        assert_eq!(vec_1.norm_infty().unwrap(), Z::from(100));
+        assert_eq!(vec_2.norm_infty().unwrap(), Z::from(1000));
     }
 
     /// Check whether the infinity norm for column vectors

--- a/src/integer/mat_z/vector/norm.rs
+++ b/src/integer/mat_z/vector/norm.rs
@@ -15,7 +15,7 @@ use crate::{
     integer::Z,
     traits::{GetNumColumns, GetNumRows},
 };
-use flint_sys::fmpz::{fmpz, fmpz_abs, fmpz_addmul, fmpz_cmpabs};
+use flint_sys::fmpz::fmpz_addmul;
 
 impl MatZ {
     /// Returns the squared Euclidean norm or 2-norm of the given (row or column) vector.
@@ -92,19 +92,9 @@ impl MatZ {
         // collect all entries in vector
         let entries = self.collect_entries();
 
-        // find maximum of absolute fmpz entries
-        let mut max = fmpz(0);
-        for entry in entries {
-            if unsafe { fmpz_cmpabs(&max, &entry) } < 0 {
-                max = entry;
-            }
-        }
-
-        // clone value and ensure that absolute maximum value is absolute
-        let mut result = Z::ZERO;
-        unsafe { fmpz_abs(&mut result.value, &max) }
-
-        Ok(result)
+        // find maximum of absolute fmpz entries and
+        // return cloned absolute maximum [`Z`] value
+        Ok(Z::find_max_abs_fmpz(&entries))
     }
 }
 

--- a/src/integer/z.rs
+++ b/src/integer/z.rs
@@ -15,6 +15,7 @@ mod arithmetic;
 mod cmp;
 mod default;
 mod exp;
+pub(crate) mod fmpz_helpers;
 mod from;
 mod ownership;
 mod serialize;

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -1,0 +1,104 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains helpful functions on [`fmpz`] that return a [`Z`] value.
+
+use super::Z;
+use flint_sys::fmpz::{fmpz, fmpz_abs, fmpz_cmpabs};
+
+impl Z {
+    /// Efficiently finds maximum absolute value and returns
+    /// a cloned [`Z`] instance out of a vector of [`fmpz`] instances.
+    ///
+    /// Parameters:
+    /// - `fmpz_vector`: contains a number of [`fmpz`] instances
+    ///
+    /// Returns the maximum absolute value out of the given [`fmpz`] vector
+    /// as a cloned [`Z`] instance.
+    ///
+    /// # Example
+    /// ```compile_fail
+    /// use math::integer::Z;
+    ///
+    /// let a = Z::from(-4);
+    /// let b = Z::from(-2);
+    ///
+    /// let fmpz_vector = vec![a.value, b.value];
+    /// let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
+    /// assert_eq!(abs_max, Z::from(4));
+    /// ```
+    pub(crate) fn find_max_abs_fmpz(fmpz_vector: &Vec<fmpz>) -> Self {
+        // find maximum of absolute fmpz entries
+        let mut max = &fmpz(0);
+        for entry in fmpz_vector {
+            if unsafe { fmpz_cmpabs(max, entry) } < 0 {
+                max = entry;
+            }
+        }
+
+        // clone and ensure that the output absolute maximum value is absolute
+        let mut result = Z::ZERO;
+        unsafe { fmpz_abs(&mut result.value, max) }
+        result
+    }
+}
+
+#[cfg(test)]
+mod test_find_max_abs_fmpz {
+    use super::Z;
+    use crate::integer::MatZ;
+    use std::str::FromStr;
+
+    /// Checks whether `find_max_abs_fmpz` works correctly for small positive
+    /// [`fmpz`] instances
+    #[test]
+    fn positive_small() {
+        let mat = MatZ::from_str("[[1, 10, 100]]").unwrap();
+        let fmpz_vector = mat.collect_entries();
+
+        let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
+
+        assert_eq!(abs_max, Z::from(100));
+    }
+
+    /// Checks whether `find_max_abs_fmpz` works correctly for large positive
+    /// [`fmpz`] instances
+    #[test]
+    fn positive_large() {
+        let mat = MatZ::from_str(&format!("[[1, {}, {}, 10]]", i64::MAX, u64::MAX)).unwrap();
+        let fmpz_vector = mat.collect_entries();
+
+        let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
+
+        assert_eq!(abs_max, Z::from(u64::MAX));
+    }
+
+    /// Checks whether `find_max_abs_fmpz` works correctly for small negative
+    /// [`fmpz`] instances
+    #[test]
+    fn negative_small() {
+        let mat = MatZ::from_str("[[1, -10, -100]]").unwrap();
+        let fmpz_vector = mat.collect_entries();
+
+        let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
+
+        assert_eq!(abs_max, Z::from(100));
+    }
+
+    /// Checks whether `find_max_abs_fmpz` works correctly for large negative
+    /// [`fmpz`] instances
+    #[test]
+    fn negative_large() {
+        let mat = MatZ::from_str(&format!("[[1, {}, -{}, 10]]", i64::MAX, u64::MAX)).unwrap();
+        let fmpz_vector = mat.collect_entries();
+
+        let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
+
+        assert_eq!(abs_max, Z::from(u64::MAX));
+    }
+}

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -6,99 +6,181 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! This module contains helpful functions on [`fmpz`] that return a [`Z`] value.
+//! This module contains helpful functions on [`fmpz`].
 
 use super::Z;
-use flint_sys::fmpz::{fmpz, fmpz_abs, fmpz_cmpabs};
+use flint_sys::fmpz::{fmpz, fmpz_abs, fmpz_cmpabs, fmpz_sub};
 
-impl Z {
-    /// Efficiently finds maximum absolute value and returns
-    /// a cloned [`Z`] instance out of a vector of [`fmpz`] instances.
-    ///
-    /// Parameters:
-    /// - `fmpz_vector`: contains a number of [`fmpz`] instances
-    ///
-    /// Returns the maximum absolute value out of the given [`fmpz`] vector
-    /// as a cloned [`Z`] instance.
-    ///
-    /// # Example
-    /// ```compile_fail
-    /// use math::integer::Z;
-    ///
-    /// let a = Z::from(-4);
-    /// let b = Z::from(-2);
-    ///
-    /// let fmpz_vector = vec![a.value, b.value];
-    /// let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
-    /// assert_eq!(abs_max, Z::from(4));
-    /// ```
-    pub(crate) fn find_max_abs_fmpz(fmpz_vector: &Vec<fmpz>) -> Self {
-        // find maximum of absolute fmpz entries
-        let mut max = &fmpz(0);
-        for entry in fmpz_vector {
-            if unsafe { fmpz_cmpabs(max, entry) } < 0 {
-                max = entry;
-            }
+/// Efficiently finds maximum absolute value and returns
+/// a cloned [`Z`] instance out of a vector of [`fmpz`] instances.
+///
+/// Parameters:
+/// - `fmpz_vector`: contains a number of [`fmpz`] instances
+///
+/// Returns the maximum absolute value out of the given [`fmpz`] vector
+/// as a cloned [`Z`] instance.
+///
+/// # Example
+/// ```compile_fail
+/// use flint_sys::fmpz::fmpz;
+/// use math::integer::{fmpz_helpers::find_max_abs, Z};
+///
+/// let fmpz_vec = vec![fmpz(0), fmpz(-13), fmpz(10)];
+///
+/// let abs_max = find_max_abs(&fmpz_vec);
+/// assert_eq!(Z::from(13), fmpz_vec);
+/// ```
+pub(crate) fn find_max_abs(fmpz_vector: &Vec<fmpz>) -> Z {
+    // find maximum of absolute fmpz entries
+    let mut max = &fmpz(0);
+    for entry in fmpz_vector {
+        if unsafe { fmpz_cmpabs(max, entry) } < 0 {
+            max = entry;
         }
-
-        // clone and ensure that the output absolute maximum value is absolute
-        let mut result = Z::ZERO;
-        unsafe { fmpz_abs(&mut result.value, max) }
-        result
     }
+
+    // clone and ensure that the output absolute maximum value is absolute
+    let mut result = Z::ZERO;
+    unsafe { fmpz_abs(&mut result.value, max) }
+    result
+}
+
+/// Computes the absolute distance between two [`fmpz`] instances.
+///
+/// Parameters:
+/// - `other`: specifies one of the [`fmpz`] values whose distance
+/// is calculated to `self`
+///
+/// Returns the absolute difference, i.e. distance between the two given [`fmpz`]
+/// instances as a new [`fmpz`] instance.
+///
+/// # Example
+/// ```compile_fail
+/// use flint_sys::fmpz::fmpz;
+/// use math::integer::fmpz_helpers::distance;
+///
+/// let a = fmpz(1);
+/// let b = fmpz(-15);
+///
+/// let distance = distance(&a, &b);
+///
+/// assert_eq!(16, distance.0);
+/// ```
+pub(crate) fn distance(value_1: &fmpz, value_2: &fmpz) -> fmpz {
+    let mut out = fmpz(0);
+    unsafe { fmpz_sub(&mut out, value_1, value_2) };
+    unsafe { fmpz_abs(&mut out, &out) };
+    out
 }
 
 #[cfg(test)]
-mod test_find_max_abs_fmpz {
-    use super::Z;
+mod test_find_max_abs {
+    use super::*;
     use crate::integer::MatZ;
     use std::str::FromStr;
 
-    /// Checks whether `find_max_abs_fmpz` works correctly for small positive
+    /// Checks whether `find_max_abs` works correctly for small positive
     /// [`fmpz`] instances
     #[test]
     fn positive_small() {
         let mat = MatZ::from_str("[[1, 10, 100]]").unwrap();
         let fmpz_vector = mat.collect_entries();
 
-        let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
+        let abs_max = find_max_abs(&fmpz_vector);
 
         assert_eq!(abs_max, Z::from(100));
     }
 
-    /// Checks whether `find_max_abs_fmpz` works correctly for large positive
+    /// Checks whether `find_max_abs` works correctly for large positive
     /// [`fmpz`] instances
     #[test]
     fn positive_large() {
         let mat = MatZ::from_str(&format!("[[1, {}, {}, 10]]", i64::MAX, u64::MAX)).unwrap();
         let fmpz_vector = mat.collect_entries();
 
-        let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
+        let abs_max = find_max_abs(&fmpz_vector);
 
         assert_eq!(abs_max, Z::from(u64::MAX));
     }
 
-    /// Checks whether `find_max_abs_fmpz` works correctly for small negative
+    /// Checks whether `find_max_abs` works correctly for small negative
     /// [`fmpz`] instances
     #[test]
     fn negative_small() {
         let mat = MatZ::from_str("[[1, -10, -100]]").unwrap();
         let fmpz_vector = mat.collect_entries();
 
-        let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
+        let abs_max = find_max_abs(&fmpz_vector);
 
         assert_eq!(abs_max, Z::from(100));
     }
 
-    /// Checks whether `find_max_abs_fmpz` works correctly for large negative
+    /// Checks whether `find_max_abs` works correctly for large negative
     /// [`fmpz`] instances
     #[test]
     fn negative_large() {
         let mat = MatZ::from_str(&format!("[[1, {}, -{}, 10]]", i64::MAX, u64::MAX)).unwrap();
         let fmpz_vector = mat.collect_entries();
 
-        let abs_max = Z::find_max_abs_fmpz(&fmpz_vector);
+        let abs_max = find_max_abs(&fmpz_vector);
 
         assert_eq!(abs_max, Z::from(u64::MAX));
+    }
+}
+
+#[cfg(test)]
+mod test_distance {
+    use super::distance;
+    use super::Z;
+    use flint_sys::fmpz::{fmpz, fmpz_cmp};
+
+    /// Checks if distance is correctly output for small [`Z`] values
+    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    #[test]
+    fn small_values() {
+        let a = fmpz(1);
+        let b = fmpz(-15);
+        let zero = fmpz(0);
+
+        assert_eq!(1, distance(&a, &zero).0);
+        assert_eq!(1, distance(&zero, &a).0);
+        assert_eq!(16, distance(&a, &b).0);
+        assert_eq!(16, distance(&b, &a).0);
+        assert_eq!(15, distance(&b, &zero).0);
+        assert_eq!(15, distance(&zero, &b).0);
+        assert_eq!(0, distance(&b, &b).0);
+        assert_eq!(0, distance(&a, &a).0);
+        assert_eq!(0, distance(&zero, &zero).0);
+    }
+
+    /// Checks if distance is correctly output for large [`Z`] values
+    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    #[test]
+    fn large_values() {
+        let a = Z::from(i64::MAX);
+        let b = Z::from(i64::MIN);
+        let zero = Z::ZERO;
+        let cmp_b_pos = Z::from(i64::MAX as u64 + 1);
+
+        assert_eq!(0, unsafe {
+            fmpz_cmp(&(&a - &b).value, &distance(&a.value, &b.value))
+        });
+        assert_eq!(0, unsafe {
+            fmpz_cmp(&(&a - &b).value, &distance(&b.value, &a.value))
+        });
+        assert_eq!(0, unsafe {
+            fmpz_cmp(&a.value, &distance(&a.value, &zero.value))
+        });
+        assert_eq!(0, unsafe {
+            fmpz_cmp(&(&a).value, &distance(&zero.value, &a.value))
+        });
+        assert_eq!(0, unsafe {
+            fmpz_cmp(&cmp_b_pos.value, &distance(&b.value, &zero.value))
+        });
+        assert_eq!(0, unsafe {
+            fmpz_cmp(&cmp_b_pos.value, &distance(&zero.value, &b.value))
+        });
+        assert_eq!(0, distance(&a.value, &a.value).0);
+        assert_eq!(0, distance(&b.value, &b.value).0);
     }
 }

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -32,6 +32,7 @@ use flint_sys::fmpz::{fmpz, fmpz_abs, fmpz_cmpabs, fmpz_sub};
 /// ```
 pub(crate) fn find_max_abs(fmpz_vector: &Vec<fmpz>) -> Z {
     // find maximum of absolute fmpz entries
+    // It's not necessary to clear `fmpz(0)` since it's small
     let mut max = &fmpz(0);
     for entry in fmpz_vector {
         if unsafe { fmpz_cmpabs(max, entry) } < 0 {

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -23,7 +23,7 @@ use flint_sys::fmpz::{fmpz, fmpz_abs, fmpz_cmpabs, fmpz_sub};
 /// # Example
 /// ```compile_fail
 /// use flint_sys::fmpz::fmpz;
-/// use math::integer::{fmpz_helpers::find_max_abs, Z};
+/// use qfall_math::integer::{fmpz_helpers::find_max_abs, Z};
 ///
 /// let fmpz_vec = vec![fmpz(0), fmpz(-13), fmpz(10)];
 ///
@@ -57,7 +57,7 @@ pub(crate) fn find_max_abs(fmpz_vector: &Vec<fmpz>) -> Z {
 /// # Example
 /// ```compile_fail
 /// use flint_sys::fmpz::fmpz;
-/// use math::integer::fmpz_helpers::distance;
+/// use qfall_math::integer::fmpz_helpers::distance;
 ///
 /// let a = fmpz(1);
 /// let b = fmpz(-15);

--- a/src/integer_mod_q.rs
+++ b/src/integer_mod_q.rs
@@ -21,4 +21,5 @@ pub use modulus::Modulus;
 pub use modulus_polynomial_ring_zq::ModulusPolynomialRingZq;
 pub use poly_over_zq::PolyOverZq;
 pub use polynomial_ring_zq::PolynomialRingZq;
+pub(crate) use z_q::fmpz_mod_helpers;
 pub use z_q::Zq;

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -189,7 +189,7 @@ impl MatZq {
     ///
     /// # Example
     /// ```compile_fail
-    /// use math::intger_mod_q::MatZq;
+    /// use qfall_math::intger_mod_q::MatZq;
     /// use std::str::FromStr;
     ///
     /// let mat = MatZq::from_str("[[1,2],[3,4]] mod 3").unwrap();

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -9,11 +9,13 @@
 //! Implementations to get entries from a [`MatZq`] matrix.
 
 use super::MatZq;
-use crate::integer::Z;
-use crate::integer_mod_q::Modulus;
-use crate::traits::{GetEntry, GetNumColumns, GetNumRows};
-use crate::utils::index::evaluate_indices;
-use crate::{error::MathError, integer_mod_q::Zq};
+use crate::{
+    error::MathError,
+    integer::Z,
+    integer_mod_q::{fmpz_mod_helpers::length, Modulus, Zq},
+    traits::{GetEntry, GetNumColumns, GetNumRows},
+    utils::index::evaluate_indices,
+};
 use flint_sys::{
     fmpz::{fmpz, fmpz_set},
     fmpz_mod_mat::fmpz_mod_mat_entry,
@@ -173,6 +175,42 @@ impl MatZq {
         }
 
         entries
+    }
+
+    /// Computes the lengths of a given vector of [`fmpz`] structs
+    /// considering the [`Modulus`](crate::integer_mod_q::Modulus) of `self`.
+    ///
+    /// Parameters:
+    /// - `entries_fmpz`: holds a vector of [`fmpz`] structs
+    /// of which the length is calculated
+    ///
+    /// Returns a [`Vec<fmpz>`] of lengths of [`Zq`] entries
+    /// considering the [`Modulus`](crate::integer_mod_q::Modulus) of `self`.
+    ///
+    /// # Example
+    /// ```compile_fail
+    /// use math::intger_mod_q::MatZq;
+    /// use std::str::FromStr;
+    ///
+    /// let mat = MatZq::from_str("[[1,2],[3,4]] mod 3").unwrap();
+    /// let fmpz_entries = mat.collect_entries();
+    ///
+    /// let entry_lengths = mat.collect_lengths(&fmpz_entries);
+    /// ```
+    pub(crate) fn collect_lengths(&self) -> Vec<fmpz> {
+        let entries_fmpz = self.collect_entries();
+
+        let modulus_fmpz = self.matrix.mod_[0];
+        let mut entry_lengths = vec![];
+        for value in entries_fmpz {
+            // this instantiation removes the need to allocate new space
+            // on heap for large fmpz values, the cloned modulus object just increments
+            // the counter of references on this struct
+
+            entry_lengths.push(length(&value, &modulus_fmpz));
+        }
+
+        entry_lengths
     }
 }
 
@@ -415,5 +453,38 @@ mod test_collect_entries {
         assert_eq!(entries_2.len(), 2);
         assert_eq!(entries_2[0].0, 1);
         assert_eq!(entries_2[1].0, 0);
+    }
+}
+
+#[cfg(test)]
+mod test_collect_lengths {
+    use super::MatZq;
+    use std::str::FromStr;
+
+    #[test]
+    fn lengths_correctly_computed() {
+        let mat_1 = MatZq::from_str(&format!(
+            "[[1,2],[{},{}],[3,4]] mod {}",
+            i64::MAX - 2,
+            i64::MIN,
+            i64::MAX - 1
+        ))
+        .unwrap();
+        let mat_2 = MatZq::from_str("[[-1,2]] mod 2").unwrap();
+
+        let lengths_1 = mat_1.collect_lengths();
+        let lengths_2 = mat_2.collect_lengths();
+
+        assert_eq!(lengths_1.len(), 6);
+        assert_eq!(lengths_1[0].0, 1);
+        assert_eq!(lengths_1[1].0, 2);
+        assert_eq!(lengths_1[2].0, 1);
+        assert_eq!(lengths_1[3].0, 2);
+        assert_eq!(lengths_1[4].0, 3);
+        assert_eq!(lengths_1[5].0, 4);
+
+        assert_eq!(lengths_2.len(), 2);
+        assert_eq!(lengths_2[0].0, 1);
+        assert_eq!(lengths_2[1].0, 0);
     }
 }

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -177,14 +177,7 @@ impl MatZq {
         entries
     }
 
-    /// Computes the lengths of a given vector of [`fmpz`] structs
-    /// considering the [`Modulus`](crate::integer_mod_q::Modulus) of `self`.
-    ///
-    /// Parameters:
-    /// - `entries_fmpz`: holds a vector of [`fmpz`] structs
-    /// of which the length is calculated
-    ///
-    /// Returns a [`Vec<fmpz>`] of lengths of [`Zq`] entries
+    /// Computes the lengths of a given vector of [`Z`] values
     /// considering the [`Modulus`](crate::integer_mod_q::Modulus) of `self`.
     ///
     /// # Example
@@ -193,20 +186,15 @@ impl MatZq {
     /// use std::str::FromStr;
     ///
     /// let mat = MatZq::from_str("[[1,2],[3,4]] mod 3").unwrap();
-    /// let fmpz_entries = mat.collect_entries();
     ///
-    /// let entry_lengths = mat.collect_lengths(&fmpz_entries);
+    /// let lengths = mat.collect_lengths();
     /// ```
-    pub(crate) fn collect_lengths(&self) -> Vec<fmpz> {
+    pub(crate) fn collect_lengths(&self) -> Vec<Z> {
         let entries_fmpz = self.collect_entries();
 
         let modulus_fmpz = self.matrix.mod_[0];
         let mut entry_lengths = vec![];
         for value in entries_fmpz {
-            // this instantiation removes the need to allocate new space
-            // on heap for large fmpz values, the cloned modulus object just increments
-            // the counter of references on this struct
-
             entry_lengths.push(length(&value, &modulus_fmpz));
         }
 
@@ -444,9 +432,8 @@ mod test_collect_entries {
         assert_eq!(entries_1.len(), 6);
         assert_eq!(entries_1[0].0, 1);
         assert_eq!(entries_1[1].0, 2);
-        // 4611686018427387904 = 2^62, i.e. value is stored on stack
-        assert!(entries_1[2].0 >= 4611686018427387904);
-        assert!(entries_1[3].0 >= 4611686018427387904);
+        assert!(entries_1[2].0 >= 2_i64.pow(62));
+        assert!(entries_1[3].0 >= 2_i64.pow(62));
         assert_eq!(entries_1[4].0, 3);
         assert_eq!(entries_1[5].0, 4);
 
@@ -458,7 +445,7 @@ mod test_collect_entries {
 
 #[cfg(test)]
 mod test_collect_lengths {
-    use super::MatZq;
+    use super::{MatZq, Z};
     use std::str::FromStr;
 
     #[test]
@@ -476,15 +463,15 @@ mod test_collect_lengths {
         let lengths_2 = mat_2.collect_lengths();
 
         assert_eq!(lengths_1.len(), 6);
-        assert_eq!(lengths_1[0].0, 1);
-        assert_eq!(lengths_1[1].0, 2);
-        assert_eq!(lengths_1[2].0, 1);
-        assert_eq!(lengths_1[3].0, 2);
-        assert_eq!(lengths_1[4].0, 3);
-        assert_eq!(lengths_1[5].0, 4);
+        assert_eq!(lengths_1[0], Z::ONE);
+        assert_eq!(lengths_1[1], Z::from(2));
+        assert_eq!(lengths_1[2], Z::ONE);
+        assert_eq!(lengths_1[3], Z::from(2));
+        assert_eq!(lengths_1[4], Z::from(3));
+        assert_eq!(lengths_1[5], Z::from(4));
 
         assert_eq!(lengths_2.len(), 2);
-        assert_eq!(lengths_2[0].0, 1);
-        assert_eq!(lengths_2[1].0, 0);
+        assert_eq!(lengths_2[0], Z::ONE);
+        assert_eq!(lengths_2[1], Z::ZERO);
     }
 }

--- a/src/integer_mod_q/mat_zq/vector.rs
+++ b/src/integer_mod_q/mat_zq/vector.rs
@@ -10,3 +10,4 @@
 //! that have one column or one row and hence represent a vector.
 
 mod is_vector;
+mod norm;

--- a/src/integer_mod_q/mat_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_zq/vector/norm.rs
@@ -26,13 +26,15 @@ impl MatZq {
     ///
     /// # Example
     /// ```
-    /// use qfall_math::integer_mod_q::MatZq;
+    /// use qfall_math::{
+    ///     integer::Z,
+    ///     integer_mod_q::MatZq,
+    /// };
     /// use std::str::FromStr;
-    /// # use qfall_math::integer::Z;
     ///
     /// let vec = MatZq::from_str("[[1],[2],[3]] mod 4").unwrap();
     ///
-    /// let sqrd_2_norm = vec.norm_sqrd_eucl().unwrap();
+    /// let sqrd_2_norm = vec.norm_eucl_sqrd().unwrap();
     ///
     /// // 1*1 + 2*2 + 1*1 = 6
     /// assert_eq!(Z::from(6), sqrd_2_norm);
@@ -41,10 +43,10 @@ impl MatZq {
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
     /// the given [`MatZq`] instance is not a (row or column) vector.
-    pub fn norm_sqrd_eucl(&self) -> Result<Z, MathError> {
+    pub fn norm_eucl_sqrd(&self) -> Result<Z, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(
-                String::from("norm_sqrd_eucl"),
+                String::from("norm_eucl_sqrd"),
                 self.get_num_rows(),
                 self.get_num_columns(),
             ));
@@ -60,7 +62,6 @@ impl MatZq {
             unsafe { fmpz_addmul(&mut result.value, &entry.value, &entry.value) }
         }
 
-        // TODO: Add sqrt function here
         Ok(result)
     }
 
@@ -71,9 +72,11 @@ impl MatZq {
     ///
     /// # Example
     /// ```
-    /// use qfall_math::integer_mod_q::MatZq;
+    /// use qfall_math::{
+    ///     integer::Z,
+    ///     integer_mod_q::MatZq,
+    /// };
     /// use std::str::FromStr;
-    /// # use qfall_math::integer::Z;
     ///
     /// let vec = MatZq::from_str("[[1],[2],[3]] mod 3").unwrap();
     ///
@@ -95,12 +98,12 @@ impl MatZq {
             ));
         }
 
+        let fmpz_entries = self.collect_entries();
+
         // compute lengths of all entries in matrix with regards to modulus
         // and find maximum length
-        let fmpz_entries = self.collect_entries();
         let modulus = self.matrix.mod_[0];
         let mut max = Z::ZERO;
-
         for fmpz_entry in fmpz_entries {
             let length = length(&fmpz_entry, &modulus);
             if length > max {
@@ -113,7 +116,7 @@ impl MatZq {
 }
 
 #[cfg(test)]
-mod test_norm_sqrd_eucl {
+mod test_norm_eucl_sqrd {
     use super::{MatZq, Z};
     use std::str::FromStr;
 
@@ -125,9 +128,9 @@ mod test_norm_sqrd_eucl {
         let vec_2 = MatZq::from_str("[[1,10,100]] mod 10").unwrap();
         let vec_3 = MatZq::from_str("[[1,10,100, 1000]] mod 10000").unwrap();
 
-        assert_eq!(vec_1.norm_sqrd_eucl().unwrap(), Z::ONE);
-        assert_eq!(vec_2.norm_sqrd_eucl().unwrap(), Z::from_i64(1));
-        assert_eq!(vec_3.norm_sqrd_eucl().unwrap(), Z::from_i64(1010101));
+        assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::ONE);
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from_i64(1));
+        assert_eq!(vec_3.norm_eucl_sqrd().unwrap(), Z::from_i64(1010101));
     }
 
     /// Check whether the squared euclidean norm for row vectors
@@ -144,7 +147,7 @@ mod test_norm_sqrd_eucl {
         let max = Z::from(i64::MAX);
         let cmp = Z::from(2) * &max * &max + Z::from(4);
 
-        assert_eq!(vec.norm_sqrd_eucl().unwrap(), cmp);
+        assert_eq!(vec.norm_eucl_sqrd().unwrap(), cmp);
     }
 
     /// Check whether the squared euclidean norm for column vectors
@@ -154,8 +157,8 @@ mod test_norm_sqrd_eucl {
         let vec_1 = MatZq::from_str("[[1],[10],[100]] mod 10").unwrap();
         let vec_2 = MatZq::from_str("[[1],[10],[100],[1000]] mod 10000").unwrap();
 
-        assert_eq!(vec_1.norm_sqrd_eucl().unwrap(), Z::from_i64(1));
-        assert_eq!(vec_2.norm_sqrd_eucl().unwrap(), Z::from_i64(1010101));
+        assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::from_i64(1));
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from_i64(1010101));
     }
 
     /// Check whether the squared euclidean norm for column vectors
@@ -172,7 +175,7 @@ mod test_norm_sqrd_eucl {
         let max = Z::from(i64::MAX);
         let cmp = Z::from(2) * &max * &max + Z::from(4);
 
-        assert_eq!(vec.norm_sqrd_eucl().unwrap(), cmp);
+        assert_eq!(vec.norm_eucl_sqrd().unwrap(), cmp);
     }
 
     /// Check whether euclidean norm calculations of non vectors yield an error
@@ -180,7 +183,7 @@ mod test_norm_sqrd_eucl {
     fn non_vector_yield_error() {
         let mat = MatZq::from_str("[[1,1],[10,2]] mod 3").unwrap();
 
-        assert!(mat.norm_sqrd_eucl().is_err());
+        assert!(mat.norm_eucl_sqrd().is_err());
     }
 }
 

--- a/src/integer_mod_q/mat_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_zq/vector/norm.rs
@@ -26,9 +26,9 @@ impl MatZq {
     ///
     /// # Example
     /// ```
-    /// use math::integer_mod_q::MatZq;
+    /// use qfall_math::integer_mod_q::MatZq;
     /// use std::str::FromStr;
-    /// # use math::integer::Z;
+    /// # use qfall_math::integer::Z;
     ///
     /// let vec = MatZq::from_str("[[1],[2],[3]] mod 4").unwrap();
     ///
@@ -70,9 +70,9 @@ impl MatZq {
     ///
     /// # Example
     /// ```
-    /// use math::integer_mod_q::MatZq;
+    /// use qfall_math::integer_mod_q::MatZq;
     /// use std::str::FromStr;
-    /// # use math::integer::Z;
+    /// # use qfall_math::integer::Z;
     ///
     /// let vec = MatZq::from_str("[[1],[2],[3]] mod 3").unwrap();
     ///

--- a/src/integer_mod_q/mat_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_zq/vector/norm.rs
@@ -9,36 +9,37 @@
 //! This module includes functionality to compute several norms
 //! defined on vectors.
 
-use super::super::MatZ;
+use super::super::MatZq;
 use crate::{
     error::MathError,
-    integer::{fmpz_helpers::find_max_abs, Z},
+    integer::fmpz_helpers::find_max_abs,
+    integer::Z,
     traits::{GetNumColumns, GetNumRows},
 };
 use flint_sys::fmpz::fmpz_addmul;
 
-impl MatZ {
+impl MatZq {
     /// Returns the squared Euclidean norm or 2-norm of the given (row or column) vector.
     ///
-    /// WARNING: This function may be renamed and changed in the future,
-    /// once we integrate a sqrt function for [`Z`] values.
+    /// Each length of an entry is defined as the shortest distance
+    /// to the next zero instance in the ring.
     ///
     /// # Example
     /// ```
-    /// use qfall_math::integer::MatZ;
+    /// use math::integer_mod_q::MatZq;
     /// use std::str::FromStr;
-    /// # use qfall_math::integer::Z;
+    /// # use math::integer::Z;
     ///
-    /// let vec = MatZ::from_str("[[1],[2],[3]]").unwrap();
+    /// let vec = MatZq::from_str("[[1],[2],[3]] mod 4").unwrap();
     ///
     /// let sqrd_2_norm = vec.norm_sqrd_eucl().unwrap();
     ///
-    /// assert_eq!(Z::from_i64(14), sqrd_2_norm);
+    /// assert_eq!(Z::from_i64(6), sqrd_2_norm);
     /// ```
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatZ`] instance is not a (row or column) vector.
+    /// the given [`MatZq`] instance is not a (row or column) vector.
     pub fn norm_sqrd_eucl(&self) -> Result<Z, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(
@@ -48,12 +49,12 @@ impl MatZ {
             ));
         }
 
-        // collect all entries in vector
-        let entries = self.collect_entries();
+        // compute lengths of all entries in matrix with regards to modulus
+        let entry_lengths = self.collect_lengths();
 
         // sum squared entries in result
         let mut result = Z::ZERO;
-        for entry in entries {
+        for entry in entry_lengths {
             // sets result = result + entry * entry without cloned Z element
             unsafe { fmpz_addmul(&mut result.value, &entry, &entry) }
         }
@@ -64,22 +65,25 @@ impl MatZ {
 
     /// Returns the infinity norm or ∞-norm of the given (row or column) vector.
     ///
+    /// Each length of an entry is defined as the shortest distance
+    /// to the next zero instance in the ring.
+    ///
     /// # Example
     /// ```
-    /// use qfall_math::integer::MatZ;
+    /// use math::integer_mod_q::MatZq;
     /// use std::str::FromStr;
-    /// # use qfall_math::integer::Z;
+    /// # use math::integer::Z;
     ///
-    /// let vec = MatZ::from_str("[[1],[2],[3]]").unwrap();
+    /// let vec = MatZq::from_str("[[1],[2],[3]] mod 3").unwrap();
     ///
     /// let infty_norm = vec.norm_infty().unwrap();
     ///
-    /// assert_eq!(Z::from_i64(3), infty_norm);
+    /// assert_eq!(Z::from_i64(1), infty_norm);
     /// ```
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatZ`] instance is not a (row or column) vector.
+    /// the given [`MatZq`] instance is not a (row or column) vector.
     pub fn norm_infty(&self) -> Result<Z, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(
@@ -89,30 +93,30 @@ impl MatZ {
             ));
         }
 
-        // collect all entries in vector
-        let entries = self.collect_entries();
+        // compute lengths of all entries in matrix with regards to modulus
+        let entry_lengths = self.collect_lengths();
 
         // find maximum of absolute fmpz entries and
         // return cloned absolute maximum [`Z`] value
-        Ok(find_max_abs(&entries))
+        Ok(find_max_abs(&entry_lengths))
     }
 }
 
 #[cfg(test)]
 mod test_norm_sqrd_eucl {
-    use super::{MatZ, Z};
+    use super::{MatZq, Z};
     use std::str::FromStr;
 
     /// Check whether the squared euclidean norm for row vectors
     /// with small entries is calculated correctly
     #[test]
     fn row_vector_small_entries() {
-        let vec_1 = MatZ::from_str("[[1]]").unwrap();
-        let vec_2 = MatZ::from_str("[[1,10,100]]").unwrap();
-        let vec_3 = MatZ::from_str("[[1,10,100, 1000]]").unwrap();
+        let vec_1 = MatZq::from_str("[[1]] mod 10").unwrap();
+        let vec_2 = MatZq::from_str("[[1,10,100]] mod 10").unwrap();
+        let vec_3 = MatZq::from_str("[[1,10,100, 1000]] mod 10000").unwrap();
 
         assert_eq!(vec_1.norm_sqrd_eucl().unwrap(), Z::ONE);
-        assert_eq!(vec_2.norm_sqrd_eucl().unwrap(), Z::from_i64(10101));
+        assert_eq!(vec_2.norm_sqrd_eucl().unwrap(), Z::from_i64(1));
         assert_eq!(vec_3.norm_sqrd_eucl().unwrap(), Z::from_i64(1010101));
     }
 
@@ -120,10 +124,15 @@ mod test_norm_sqrd_eucl {
     /// with large entries is calculated correctly
     #[test]
     fn row_vector_large_entries() {
-        let vec = MatZ::from_str(&format!("[[{},{}, 2]]", i64::MAX, i64::MIN)).unwrap();
+        let vec = MatZq::from_str(&format!(
+            "[[{},{}, 2]] mod {}",
+            i64::MAX,
+            i64::MIN,
+            u64::MAX
+        ))
+        .unwrap();
         let max = Z::from(i64::MAX);
-        let min = Z::from(i64::MIN);
-        let cmp = &min * &min + &max * &max + Z::from(4);
+        let cmp = Z::from(2) * &max * &max + Z::from(4);
 
         assert_eq!(vec.norm_sqrd_eucl().unwrap(), cmp);
     }
@@ -132,10 +141,10 @@ mod test_norm_sqrd_eucl {
     /// with small entries is calculated correctly
     #[test]
     fn column_vector_small_entries() {
-        let vec_1 = MatZ::from_str("[[1],[10],[100]]").unwrap();
-        let vec_2 = MatZ::from_str("[[1],[10],[100],[1000]]").unwrap();
+        let vec_1 = MatZq::from_str("[[1],[10],[100]] mod 10").unwrap();
+        let vec_2 = MatZq::from_str("[[1],[10],[100],[1000]] mod 10000").unwrap();
 
-        assert_eq!(vec_1.norm_sqrd_eucl().unwrap(), Z::from_i64(10101));
+        assert_eq!(vec_1.norm_sqrd_eucl().unwrap(), Z::from_i64(1));
         assert_eq!(vec_2.norm_sqrd_eucl().unwrap(), Z::from_i64(1010101));
     }
 
@@ -143,10 +152,15 @@ mod test_norm_sqrd_eucl {
     /// with large entries is calculated correctly
     #[test]
     fn column_vector_large_entries() {
-        let vec = MatZ::from_str(&format!("[[{}],[{}],[2]]", i64::MAX, i64::MIN)).unwrap();
+        let vec = MatZq::from_str(&format!(
+            "[[{}],[{}],[2]] mod {}",
+            i64::MAX,
+            i64::MIN,
+            u64::MAX
+        ))
+        .unwrap();
         let max = Z::from(i64::MAX);
-        let min = Z::from(i64::MIN);
-        let cmp = &min * &min + &max * &max + Z::from(4);
+        let cmp = Z::from(2) * &max * &max + Z::from(4);
 
         assert_eq!(vec.norm_sqrd_eucl().unwrap(), cmp);
     }
@@ -154,7 +168,7 @@ mod test_norm_sqrd_eucl {
     /// Check whether euclidean norm calculations of non vectors yield an error
     #[test]
     fn non_vector_yield_error() {
-        let mat = MatZ::from_str("[[1,1],[10,2]]").unwrap();
+        let mat = MatZq::from_str("[[1,1],[10,2]] mod 3").unwrap();
 
         assert!(mat.norm_sqrd_eucl().is_err());
     }
@@ -162,28 +176,34 @@ mod test_norm_sqrd_eucl {
 
 #[cfg(test)]
 mod test_norm_infty {
-    use super::{MatZ, Z};
+    use super::{MatZq, Z};
     use std::str::FromStr;
 
     /// Check whether the infinity norm for row vectors
     /// with small entries is calculated correctly
     #[test]
     fn row_vector_small_entries() {
-        let vec_1 = MatZ::from_str("[[1]]").unwrap();
-        let vec_2 = MatZ::from_str("[[1,10,100]]").unwrap();
-        let vec_3 = MatZ::from_str("[[1,10,100, 1000]]").unwrap();
+        let vec_1 = MatZq::from_str("[[6]] mod 10").unwrap();
+        let vec_2 = MatZq::from_str("[[1,10,100]] mod 1000").unwrap();
+        let vec_3 = MatZq::from_str("[[1,10,100, 1000]] mod 1000").unwrap();
 
-        assert_eq!(vec_1.norm_infty().unwrap(), Z::ONE);
+        assert_eq!(vec_1.norm_infty().unwrap(), Z::from(4));
         assert_eq!(vec_2.norm_infty().unwrap(), Z::from_i64(100));
-        assert_eq!(vec_3.norm_infty().unwrap(), Z::from_i64(1000));
+        assert_eq!(vec_3.norm_infty().unwrap(), Z::from_i64(100));
     }
 
     /// Check whether the infinity norm for row vectors
     /// with large entries is calculated correctly
     #[test]
     fn row_vector_large_entries() {
-        let vec = MatZ::from_str(&format!("[[{},{}, 2]]", i64::MAX, i64::MIN)).unwrap();
-        let cmp = Z::from(-1) * Z::from(i64::MIN);
+        let vec = MatZq::from_str(&format!(
+            "[[{},{}, 2]] mod {}",
+            i64::MAX,
+            i64::MIN,
+            u64::MAX
+        ))
+        .unwrap();
+        let cmp = Z::from(i64::MAX);
 
         assert_eq!(vec.norm_infty().unwrap(), cmp);
     }
@@ -192,19 +212,25 @@ mod test_norm_infty {
     /// with small entries is calculated correctly
     #[test]
     fn column_vector_small_entries() {
-        let vec_1 = MatZ::from_str("[[1],[10],[100]]").unwrap();
-        let vec_2 = MatZ::from_str("[[1],[10],[100],[1000]]").unwrap();
+        let vec_1 = MatZq::from_str("[[1],[10],[100]] mod 50").unwrap();
+        let vec_2 = MatZq::from_str("[[1],[10],[100],[1000]] mod 1999").unwrap();
 
-        assert_eq!(vec_1.norm_infty().unwrap(), Z::from_i64(100));
-        assert_eq!(vec_2.norm_infty().unwrap(), Z::from_i64(1000));
+        assert_eq!(vec_1.norm_infty().unwrap(), Z::from_i64(10));
+        assert_eq!(vec_2.norm_infty().unwrap(), Z::from_i64(999));
     }
 
     /// Check whether the infinity norm for column vectors
     /// with large entries is calculated correctly
     #[test]
     fn column_vector_large_entries() {
-        let vec = MatZ::from_str(&format!("[[{}],[{}],[2]]", i64::MAX, i64::MIN)).unwrap();
-        let cmp = Z::from(-1) * Z::from(i64::MIN);
+        let vec = MatZq::from_str(&format!(
+            "[[{}],[{}],[2]] mod {}",
+            i64::MAX,
+            i64::MIN,
+            u64::MAX
+        ))
+        .unwrap();
+        let cmp = Z::from(i64::MAX);
 
         assert_eq!(vec.norm_infty().unwrap(), cmp);
     }
@@ -212,7 +238,7 @@ mod test_norm_infty {
     /// Check whether infinity norm calculations of non vectors yield an error
     #[test]
     fn non_vector_yield_error() {
-        let mat = MatZ::from_str("[[1,1],[10,2]]").unwrap();
+        let mat = MatZq::from_str("[[1,1],[10,2]] mod 3").unwrap();
 
         assert!(mat.norm_infty().is_err());
     }

--- a/src/integer_mod_q/mat_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_zq/vector/norm.rs
@@ -83,7 +83,7 @@ impl MatZq {
     /// let infty_norm = vec.norm_infty().unwrap();
     ///
     /// // max{1, 1, 0} = 1
-    /// assert_eq!(Z::from_i64(1), infty_norm);
+    /// assert_eq!(Z::ONE, infty_norm);
     /// ```
     ///
     /// Errors and Failures
@@ -129,8 +129,8 @@ mod test_norm_eucl_sqrd {
         let vec_3 = MatZq::from_str("[[1,10,100, 1000]] mod 10000").unwrap();
 
         assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::ONE);
-        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from_i64(1));
-        assert_eq!(vec_3.norm_eucl_sqrd().unwrap(), Z::from_i64(1010101));
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::ONE);
+        assert_eq!(vec_3.norm_eucl_sqrd().unwrap(), Z::from(1010101));
     }
 
     /// Check whether the squared euclidean norm for row vectors
@@ -157,8 +157,8 @@ mod test_norm_eucl_sqrd {
         let vec_1 = MatZq::from_str("[[1],[10],[100]] mod 10").unwrap();
         let vec_2 = MatZq::from_str("[[1],[10],[100],[1000]] mod 10000").unwrap();
 
-        assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::from_i64(1));
-        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from_i64(1010101));
+        assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Z::ONE);
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Z::from(1010101));
     }
 
     /// Check whether the squared euclidean norm for column vectors
@@ -201,8 +201,8 @@ mod test_norm_infty {
         let vec_3 = MatZq::from_str("[[1,10,100, 1000]] mod 1000").unwrap();
 
         assert_eq!(vec_1.norm_infty().unwrap(), Z::from(4));
-        assert_eq!(vec_2.norm_infty().unwrap(), Z::from_i64(100));
-        assert_eq!(vec_3.norm_infty().unwrap(), Z::from_i64(100));
+        assert_eq!(vec_2.norm_infty().unwrap(), Z::from(100));
+        assert_eq!(vec_3.norm_infty().unwrap(), Z::from(100));
     }
 
     /// Check whether the infinity norm for row vectors
@@ -228,8 +228,8 @@ mod test_norm_infty {
         let vec_1 = MatZq::from_str("[[1],[10],[100]] mod 50").unwrap();
         let vec_2 = MatZq::from_str("[[1],[10],[100],[1000]] mod 1999").unwrap();
 
-        assert_eq!(vec_1.norm_infty().unwrap(), Z::from_i64(10));
-        assert_eq!(vec_2.norm_infty().unwrap(), Z::from_i64(999));
+        assert_eq!(vec_1.norm_infty().unwrap(), Z::from(10));
+        assert_eq!(vec_2.norm_infty().unwrap(), Z::from(999));
     }
 
     /// Check whether the infinity norm for column vectors

--- a/src/integer_mod_q/z_q.rs
+++ b/src/integer_mod_q/z_q.rs
@@ -22,6 +22,7 @@ use crate::integer::Z;
 use serde::{Deserialize, Serialize};
 
 mod arithmetic;
+pub(crate) mod fmpz_mod_helpers;
 mod from;
 mod reduce;
 mod to_string;

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -70,7 +70,12 @@ mod test_length {
         let pos_1 = Z::from(i64::MAX);
         let pos_2 = Z::from(u64::MAX - 58);
 
-        assert_eq!(0, unsafe { fmpz_cmp(&Z::from(9223372036854775807_u64).value, &length(&pos_1.value, &modulus.value)) });
+        assert_eq!(0, unsafe {
+            fmpz_cmp(
+                &Z::from(9223372036854775807_u64).value,
+                &length(&pos_1.value, &modulus.value),
+            )
+        });
         assert_eq!(58, length(&pos_2.value, &modulus.value).0);
     }
 }

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -22,7 +22,7 @@ const ZERO_FMPZ: fmpz = fmpz(0);
 /// # Example
 /// ```compile_fail
 /// use flint_sys::fmpz::fmpz;
-/// use math::integer_mod_q::fmpz_mod_helpers::length;
+/// use qfall_math::integer_mod_q::fmpz_mod_helpers::length;
 ///
 /// let modulus = fmpz(15);
 /// let value = fmpz(10);

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -71,10 +71,7 @@ mod test_length {
         let pos_1 = Z::from(i64::MAX);
         let pos_2 = Z::from(u64::MAX - 58);
 
-        assert_eq!(
-            &Z::from(9223372036854775807_u64),
-            &length(&pos_1.value, &modulus.value)
-        );
+        assert_eq!(&Z::from(i64::MAX), &length(&pos_1.value, &modulus.value));
         assert_eq!(Z::from(58), length(&pos_2.value, &modulus.value));
     }
 }

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -1,0 +1,76 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains helpful functions on [`fmpz`] values in a ring/`modulus` context.
+
+use crate::integer::fmpz_helpers::distance;
+use flint_sys::fmpz::{fmpz, fmpz_cmp};
+
+const ZERO_FMPZ: fmpz = fmpz(0);
+
+/// Computes the shortest distance of `self` to the next zero instance
+/// regarding the `modulus`.
+///
+/// WARNING: This function assumes `value` to be reduced,
+/// i.e. `0 <= value <= modulus`.
+///
+/// # Example
+/// ```compile_fail
+/// use flint_sys::fmpz::fmpz;
+/// use math::integer_mod_q::fmpz_mod_helpers::length;
+///
+/// let modulus = fmpz(15);
+/// let value = fmpz(10);
+///
+/// let length = length(&value, &modulus);
+///
+/// assert_eq!(5, length.0);
+/// ```
+pub(crate) fn length(value: &fmpz, modulus: &fmpz) -> fmpz {
+    let distance_zero = distance(&ZERO_FMPZ, value);
+    let distance_modulus = distance(value, modulus);
+
+    // if distance_zero < distance modulus => return distance_zero
+    if unsafe { fmpz_cmp(&distance_zero, &distance_modulus) } < 0 {
+        distance_zero
+    } else {
+        distance_modulus
+    }
+}
+
+#[cfg(test)]
+mod test_length {
+    use super::*;
+    use crate::integer::Z;
+
+    /// Checks whether lengths for values in rings are computed correctly for all possible cases
+    /// (shortest distance to next zero is found) for small values
+    #[test]
+    fn small_values() {
+        let modulus = fmpz(15);
+        let pos_1 = fmpz(10);
+        let pos_2 = fmpz(7);
+        let zero = fmpz(0);
+
+        assert_eq!(5, length(&pos_1, &modulus).0);
+        assert_eq!(7, length(&pos_2, &modulus).0);
+        assert_eq!(0, length(&zero, &modulus).0);
+    }
+
+    /// Checks whether lengths for values in rings are computed correctly for all possible cases
+    /// (shortest distance to next zero is found) for large values
+    #[test]
+    fn large_values() {
+        let modulus = Z::from(u64::MAX);
+        let pos_1 = Z::from(i64::MAX);
+        let pos_2 = Z::from(u64::MAX - 58);
+
+        assert_eq!(0, unsafe { fmpz_cmp(&Z::from(9223372036854775807_u64).value, &length(&pos_1.value, &modulus.value)) });
+        assert_eq!(58, length(&pos_2.value, &modulus.value).0);
+    }
+}

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -287,14 +287,13 @@ mod test_collect_entries {
         let entries_2 = mat_2.collect_entries();
 
         assert_eq!(entries_1.len(), 6);
-        // 4611686018427387904 = 2^62, i.e. value is stored on stack
         assert_eq!(entries_1[0].num.0, 1);
-        assert!(entries_1[0].den.0 > 4611686018427387904);
+        assert!(entries_1[0].den.0 >= 2_i64.pow(62));
         assert_eq!(entries_1[1].num.0, 2);
         assert_eq!(entries_1[1].den.0, 1);
-        assert!(entries_1[2].num.0 >= 4611686018427387904);
+        assert!(entries_1[2].num.0 >= 2_i64.pow(62));
         assert_eq!(entries_1[2].den.0, 1);
-        assert!(entries_1[3].num.0 >= 4611686018427387904);
+        assert!(entries_1[3].num.0 >= 2_i64.pow(62));
         assert_eq!(entries_1[3].den.0, 1);
         assert_eq!(entries_1[4].num.0, 3);
         assert_eq!(entries_1[4].den.0, 4);


### PR DESCRIPTION
This PR implements...
several features needed to compute norms on `Zq` vectors like
- [X] distance for fmpz
- [X] length for fmpz_mod
- [X] collect_lengths for MatZq

and `norm_eucl_sqrd`, `norm_infty` for `MatZq` including tests.