### PR TITLE
Z Properties

### DIFF
--- a/src/integer/z.rs
+++ b/src/integer/z.rs
@@ -17,6 +17,7 @@ mod default;
 mod exp;
 mod from;
 mod ownership;
+mod properties;
 mod serialize;
 mod to_string;
 

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -110,11 +110,11 @@ impl Z {
     /// let a: Z = Z::from_fmpz(&value);
     /// ```
     pub(crate) fn from_fmpz(value: &fmpz) -> Self {
-        let mut ret_value = fmpz(0);
+        let mut out = Z::default();
         unsafe {
-            fmpz_set(&mut ret_value, value);
+            fmpz_set(&mut out.value, value);
         }
-        Z { value: ret_value }
+        out
     }
 }
 
@@ -339,7 +339,7 @@ mod tests_from_modulus {
     use crate::integer_mod_q::Modulus;
     use std::str::FromStr;
 
-    /// Ensure that `from_modulus` works correctly for small and large numbers
+    /// Ensure that `from_modulus` is available for small and large numbers
     #[test]
     fn large_and_small_numbers() {
         let mod_1 = Modulus::from_str(&"1".repeat(65)).unwrap();
@@ -363,18 +363,15 @@ mod tests_from_modulus {
 
 #[cfg(test)]
 mod tests_from_fmpz {
-    use super::fmpz;
     use super::Z;
-    use flint_sys::fmpz::fmpz_init_set_ui;
 
-    /// Ensure that `from_fmpz` works correctly for small and large numbers
+    /// Ensure that `from_fmpz` is available for small and large numbers
     #[test]
     fn large_small_numbers() {
-        let mut mod_1 = fmpz(0);
-        unsafe { fmpz_init_set_ui(&mut mod_1, u64::MAX) };
-        let mod_2 = fmpz(0);
+        let mod_1 = Z::from(u64::MAX);
+        let mod_2 = Z::ZERO;
 
-        let _ = Z::from_fmpz(&mod_1);
-        let _ = Z::from_fmpz(&mod_2);
+        let _ = Z::from_fmpz(&mod_1.value);
+        let _ = Z::from_fmpz(&mod_2.value);
     }
 }

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -91,6 +91,31 @@ impl Z {
         unsafe { fmpz_set(&mut out.value, &value.get_fmpz_mod_ctx_struct().n[0]) };
         out
     }
+
+    #[allow(dead_code)]
+    /// Create a new Integer that can grow arbitrary large.
+    ///
+    /// Parameters:
+    /// - `value`: the initial value the integer should have
+    ///
+    /// Returns the new integer.
+    ///
+    /// # Example
+    /// ```compile_fail
+    /// use math::integer::Z;
+    /// use flint_sys::fmpz::fmpz;
+    ///
+    /// let value = fmpz(0);
+    ///
+    /// let a: Z = Z::from_fmpz(&value);
+    /// ```
+    pub(crate) fn from_fmpz(value: &fmpz) -> Self {
+        let mut ret_value = fmpz(0);
+        unsafe {
+            fmpz_set(&mut ret_value, value);
+        }
+        Z { value: ret_value }
+    }
 }
 
 // Generate [`From`] trait for the different types.
@@ -314,11 +339,9 @@ mod tests_from_modulus {
     use crate::integer_mod_q::Modulus;
     use std::str::FromStr;
 
-    /// Ensure that the `from_<type_name>` functions are available for
-    /// singed and unsigned integers of 8, 16, 32, and 64 bit length.
-    /// Tested with their maximum value.
+    /// Ensure that `from_modulus` works correctly for small and large numbers
     #[test]
-    fn large_small_numbers() {
+    fn large_and_small_numbers() {
         let mod_1 = Modulus::from_str(&"1".repeat(65)).unwrap();
         let mod_2 = Modulus::from_str("10").unwrap();
 
@@ -335,5 +358,23 @@ mod tests_from_modulus {
 
         let _ = Z::from(mod_1);
         let _ = Z::from(mod_2);
+    }
+}
+
+#[cfg(test)]
+mod tests_from_fmpz {
+    use super::fmpz;
+    use super::Z;
+    use flint_sys::fmpz::fmpz_init_set_ui;
+
+    /// Ensure that `from_fmpz` works correctly for small and large numbers
+    #[test]
+    fn large_small_numbers() {
+        let mut mod_1 = fmpz(0);
+        unsafe { fmpz_init_set_ui(&mut mod_1, u64::MAX) };
+        let mod_2 = fmpz(0);
+
+        let _ = Z::from_fmpz(&mod_1);
+        let _ = Z::from_fmpz(&mod_2);
     }
 }

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -102,7 +102,7 @@ impl Z {
     ///
     /// # Example
     /// ```compile_fail
-    /// use math::integer::Z;
+    /// use qfall_math::integer::Z;
     /// use flint_sys::fmpz::fmpz;
     ///
     /// let value = fmpz(0);

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -92,6 +92,7 @@ impl Z {
         out
     }
 
+    #[allow(dead_code)]
     /// Create a new Integer that can grow arbitrary large.
     ///
     /// Parameters:
@@ -115,7 +116,7 @@ impl Z {
         }
         out
     }
-    
+
     /// Create a new Integer that can grow arbitrary large.
     ///
     /// Parameters:
@@ -382,7 +383,7 @@ mod tests_from_modulus {
 }
 
 #[cfg(test)]
-mod tests_from_fmpz {
+mod test_from_fmpz {
     use super::Z;
 
     /// Ensure that `from_fmpz` is available for small and large numbers
@@ -396,6 +397,7 @@ mod tests_from_fmpz {
     }
 }
 
+#[cfg(test)]
 mod test_from_zq {
     use super::Z;
     use crate::integer_mod_q::Zq;

--- a/src/integer/z/properties.rs
+++ b/src/integer/z/properties.rs
@@ -1,0 +1,120 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module includes functionality about properties of [`Z`] instances.
+
+use super::Z;
+use flint_sys::fmpz::fmpz_abs;
+
+impl Z {
+    /// Computes the absolute distance between two [`Z`] instances.
+    ///
+    /// Parameters:
+    /// - `other`: specifies one of the [`Z`] values whose distance
+    /// is calculated to `self`
+    ///
+    /// Returns the absolute difference, i.e. distance between the two given [`Z`]
+    /// instances as a new [`Z`] instance.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer::Z;
+    ///
+    /// let a = Z::from(-1);
+    /// let b = Z::from(5);
+    ///
+    /// assert_eq!(Z::from(6), a.distance(&b));
+    /// ```
+    pub fn distance(&self, other: &Self) -> Z {
+        let difference = self - other;
+        difference.abs()
+    }
+
+    /// Returns the given [`Z`] instance with its absolute value.
+    ///
+    /// # Example
+    /// ```
+    /// use math::integer::Z;
+    ///
+    /// let value = Z::from(-1);
+    ///
+    /// assert_eq!(Z::ONE, value.abs());
+    /// ```
+    pub fn abs(mut self) -> Z {
+        unsafe {
+            fmpz_abs(&mut self.value, &self.value);
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod test_abs {
+    use super::Z;
+
+    /// Checks whether `abs` returns the positive value for small values correctly
+    #[test]
+    fn small_values() {
+        let pos = Z::ONE;
+        let zero = Z::ZERO;
+        let neg = Z::from(-15);
+
+        assert_eq!(Z::ONE, pos.abs());
+        assert_eq!(Z::ZERO, zero.abs());
+        assert_eq!(Z::from(15), neg.abs());
+    }
+
+    /// Checks whether `abs` returns the positive value for large values correctly
+    #[test]
+    fn large_values() {
+        let pos = Z::from(i64::MAX);
+        let neg = Z::from(i64::MIN);
+
+        assert_eq!(Z::from(i64::MAX), pos.abs());
+        assert_eq!(Z::from(i64::MIN) * Z::from(-1), neg.abs());
+    }
+}
+
+#[cfg(test)]
+mod test_distance {
+    use super::Z;
+
+    /// Checks if distance is correctly output for small [`Z`] values
+    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    #[test]
+    fn small_values() {
+        let a = Z::ONE;
+        let b = Z::from(-15);
+        let zero = Z::ZERO;
+
+        assert_eq!(Z::ONE, a.distance(&zero));
+        assert_eq!(Z::ONE, zero.distance(&a));
+        assert_eq!(Z::from(16), a.distance(&b));
+        assert_eq!(Z::from(16), b.distance(&a));
+        assert_eq!(Z::from(15), b.distance(&zero));
+        assert_eq!(Z::from(15), zero.distance(&b));
+        assert_eq!(Z::ZERO, b.distance(&b))
+    }
+
+    /// Checks if distance is correctly output for large [`Z`] values
+    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    #[test]
+    fn large_values() {
+        let a = Z::from(i64::MAX);
+        let b = Z::from(i64::MIN);
+        let zero = Z::ZERO;
+
+        assert_eq!(&a - &b, a.distance(&b));
+        assert_eq!(&a - &b, b.distance(&a));
+        assert_eq!(a, a.distance(&zero));
+        assert_eq!(a, zero.distance(&a));
+        assert_eq!(&a + Z::ONE, b.distance(&zero));
+        assert_eq!(&a + Z::ONE, zero.distance(&b));
+        assert_eq!(Z::ZERO, a.distance(&a));
+    }
+}

--- a/src/integer/z/properties.rs
+++ b/src/integer/z/properties.rs
@@ -23,7 +23,7 @@ impl Z {
     ///
     /// # Example
     /// ```
-    /// use math::integer::Z;
+    /// use qfall_math::integer::Z;
     ///
     /// let a = Z::from(-1);
     /// let b = Z::from(5);
@@ -39,7 +39,7 @@ impl Z {
     ///
     /// # Example
     /// ```
-    /// use math::integer::Z;
+    /// use qfall_math::integer::Z;
     ///
     /// let value = Z::from(-1);
     ///


### PR DESCRIPTION
This PR implements useful leftovers from the `MatZq::norm` implementation. This includes
- [X] from_fmpz
- [X] distance
- [X] abs/ absolute value

including tests for `Z`.