### PR TITLE
PolyOverQ: fix coefficients from_str not reduced

### DIFF
--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -14,7 +14,7 @@
 
 use super::PolyOverQ;
 use crate::error::MathError;
-use flint_sys::fmpq_poly::fmpq_poly_set_str;
+use flint_sys::fmpq_poly::{fmpq_poly_canonicalise, fmpq_poly_set_str};
 use std::{ffi::CString, str::FromStr};
 
 impl FromStr for PolyOverQ {
@@ -58,7 +58,12 @@ impl FromStr for PolyOverQ {
         // additionally if it was not successfully, test if the provided value 's' actually
         // contains two whitespaces, since this might be a common error
         match unsafe { fmpq_poly_set_str(&mut res.poly, c_string.as_ptr()) } {
-            0 => Ok(res),
+            0 => unsafe {
+                // set_str assumes that all coefficients are reduced as far as possible,
+                // hence we have to reduce manually
+                fmpq_poly_canonicalise(&mut res.poly);
+                Ok(res)
+            },
             _ if !s.contains("  ") => Err(MathError::InvalidStringToPolyMissingWhitespace(
                 s.to_owned(),
             )),
@@ -79,6 +84,15 @@ mod test_from_str {
         let one_2 = PolyOverQ::from_str("3  24/42 1 0").unwrap();
 
         assert_eq!(one_1, one_2)
+    }
+
+    /// Ensure that coefficients in the string are reduced
+    #[test]
+    fn reduce_coeff() {
+        assert_eq!(
+            PolyOverQ::from_str("3  4/77 4/14 -28/21").unwrap(),
+            PolyOverQ::from_str("3  4/77 2/7 -28/21").unwrap()
+        );
     }
 
     /// tests whether the same string yields the same polynomial


### PR DESCRIPTION
#155
This PR fixes the reducing of coefficients of a PolyOverQ when instantiated from a string