### PR TITLE
Toolbox for established PK encryption

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ use thiserror::Error;
 ///
 /// Possible entries:
 /// - `DivisionByZeroError` is thrown if it is tried to perform a division by `0`
+/// - `InvalidExponent` is thrown if an invalid exponent is used for a `pow` function
 /// - `InvalidIntToModulus` is thrown if an integer is provided, which is not greater than `0`
 /// - `InvalidMatrix` is thrown if an invalid string input of a matrix is given
 /// - `InvalidStringToCStringInput` is thrown if an invalid string is given to
@@ -68,6 +69,10 @@ pub enum MathError {
     /// division by zero error
     #[error("the division by zero is not possible {0}")]
     DivisionByZeroError(String),
+
+    /// invalid exponent
+    #[error("Invalid exponent given: {0}")]
+    InvalidExponent(String),
 
     /// parse int to modulus error
     #[error(

--- a/src/integer/z/properties.rs
+++ b/src/integer/z/properties.rs
@@ -9,9 +9,23 @@
 //! This module includes functionality about properties of [`Z`] instances.
 
 use super::Z;
-use flint_sys::fmpz::fmpz_abs;
+use flint_sys::fmpz::{fmpz_abs, fmpz_is_prime};
 
 impl Z {
+    /// Checks if a [`Z`] is prime.
+    ///
+    /// Returns true if the value is prime.
+    ///
+    /// ```
+    /// use qfall_math::integer::Z;
+    ///
+    /// let value = Z::from(17);
+    /// assert!(value.is_prime())
+    /// ```
+    pub fn is_prime(&self) -> bool {
+        1 == unsafe { fmpz_is_prime(&self.value) }
+    }
+
     /// Computes the absolute distance between two [`Z`] instances.
     ///
     /// Parameters:
@@ -116,5 +130,28 @@ mod test_distance {
         assert_eq!(&a + Z::ONE, b.distance(&zero));
         assert_eq!(&a + Z::ONE, zero.distance(&b));
         assert_eq!(Z::ZERO, a.distance(&a));
+    }
+}
+
+#[cfg(test)]
+mod test_is_prime {
+    use super::Z;
+
+    /// ensure that primes are correctly detected
+    #[test]
+    fn prime_detection() {
+        let small = Z::from(2_i32.pow(16) + 1);
+        let large = Z::from(u64::MAX - 58);
+        assert!(small.is_prime());
+        assert!(large.is_prime());
+    }
+
+    /// ensure that non-primes are correctly detected
+    #[test]
+    fn non_prime_detection() {
+        let small = Z::from(2_i32.pow(16));
+        let large = Z::from(i64::MAX);
+        assert!(!small.is_prime());
+        assert!(!large.is_prime());
     }
 }

--- a/src/integer_mod_q/z_q/arithmetic.rs
+++ b/src/integer_mod_q/z_q/arithmetic.rs
@@ -11,4 +11,5 @@
 
 mod add;
 mod mul;
+mod pow;
 mod sub;

--- a/src/integer_mod_q/z_q/arithmetic/pow.rs
+++ b/src/integer_mod_q/z_q/arithmetic/pow.rs
@@ -1,0 +1,127 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module provides an implementation of the [`Pow`] trait for [`Zq`].
+
+use crate::{
+    error::MathError,
+    integer::Z,
+    integer_mod_q::Zq,
+    macros::for_others::{implement_for_others, implement_for_owned},
+    traits::Pow,
+};
+use flint_sys::fmpz_mod::fmpz_mod_pow_fmpz;
+
+impl Pow<&Z> for &Zq {
+    type Output = Zq;
+
+    /// Raises the value of `self` to the power of an integer `exp`.
+    ///
+    /// Parameters:
+    /// - `exp`: specifies the exponent to which the value is raised
+    ///
+    /// Returns the value of `self` powered by `exp` as a new `Output` instance.
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::integer::Z;
+    /// use qfall_math::integer_mod_q::Zq;
+    /// use qfall_math::traits::*;
+    ///
+    /// let base = Zq::try_from((2, 9)).unwrap();
+    /// let exp = Z::from(4);
+    ///
+    /// let powered_value = base.pow(&exp).unwrap();
+    ///
+    /// let cmp = Zq::try_from((7, 9)).unwrap();
+    /// assert_eq!(cmp, powered_value);
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError::InvalidExponent`] if the provided exponent is
+    /// negative and the base value of `self` is not invertible.
+    fn pow(self, exp: &Z) -> Result<Self::Output, MathError> {
+        let mut out = self.clone();
+        if 0 == unsafe {
+            fmpz_mod_pow_fmpz(
+                &mut out.value.value,
+                &self.value.value,
+                &exp.value,
+                self.modulus.get_fmpz_mod_ctx_struct(),
+            )
+        } {
+            return Err(MathError::InvalidExponent(format!(
+                "The negative exponent {} was used for a non-invertible base {}",
+                exp, self
+            )));
+        }
+        Ok(out)
+    }
+}
+
+implement_for_owned!(Z, Zq, Pow);
+implement_for_others!(Z, Zq, Pow for u8 u16 u32 u64 i8 i16 i32 i64);
+
+#[cfg(test)]
+mod test_pow {
+    use super::*;
+
+    /// Ensure that `pow` works for [`Zq`] properly for small values
+    #[test]
+    fn small() {
+        let base = Zq::try_from((2, 9)).unwrap();
+        let exp_0 = Z::from(4);
+        let exp_1 = Z::ZERO;
+        let exp_2 = Z::from(-2);
+
+        let res_0 = base.pow(&exp_0).unwrap();
+        let res_1 = base.pow(&exp_1).unwrap();
+        let res_2 = base.pow(&exp_2).unwrap();
+
+        assert_eq!(Zq::try_from((7, 9)).unwrap(), res_0);
+        assert_eq!(Zq::try_from((1, 9)).unwrap(), res_1);
+        assert_eq!(Zq::try_from((7, 9)).unwrap(), res_2);
+    }
+
+    /// Ensure that `pow` works for [`Zq`] properly for large values
+    #[test]
+    fn large() {
+        let base = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
+        let exp_0 = Z::from(4);
+        let exp_1 = Z::ZERO;
+        let exp_2 = Z::from(-1);
+        let cmp_0 = Zq::try_from((1152921504606846976_i64, u64::MAX)).unwrap();
+        let cmp_1 = Zq::try_from((1, u64::MAX)).unwrap();
+        let cmp_2 = Zq::try_from((18446744073709551613_u64, u64::MAX)).unwrap();
+
+        let res_0 = base.pow(&exp_0).unwrap();
+        let res_1 = base.pow(&exp_1).unwrap();
+        let res_2 = base.pow(&exp_2).unwrap();
+
+        assert_eq!(cmp_0, res_0);
+        assert_eq!(cmp_1, res_1);
+        assert_eq!(cmp_2, res_2);
+    }
+
+    /// Ensures that the `pow` trait is available for other types
+    #[test]
+    fn availability() {
+        let base = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
+        let exp = Z::from(4);
+
+        let _ = base.pow(exp);
+        let _ = base.pow(2_i8);
+        let _ = base.pow(2_i16);
+        let _ = base.pow(2_i32);
+        let _ = base.pow(2_i64);
+        let _ = base.pow(2_u8);
+        let _ = base.pow(2_u16);
+        let _ = base.pow(2_u32);
+        let _ = base.pow(2_u64);
+    }
+}

--- a/src/integer_mod_q/z_q/arithmetic/pow.rs
+++ b/src/integer_mod_q/z_q/arithmetic/pow.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use flint_sys::fmpz_mod::fmpz_mod_pow_fmpz;
 
-impl Pow<&Z> for &Zq {
+impl Pow<&Z> for Zq {
     type Output = Zq;
 
     /// Raises the value of `self` to the power of an integer `exp`.
@@ -43,9 +43,9 @@ impl Pow<&Z> for &Zq {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError::InvalidExponent`] if the provided exponent is
-    /// negative and the base value of `self` is not invertible.
-    fn pow(self, exp: &Z) -> Result<Self::Output, MathError> {
+    /// - Returns a [`MathError`] of type [`InvalidExponent`](MathError::InvalidExponent)
+    /// if the provided exponent is negative and the base value of `self` is not invertible.
+    fn pow(&self, exp: &Z) -> Result<Self::Output, MathError> {
         let mut out = self.clone();
         if 0 == unsafe {
             fmpz_mod_pow_fmpz(
@@ -123,5 +123,14 @@ mod test_pow {
         let _ = base.pow(2_u16);
         let _ = base.pow(2_u32);
         let _ = base.pow(2_u64);
+    }
+
+    /// Ensures that `pow` returns an error if a non-invertible basis is
+    /// powered by a negative exponent
+    #[test]
+    fn non_invertible_detection() {
+        let base = Zq::try_from((2, 4)).unwrap();
+
+        assert!(base.pow(-1).is_err());
     }
 }

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -29,6 +29,8 @@
 /// - ['Mul'](std::ops::Mul) with signatures
 /// `($bridge_type:ident, $type:ident, Mul Matrix for $source_type:ident)` and
 /// `($bridge_type:ident, $type:ident, Mul Scalar for $source_type:ident)`
+/// - [`Pow`](crate::traits::Pow) with the signature
+/// `($bridge_type, $type, Pow for $source_type:ident)`
 ///
 /// # Examples
 /// ```compile_fail
@@ -109,6 +111,19 @@ macro_rules! implement_for_others {
             }
         })*
     };
+
+    // [`Pow`] trait
+    ($bridge_type:ident, $type:ident, Pow for $($source_type:ident)*) => {
+        $(impl Pow<$source_type> for &$type {
+            type Output = $type;
+            paste::paste! {
+                #[doc = "Documentation can be found at [`" $type "::pow`]. Implicitly converts [`" $source_type "`] into [`" $bridge_type "`]."]
+                fn pow(self, exp: $source_type) -> Result<Self::Output, MathError> {
+                    self.pow(&$bridge_type::from(exp))
+                }
+            }
+        })*
+    };
 }
 
 pub(crate) use implement_for_others;
@@ -123,6 +138,8 @@ pub(crate) use implement_for_others;
 /// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
 /// - [`SetEntry`](crate::traits::SetEntry) with the signature
 /// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
+/// - [`Pow`](crate::traits::Pow) with the signature
+/// `($bridge_type, $type, Pow for $source_type:ident)`
 ///
 /// # Examples
 /// ```compile_fail
@@ -174,6 +191,22 @@ macro_rules! implement_for_owned {
                 value: $source_type,
             ) -> Result<(), MathError> {
                 self.set_entry(row, column, &value)
+            }
+            }
+        }
+    };
+
+    // [`Pow`] trait
+    ($source_type:ident, $type:ident, Pow) => {
+        impl Pow<$source_type> for &$type {
+            type Output = $type;
+            paste::paste! {
+                #[doc = "Documentation can be found at [`" $type "::pow`]."]
+            fn pow(
+                self,
+                exp: $source_type,
+            ) -> Result<Self::Output, MathError> {
+                self.pow(&exp)
             }
             }
         }

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -22,6 +22,8 @@
 ///
 /// - [`Evaluate`](crate::traits::Evaluate) with the signature
 /// `($bridge_type, $output_type, $type, Evaluate for $source_type:ident)`
+/// - [`Pow`](crate::traits::Pow) with the signature
+/// `($bridge_type, $type, Pow for $source_type)`
 /// - [`SetCoefficient`](crate::traits::SetCoefficient) with the signature
 /// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
 /// - [`SetEntry`](crate::traits::SetEntry) with the signature
@@ -29,8 +31,6 @@
 /// - ['Mul'](std::ops::Mul) with signatures
 /// `($bridge_type:ident, $type:ident, Mul Matrix for $source_type:ident)` and
 /// `($bridge_type:ident, $type:ident, Mul Scalar for $source_type:ident)`
-/// - [`Pow`](crate::traits::Pow) with the signature
-/// `($bridge_type, $type, Pow for $source_type:ident)`
 ///
 /// # Examples
 /// ```compile_fail
@@ -39,6 +39,7 @@
 /// implement_for_others!(Z, MatZq, SetEntry for i8 i16 i32 i64 u8 u16 u32 u64);
 /// implement_for_others!(Z, MatZ, Mul Matrix for i8 i16 i32 i64 u8 u16 u32 u64);
 /// implement_for_others!(Z, i8 i16 i32 i64 u8 u16 u32 u64, Mul Scalar for MatZ);
+/// implement_for_others!(Z, Zq, Pow for u8 u16 u32 u64 i8 i16 i32 i64);
 /// ```
 macro_rules! implement_for_others {
     // [`Evaluate`] trait
@@ -114,11 +115,11 @@ macro_rules! implement_for_others {
 
     // [`Pow`] trait
     ($bridge_type:ident, $type:ident, Pow for $($source_type:ident)*) => {
-        $(impl Pow<$source_type> for &$type {
+        $(impl Pow<$source_type> for $type {
             type Output = $type;
             paste::paste! {
                 #[doc = "Documentation can be found at [`" $type "::pow`]. Implicitly converts [`" $source_type "`] into [`" $bridge_type "`]."]
-                fn pow(self, exp: $source_type) -> Result<Self::Output, MathError> {
+                fn pow(&self, exp: $source_type) -> Result<Self::Output, MathError> {
                     self.pow(&$bridge_type::from(exp))
                 }
             }
@@ -134,18 +135,19 @@ pub(crate) use implement_for_others;
 ///
 /// - [`Evaluate`](crate::traits::Evaluate) with the signature
 /// `($bridge_type, $output_type, $type, Evaluate for $source_type:ident)`
+/// - [`Pow`](crate::traits::Pow) with the signature
+/// `($bridge_type, $type, Pow)`
 /// - [`SetCoefficient`](crate::traits::SetCoefficient) with the signature
 /// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
 /// - [`SetEntry`](crate::traits::SetEntry) with the signature
 /// `($bridge_type, $type, SetCoefficient for $source_type:ident)`
-/// - [`Pow`](crate::traits::Pow) with the signature
-/// `($bridge_type, $type, Pow for $source_type:ident)`
 ///
 /// # Examples
 /// ```compile_fail
 /// implement_for_owned!(Q, Q, PolyOverQ, Evaluate);
 /// implement_for_owned!(Z, PolyOverZ, SetCoefficient);
 /// implement_for_owned!(Z, MatZq, SetEntry);
+/// implement_for_owned!(Z, Zq, Pow);
 /// ```
 macro_rules! implement_for_owned {
     // [`Evaluate`] trait
@@ -198,12 +200,12 @@ macro_rules! implement_for_owned {
 
     // [`Pow`] trait
     ($source_type:ident, $type:ident, Pow) => {
-        impl Pow<$source_type> for &$type {
+        impl Pow<$source_type> for $type {
             type Output = $type;
             paste::paste! {
                 #[doc = "Documentation can be found at [`" $type "::pow`]."]
             fn pow(
-                self,
+                &self,
                 exp: $source_type,
             ) -> Result<Self::Output, MathError> {
                 self.pow(&exp)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -147,5 +147,5 @@ pub trait Pow<T> {
     /// - `exp`: specifies the exponent to which the value is raised
     ///
     /// Returns the value of `self` powered by `exp` as a new `Output` instance.
-    fn pow(self, exp: T) -> Result<Self::Output, MathError>;
+    fn pow(&self, exp: T) -> Result<Self::Output, MathError>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -137,3 +137,15 @@ pub trait Concatenate {
     /// if the matrices can not be concatenated due to mismatching dimensions
     fn concat_horizontal(self, other: Self) -> Result<Self::Output, MathError>;
 }
+
+pub trait Pow<T> {
+    type Output;
+
+    /// Raises the value of `self` to the power of an `exp`.
+    ///
+    /// Parameters:
+    /// - `exp`: specifies the exponent to which the value is raised
+    ///
+    /// Returns the value of `self` powered by `exp` as a new `Output` instance.
+    fn pow(self, exp: T) -> Result<Self::Output, MathError>;
+}


### PR DESCRIPTION
This PR implements missing pieces to be able to implement established public key encryption like RSA and El-Gamal with some additional help from other libraries using our data types.

Hence, it implements...
- [x] `is_prime` for `Z`
- [x] `pow` for `Zq`

including tests.