### PR TITLE
add get_i64 for Z values

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,7 @@ use thiserror::Error;
 /// errors occurring in this crate.
 ///
 /// Possible entries:
+/// -  `ConversionError` is thrown if a conversion between types is not possible
 /// - `DivisionByZeroError` is thrown if it is tried to perform a division by `0`
 /// - `InvalidExponent` is thrown if an invalid exponent is used for a `pow` function
 /// - `InvalidIntToModulus` is thrown if an integer is provided, which is not greater than `0`
@@ -66,6 +67,10 @@ use thiserror::Error;
 /// ```
 #[derive(Error, Debug)]
 pub enum MathError {
+    /// conversion error
+    #[error("while performing the conversion an error occurred: {0}")]
+    ConversionError(String),
+
     /// division by zero error
     #[error("the division by zero is not possible {0}")]
     DivisionByZeroError(String),

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -227,14 +227,19 @@ impl TryFrom<&Z> for i64 {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
+    /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
+    /// if the value does not fit into an [`i64`]
     fn try_from(value: &Z) -> Result<Self, Self::Error> {
+        // fmpz_get_si returns the i64::MAX or respectively i64::MIN
+        // if the value is too large/small to fit into an [`i64`].
+        // Hence we are required to manually check if the value is actually correct
         let value_i64 = unsafe { fmpz_get_si(&value.value) };
         if &Z::from(value_i64) == value {
             Ok(value_i64)
         } else {
             Err(MathError::ConversionError(format!(
-                "The provided value has to fit into an i64 and the provided value is {}.",
+                "The provided value has to fit into an i64 and it doesn't as the 
+                provided value is {}.",
                 value
             )))
         }

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -18,7 +18,9 @@ use crate::{
     integer_mod_q::{Modulus, Zq},
     macros::from::{from_trait, from_type},
 };
-use flint_sys::fmpz::{fmpz, fmpz_init_set_si, fmpz_init_set_ui, fmpz_set, fmpz_set_str};
+use flint_sys::fmpz::{
+    fmpz, fmpz_get_si, fmpz_init_set_si, fmpz_init_set_ui, fmpz_set, fmpz_set_str,
+};
 use std::{ffi::CString, str::FromStr};
 
 impl Z {
@@ -197,6 +199,44 @@ impl FromStr for Z {
         match unsafe { fmpz_set_str(&mut value, c_string.as_ptr(), 10) } {
             0 => Ok(Z { value }),
             _ => Err(MathError::InvalidStringToZInput(s.to_owned())),
+        }
+    }
+}
+
+impl TryFrom<&Z> for i64 {
+    type Error = MathError;
+
+    /// Converts a [`Z`] into an [`i64`]. If the value is either too large
+    /// or too small an error is returned.
+    ///
+    /// Parameters:
+    /// - `value`: the value that will be converted into an [`i64`]
+    ///
+    /// Returns the value as an [`i64`] or an error, if it does not fit
+    /// into an [`i64`]
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::integer::Z;
+    ///
+    /// let max = Z::from(i64::MAX);
+    /// assert_eq!(i64::MAX, i64::try_from(&max).unwrap());
+    ///
+    /// let max = Z::from(u64::MAX);
+    /// assert!(i64::try_from(&max).is_err());
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type
+    fn try_from(value: &Z) -> Result<Self, Self::Error> {
+        let value_i64 = unsafe { fmpz_get_si(&value.value) };
+        if &Z::from(value_i64) == value {
+            Ok(value_i64)
+        } else {
+            Err(MathError::ConversionError(format!(
+                "The provided value has to fit into an i64 and the provided value is {}.",
+                value
+            )))
         }
     }
 }
@@ -422,5 +462,31 @@ mod test_from_zq {
 
         assert_eq!(Z::from(i64::MAX), Z::from(zq_1));
         assert_eq!(Z::from(17), Z::from(zq_2));
+    }
+}
+
+#[cfg(test)]
+mod test_try_from_into_i64 {
+    use crate::integer::Z;
+
+    //// ensure that an error is returned, if the value of the [`Z`]
+    /// does not fit into an [`i64`]
+    #[test]
+    fn overflow() {
+        assert!(i64::try_from(&Z::from(u64::MAX)).is_err());
+        assert!(i64::try_from(&(-1 * Z::from(u64::MAX))).is_err());
+    }
+
+    /// ensure that a correct value is returned for values in bounds.
+    #[test]
+    fn correct() {
+        let min = Z::from(i64::MIN);
+        let max = Z::from(i64::MAX);
+        let z_42 = Z::from(42);
+
+        assert_eq!(i64::MIN, i64::try_from(&min).unwrap());
+        assert_eq!(i64::MAX, i64::try_from(&max).unwrap());
+        assert_eq!(0, i64::try_from(&Z::ZERO).unwrap());
+        assert_eq!(42, i64::try_from(&z_42).unwrap());
     }
 }


### PR DESCRIPTION
This PR adds the ability to turn a `Z` value into an `i64`.