### PR TITLE
Z `distance`

### DIFF
--- a/src/integer/z.rs
+++ b/src/integer/z.rs
@@ -14,6 +14,7 @@ use flint_sys::fmpz::fmpz;
 mod arithmetic;
 mod cmp;
 mod default;
+mod distance;
 mod exp;
 mod from;
 mod ownership;

--- a/src/integer/z/distance.rs
+++ b/src/integer/z/distance.rs
@@ -10,6 +10,7 @@
 
 use super::Z;
 use crate::{
+    integer_mod_q::{Modulus, Zq},
     macros::for_others::{implement_for_others, implement_for_owned},
     traits::Distance,
 };
@@ -44,12 +45,12 @@ impl Distance<&Z> for Z {
     }
 }
 
-implement_for_others!(Z, Z, Distance for u8 u16 u32 u64 i8 i16 i32 i64);
 implement_for_owned!(Z, Z, Distance);
+implement_for_others!(Z, Z, Distance for u8 u16 u32 u64 i8 i16 i32 i64 Modulus Zq);
 
 #[cfg(test)]
 mod test_distance {
-    use super::{Distance, Z};
+    use super::{Distance, Modulus, Zq, Z};
 
     /// Checks if distance is correctly output for small [`Z`] values
     /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
@@ -89,6 +90,8 @@ mod test_distance {
     #[test]
     fn other_types() {
         let a = Z::ZERO;
+        let modulus = Modulus::try_from_z(&Z::ONE).unwrap();
+        let zq = Zq::try_from_int_int(15, 19).unwrap();
 
         let u_0 = a.distance(0_u8);
         let u_1 = a.distance(15_u16);
@@ -98,6 +101,8 @@ mod test_distance {
         let i_1 = a.distance(-15_i16);
         let i_2 = a.distance(35_i32);
         let i_3 = a.distance(i64::MIN);
+        let dist_mod = Z::distance(&a, modulus);
+        let dist_zq = a.distance(zq);
 
         assert_eq!(Z::ZERO, u_0);
         assert_eq!(Z::from(15), u_1);
@@ -107,5 +112,7 @@ mod test_distance {
         assert_eq!(Z::from(15), i_1);
         assert_eq!(Z::from(35), i_2);
         assert_eq!(Z::from(i64::MIN).abs(), i_3);
+        assert_eq!(Z::ONE, dist_mod);
+        assert_eq!(Z::from(15), dist_zq);
     }
 }

--- a/src/integer/z/distance.rs
+++ b/src/integer/z/distance.rs
@@ -10,7 +10,7 @@
 
 use super::Z;
 use crate::{
-    integer_mod_q::{Modulus, Zq},
+    integer_mod_q::Modulus,
     macros::for_others::{implement_for_others, implement_for_owned},
     traits::Distance,
 };
@@ -48,11 +48,11 @@ impl Distance<&Z> for Z {
 }
 
 implement_for_owned!(Z, Z, Distance);
-implement_for_others!(Z, Z, Distance for u8 u16 u32 u64 i8 i16 i32 i64 Modulus Zq);
+implement_for_others!(Z, Z, Distance for u8 u16 u32 u64 i8 i16 i32 i64 Modulus);
 
 #[cfg(test)]
 mod test_distance {
-    use super::{Distance, Modulus, Zq, Z};
+    use super::{Distance, Modulus, Z};
 
     /// Checks if distance is correctly computed for small [`Z`] values
     /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
@@ -93,7 +93,6 @@ mod test_distance {
     fn availability() {
         let a = Z::ZERO;
         let modulus = Modulus::try_from_z(&Z::ONE).unwrap();
-        let zq = Zq::try_from_int_int(15, 19).unwrap();
 
         let u_0 = a.distance(0_u8);
         let u_1 = a.distance(15_u16);
@@ -104,7 +103,6 @@ mod test_distance {
         let i_2 = a.distance(35_i32);
         let i_3 = a.distance(i64::MIN);
         let dist_mod = a.distance(modulus);
-        let dist_zq = a.distance(zq);
 
         assert_eq!(Z::ZERO, u_0);
         assert_eq!(Z::from(15), u_1);
@@ -115,6 +113,5 @@ mod test_distance {
         assert_eq!(Z::from(35), i_2);
         assert_eq!(Z::from(i64::MIN).abs(), i_3);
         assert_eq!(Z::ONE, dist_mod);
-        assert_eq!(Z::from(15), dist_zq);
     }
 }

--- a/src/integer/z/distance.rs
+++ b/src/integer/z/distance.rs
@@ -16,6 +16,8 @@ use crate::{
 };
 
 impl Distance<&Z> for Z {
+    type Output = Z;
+
     /// Computes the absolute distance between two [`Z`] instances.
     ///
     /// Parameters:
@@ -39,7 +41,7 @@ impl Distance<&Z> for Z {
     /// # assert_eq!(Z::from(6), distance_0);
     /// # assert_eq!(Z::from(11), distance_1);
     /// ```
-    fn distance(&self, other: &Z) -> Self {
+    fn distance(&self, other: &Z) -> Self::Output {
         let difference = other - self;
         difference.abs()
     }
@@ -52,7 +54,7 @@ implement_for_others!(Z, Z, Distance for u8 u16 u32 u64 i8 i16 i32 i64 Modulus Z
 mod test_distance {
     use super::{Distance, Modulus, Zq, Z};
 
-    /// Checks if distance is correctly output for small [`Z`] values
+    /// Checks if distance is correctly computed for small [`Z`] values
     /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
     #[test]
     fn small_values() {
@@ -69,7 +71,7 @@ mod test_distance {
         assert_eq!(Z::ZERO, b.distance(&b))
     }
 
-    /// Checks if distance is correctly output for large [`Z`] values
+    /// Checks if distance is correctly computed for large [`Z`] values
     /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
     #[test]
     fn large_values() {
@@ -88,7 +90,7 @@ mod test_distance {
 
     /// Check whether distance is available for owned [`Z`] and other types
     #[test]
-    fn other_types() {
+    fn availability() {
         let a = Z::ZERO;
         let modulus = Modulus::try_from_z(&Z::ONE).unwrap();
         let zq = Zq::try_from_int_int(15, 19).unwrap();
@@ -101,7 +103,7 @@ mod test_distance {
         let i_1 = a.distance(-15_i16);
         let i_2 = a.distance(35_i32);
         let i_3 = a.distance(i64::MIN);
-        let dist_mod = Z::distance(&a, modulus);
+        let dist_mod = a.distance(modulus);
         let dist_zq = a.distance(zq);
 
         assert_eq!(Z::ZERO, u_0);

--- a/src/integer/z/distance.rs
+++ b/src/integer/z/distance.rs
@@ -1,0 +1,111 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains the implementation of the [`Distance`] trait for [`Z`].
+
+use super::Z;
+use crate::{
+    macros::for_others::{implement_for_others, implement_for_owned},
+    traits::Distance,
+};
+
+impl Distance<&Z> for Z {
+    /// Computes the absolute distance between two [`Z`] instances.
+    ///
+    /// Parameters:
+    /// - `other`: specifies one of the [`Z`] values whose distance
+    /// is calculated to `self`
+    ///
+    /// Returns the absolute difference, i.e. distance between the two given [`Z`]
+    /// instances as a new [`Z`] instance.
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::integer::Z;
+    /// use qfall_math::traits::*;
+    ///
+    /// let a = Z::from(-1);
+    /// let b = Z::from(10);
+    ///
+    /// let distance_0 = a.distance(5);
+    /// let distance_1 = a.distance(10);
+    ///
+    /// # assert_eq!(Z::from(6), distance_0);
+    /// # assert_eq!(Z::from(11), distance_1);
+    /// ```
+    fn distance(&self, other: &Z) -> Self {
+        let difference = other - self;
+        difference.abs()
+    }
+}
+
+implement_for_others!(Z, Z, Distance for u8 u16 u32 u64 i8 i16 i32 i64);
+implement_for_owned!(Z, Z, Distance);
+
+#[cfg(test)]
+mod test_distance {
+    use super::{Distance, Z};
+
+    /// Checks if distance is correctly output for small [`Z`] values
+    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    #[test]
+    fn small_values() {
+        let a = Z::ONE;
+        let b = Z::from(-15);
+        let zero = Z::ZERO;
+
+        assert_eq!(Z::ONE, a.distance(&zero));
+        assert_eq!(Z::ONE, zero.distance(&a));
+        assert_eq!(Z::from(16), a.distance(&b));
+        assert_eq!(Z::from(16), b.distance(&a));
+        assert_eq!(Z::from(15), b.distance(&zero));
+        assert_eq!(Z::from(15), zero.distance(&b));
+        assert_eq!(Z::ZERO, b.distance(&b))
+    }
+
+    /// Checks if distance is correctly output for large [`Z`] values
+    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    #[test]
+    fn large_values() {
+        let a = Z::from(i64::MAX);
+        let b = Z::from(i64::MIN);
+        let zero = Z::ZERO;
+
+        assert_eq!(&a - &b, a.distance(&b));
+        assert_eq!(&a - &b, b.distance(&a));
+        assert_eq!(a, a.distance(&zero));
+        assert_eq!(a, zero.distance(&a));
+        assert_eq!(&a + Z::ONE, b.distance(&zero));
+        assert_eq!(&a + Z::ONE, zero.distance(&b));
+        assert_eq!(Z::ZERO, a.distance(&a));
+    }
+
+    /// Check whether distance is available for owned [`Z`] and other types
+    #[test]
+    fn other_types() {
+        let a = Z::ZERO;
+
+        let u_0 = a.distance(0_u8);
+        let u_1 = a.distance(15_u16);
+        let u_2 = a.distance(35_u32);
+        let u_3 = a.distance(u64::MAX);
+        let i_0 = a.distance(0_i8);
+        let i_1 = a.distance(-15_i16);
+        let i_2 = a.distance(35_i32);
+        let i_3 = a.distance(i64::MIN);
+
+        assert_eq!(Z::ZERO, u_0);
+        assert_eq!(Z::from(15), u_1);
+        assert_eq!(Z::from(35), u_2);
+        assert_eq!(Z::from(u64::MAX), u_3);
+        assert_eq!(Z::ZERO, i_0);
+        assert_eq!(Z::from(15), i_1);
+        assert_eq!(Z::from(35), i_2);
+        assert_eq!(Z::from(i64::MIN).abs(), i_3);
+    }
+}

--- a/src/integer/z/properties.rs
+++ b/src/integer/z/properties.rs
@@ -12,29 +12,6 @@ use super::Z;
 use flint_sys::fmpz::fmpz_abs;
 
 impl Z {
-    /// Computes the absolute distance between two [`Z`] instances.
-    ///
-    /// Parameters:
-    /// - `other`: specifies one of the [`Z`] values whose distance
-    /// is calculated to `self`
-    ///
-    /// Returns the absolute difference, i.e. distance between the two given [`Z`]
-    /// instances as a new [`Z`] instance.
-    ///
-    /// # Example
-    /// ```
-    /// use qfall_math::integer::Z;
-    ///
-    /// let a = Z::from(-1);
-    /// let b = Z::from(5);
-    ///
-    /// assert_eq!(Z::from(6), a.distance(&b));
-    /// ```
-    pub fn distance(&self, other: &Self) -> Z {
-        let difference = self - other;
-        difference.abs()
-    }
-
     /// Returns the given [`Z`] instance with its absolute value.
     ///
     /// # Example
@@ -45,7 +22,7 @@ impl Z {
     ///
     /// assert_eq!(Z::ONE, value.abs());
     /// ```
-    pub fn abs(mut self) -> Z {
+    pub fn abs(mut self) -> Self {
         unsafe {
             fmpz_abs(&mut self.value, &self.value);
         }
@@ -77,44 +54,5 @@ mod test_abs {
 
         assert_eq!(Z::from(i64::MAX), pos.abs());
         assert_eq!(Z::from(i64::MIN) * Z::from(-1), neg.abs());
-    }
-}
-
-#[cfg(test)]
-mod test_distance {
-    use super::Z;
-
-    /// Checks if distance is correctly output for small [`Z`] values
-    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
-    #[test]
-    fn small_values() {
-        let a = Z::ONE;
-        let b = Z::from(-15);
-        let zero = Z::ZERO;
-
-        assert_eq!(Z::ONE, a.distance(&zero));
-        assert_eq!(Z::ONE, zero.distance(&a));
-        assert_eq!(Z::from(16), a.distance(&b));
-        assert_eq!(Z::from(16), b.distance(&a));
-        assert_eq!(Z::from(15), b.distance(&zero));
-        assert_eq!(Z::from(15), zero.distance(&b));
-        assert_eq!(Z::ZERO, b.distance(&b))
-    }
-
-    /// Checks if distance is correctly output for large [`Z`] values
-    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
-    #[test]
-    fn large_values() {
-        let a = Z::from(i64::MAX);
-        let b = Z::from(i64::MIN);
-        let zero = Z::ZERO;
-
-        assert_eq!(&a - &b, a.distance(&b));
-        assert_eq!(&a - &b, b.distance(&a));
-        assert_eq!(a, a.distance(&zero));
-        assert_eq!(a, zero.distance(&a));
-        assert_eq!(&a + Z::ONE, b.distance(&zero));
-        assert_eq!(&a + Z::ONE, zero.distance(&b));
-        assert_eq!(Z::ZERO, a.distance(&a));
     }
 }

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -109,6 +109,21 @@ macro_rules! implement_for_others {
             }
         })*
     };
+
+    // [`Distance`] trait
+    ($bridge_type:ident, $type:ident, Distance for $($source_type:ident)*) => {
+        $(impl Distance<$source_type> for $type {
+            paste::paste! {
+                #[doc = "Documentation can be found at [`" $type "::distance`]. Implicitly converts [`" $source_type "`] into [`" $bridge_type "`]."]
+            fn distance(
+                &self,
+                other: $source_type,
+            ) -> Self {
+                self.distance($bridge_type::from(other))
+            }
+            }
+        })*
+    };
 }
 
 pub(crate) use implement_for_others;
@@ -174,6 +189,21 @@ macro_rules! implement_for_owned {
                 value: $source_type,
             ) -> Result<(), MathError> {
                 self.set_entry(row, column, &value)
+            }
+            }
+        }
+    };
+
+    // [`Distance`] trait
+    ($source_type:ident, $type:ident, Distance) => {
+        impl Distance<$source_type> for $type {
+            paste::paste! {
+                #[doc = "Documentation can be found at [`" $type "::distance`]."]
+            fn distance(
+                &self,
+                other: $source_type,
+            ) -> Self {
+                self.distance(&other)
             }
             }
         }

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -20,18 +20,21 @@
 /// Implements a specified trait using implicit conversions to a bridge type.
 /// Several traits are already supported:
 ///
+/// - [`Distance`](crate::traits::Distance) with the signature
+/// `($out_type, $type, Distance for $source_type)`
 /// - [`Evaluate`](crate::traits::Evaluate) with the signature
-/// `($bridge_type, $output_type, $type, Evaluate for $source_type:ident)`
+/// `($bridge_type, $output_type, $type, Evaluate for $source_type)`
 /// - [`SetCoefficient`](crate::traits::SetCoefficient) with the signature
-/// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
+/// `($bridge_type, $type, SetCoefficient for $source_type)`
 /// - [`SetEntry`](crate::traits::SetEntry) with the signature
-/// `($bridge_type, $type, SetEntry for $source_type:ident)`
+/// `($bridge_type, $type, SetEntry for $source_type)`
 /// - ['Mul'](std::ops::Mul) with signatures
-/// `($bridge_type:ident, $type:ident, Mul Matrix for $source_type:ident)` and
-/// `($bridge_type:ident, $type:ident, Mul Scalar for $source_type:ident)`
+/// `($bridge_type, $type, Mul Matrix for $source_type)` and
+/// `($bridge_type, $type, Mul Scalar for $source_type)`
 ///
 /// # Examples
 /// ```compile_fail
+/// implement_for_others!(Z, Z, Distance for u8 u16 u32 u64 i8 i16 i32 i64 Modulus Zq);
 /// implement_for_others!(Z, Z, PolyOverZ, Evaluate for u8 u16 u32 u64 i8 i16 i32 i64);
 /// implement_for_others!(Z, PolyOverZ, SetCoefficient for i8 i16 i32 i64 u8 u16 u32 u64);
 /// implement_for_others!(Z, MatZq, SetEntry for i8 i16 i32 i64 u8 u16 u32 u64);
@@ -111,15 +114,16 @@ macro_rules! implement_for_others {
     };
 
     // [`Distance`] trait
-    ($bridge_type:ident, $type:ident, Distance for $($source_type:ident)*) => {
+    ($out_type:ident, $type:ident, Distance for $($source_type:ident)*) => {
         $(impl Distance<$source_type> for $type {
+            type Output = $out_type;
             paste::paste! {
-                #[doc = "Documentation can be found at [`" $type "::distance`]. Implicitly converts [`" $source_type "`] into [`" $bridge_type "`]."]
+                #[doc = "Documentation can be found at [`" $type "::distance`]. Implicitly converts [`" $source_type "`] into [`" $type "`]."]
             fn distance(
                 &self,
                 other: $source_type,
-            ) -> Self {
-                self.distance($bridge_type::from(other))
+            ) -> $out_type {
+                self.distance(&$type::from(other))
             }
             }
         })*
@@ -132,18 +136,21 @@ pub(crate) use implement_for_others;
 /// implementation for a borrowed input.
 /// Several traits are already supported:
 ///
+/// - [`Distance`](crate::traits::Distance) with the signature
+/// `($out_type, $type, Distance)`
 /// - [`Evaluate`](crate::traits::Evaluate) with the signature
-/// `($bridge_type, $output_type, $type, Evaluate for $source_type:ident)`
+/// `($bridge_type, $output_type, $type, Evaluate)`
 /// - [`SetCoefficient`](crate::traits::SetCoefficient) with the signature
-/// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
+/// `($bridge_type, $type, SetCoefficient)`
 /// - [`SetEntry`](crate::traits::SetEntry) with the signature
-/// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
+/// `($bridge_type, $type, SetCoefficient)`
 ///
 /// # Examples
 /// ```compile_fail
 /// implement_for_owned!(Q, Q, PolyOverQ, Evaluate);
 /// implement_for_owned!(Z, PolyOverZ, SetCoefficient);
 /// implement_for_owned!(Z, MatZq, SetEntry);
+/// implement_for_owned!(Z, Z, Distance);
 /// ```
 macro_rules! implement_for_owned {
     // [`Evaluate`] trait
@@ -195,14 +202,15 @@ macro_rules! implement_for_owned {
     };
 
     // [`Distance`] trait
-    ($source_type:ident, $type:ident, Distance) => {
-        impl Distance<$source_type> for $type {
+    ($out_type:ident, $type:ident, Distance) => {
+        impl Distance<$type> for $type {
+            type Output = $out_type;
             paste::paste! {
                 #[doc = "Documentation can be found at [`" $type "::distance`]."]
             fn distance(
                 &self,
-                other: $source_type,
-            ) -> Self {
+                other: $type,
+            ) -> Self::Output {
                 self.distance(&other)
             }
             }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -126,3 +126,14 @@ pub trait Concatenate {
     /// if the matrices can not be concatenated due to mismatching dimensions
     fn concat_horizontal(self, other: Self) -> Result<Self::Output, MathError>;
 }
+
+pub trait Distance<T> {
+    /// Computes the absolute distance between two values.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value whose distance is calculated to `self`
+    ///
+    /// Returns the absolute difference, i.e. distance between the two given values
+    /// as a new instance.
+    fn distance(&self, other: T) -> Self;
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -127,7 +127,9 @@ pub trait Concatenate {
     fn concat_horizontal(self, other: Self) -> Result<Self::Output, MathError>;
 }
 
-pub trait Distance<T> {
+pub trait Distance<T = Self> {
+    type Output;
+
     /// Computes the absolute distance between two values.
     ///
     /// Parameters:
@@ -135,5 +137,5 @@ pub trait Distance<T> {
     ///
     /// Returns the absolute difference, i.e. distance between the two given values
     /// as a new instance.
-    fn distance(&self, other: T) -> Self;
+    fn distance(&self, other: T) -> Self::Output;
 }


### PR DESCRIPTION
This PR refactors the implementation of `distance` for `Z`.
It implements a new trait `Distance` s.t. it can also be used for owned, borrowed, and u8, u16,... types.

This PR prepares an implementation of the `distance` trait for all numeric types.