### PR TITLE
CI: use latest version of tarpaulin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,12 +61,12 @@ jobs:
           command: test
           args: --verbose
       - name: Run tarpaulin to calculate code coverage
-        uses: actions-rs/tarpaulin@v0.1
+        uses: actions-rs/install@v0.1
         with:
-          version: '0.15.0'
-          args: '-- --test-threads 1'
-          out-type: Html
-      
+          crate: cargo-tarpaulin
+          version: latest
+      - run: cargo tarpaulin --out Html
+
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,12 +58,12 @@ jobs:
           command: test
           args: --verbose
       - name: Run tarpaulin to calculate code coverage
-        uses: actions-rs/tarpaulin@v0.1
+        uses: actions-rs/install@v0.1
         with:
-          version: '0.15.0'
-          args: '-- --test-threads 1'
-          out-type: Html
-      
+          crate: cargo-tarpaulin
+          version: latest
+      - run: cargo tarpaulin --out Html
+
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:


### PR DESCRIPTION
Update tarpaulin version used in CI. This improves code coverage accuracy.