### PR TITLE
MatZq additional attribute `modulus`

### DIFF
--- a/src/integer_mod_q/mat_zq.rs
+++ b/src/integer_mod_q/mat_zq.rs
@@ -9,6 +9,7 @@
 //! [`MatZq`] is a type of matrix with integer entries of arbitrary length modulo `q`.
 //! This implementation uses the [FLINT](https://flintlib.org/) library.
 
+use crate::integer_mod_q::Modulus;
 use flint_sys::fmpz_mod_mat::fmpz_mod_mat_struct;
 
 mod cmp;
@@ -67,4 +68,12 @@ mod vector;
 #[derive(Debug)]
 pub struct MatZq {
     pub(crate) matrix: fmpz_mod_mat_struct,
+
+    // Since `get_mod` is needed for almost any action with `MatZq` instances
+    // a separate storage of the modulus object guarantees memory safety and
+    // is due to a reference counter in the `Modulus` object memory efficient.
+    // The modulus of a `MatZq` is not able to be modified afterwards. Hence, we
+    // do not need to care about conformity of the modulus stored in the `matrix`
+    // attribute and `modulus` attribute, if they are both set from the same value.
+    pub(crate) modulus: Modulus,
 }

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -17,6 +17,7 @@ use super::MatZq;
 use crate::{
     error::MathError,
     integer::Z,
+    integer_mod_q::Modulus,
     traits::SetEntry,
     utils::{
         dimensions::find_matrix_dimensions, index::evaluate_index, parse::parse_matrix_string,
@@ -87,6 +88,8 @@ impl MatZq {
 
             Ok(MatZq {
                 matrix: matrix.assume_init(),
+                // we can unwrap here since modulus > 0 was checked before
+                modulus: Modulus::try_from(&modulus).unwrap(),
             })
         }
     }

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -31,10 +31,7 @@ impl MatZq {
     /// let entry = matrix.get_mod();
     /// ```
     pub fn get_mod(&self) -> Modulus {
-        let mut out = Z::default();
-        unsafe { fmpz_set(&mut out.value, &self.matrix.mod_[0]) };
-
-        Modulus::try_from_z(&out).expect("The matrix modulus is not a valid modulus.")
+        self.modulus.clone()
     }
 }
 


### PR DESCRIPTION
This PR adds an additional attribute `modulus` to the `MatZq` struct. It allows for a more convenient way to `get_mod`, use this modulus efficiently, and not care about memory management issues, which arised from dropped Z/ Modulus values before.