### PR TITLE
fix parse error for PolyOverZ from_str

### DIFF
--- a/src/integer/poly_over_z/arithmetic/add.rs
+++ b/src/integer/poly_over_z/arithmetic/add.rs
@@ -98,7 +98,7 @@ mod test_add {
         let a: PolyOverZ = PolyOverZ::from_str("3  1 2 -3").unwrap();
         let b: PolyOverZ = PolyOverZ::from_str("3  -1 -2 3").unwrap();
         let c: PolyOverZ = a + b;
-        assert!(c == PolyOverZ::from_str("0").unwrap());
+        assert!(c == PolyOverZ::default());
     }
 
     /// testing addition for large [`PolyOverZ`]

--- a/src/integer/poly_over_z/arithmetic/mul.rs
+++ b/src/integer/poly_over_z/arithmetic/mul.rs
@@ -105,9 +105,9 @@ mod test_mul {
     #[test]
     fn mul_zero() {
         let a: PolyOverZ = PolyOverZ::from_str("3  1 2 -3").unwrap();
-        let b: PolyOverZ = PolyOverZ::from_str("0").unwrap();
+        let b: PolyOverZ = PolyOverZ::default();
         let c: PolyOverZ = a * b;
-        assert!(c == PolyOverZ::from_str("0").unwrap());
+        assert!(c == PolyOverZ::default());
     }
 
     /// testing multiplication for large [`PolyOverZ`]

--- a/src/integer/poly_over_z/arithmetic/sub.rs
+++ b/src/integer/poly_over_z/arithmetic/sub.rs
@@ -98,7 +98,7 @@ mod test_sub {
         let a: PolyOverZ = PolyOverZ::from_str("3  1 2 -3").unwrap();
         let b: PolyOverZ = PolyOverZ::from_str("3  1 2 -3").unwrap();
         let c: PolyOverZ = a - b;
-        assert!(c == PolyOverZ::from_str("0").unwrap());
+        assert!(c == PolyOverZ::default());
     }
 
     /// testing subtraction for large [`PolyOverZ`]

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -61,11 +61,11 @@ impl FromStr for PolyOverZ {
             return Ok(Self::default());
         }
 
-        // fmpz_poly_set_str just skips the two symbols after the number of
-        // coefficients (even if they are not whitespaces), hence we have to check if
-        // they are whitespaces manually.
-        // and we only have to check it once, because for every other position it checks
-        // whether there is only one whitespace
+        // fmpz_poly_set_str just skips the two symbols after the first space
+        // behind the number of coefficients (even if not a space), hence
+        // it has to be checked here to ensure that no number is lost.
+        // We only have to check it once, because for every other position it checks
+        // whether there is only one space.
         if !s_trimmed.contains("  ") {
             return Err(MathError::InvalidStringToPolyMissingWhitespace(
                 s.to_owned(),

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -54,6 +54,11 @@ impl FromStr for PolyOverZ {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // remove whitespaces at the start and at the end
         let s_trimmed = s.trim();
+
+        if s_trimmed == "0" {
+            return Ok(Self::default());
+        }
+
         // fmpz_poly_set_str just skips the two symbols after the number of
         // coefficients (even if they are not whitespaces), hence we have to check if
         // they are whitespaces manually.

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -26,8 +26,10 @@ impl FromStr for PolyOverZ {
     ///
     /// Parameters:
     /// - `s`: the polynomial of form: `"[#number of coefficients]⌴⌴[0th coefficient]⌴[1st coefficient]⌴..."`.
-    ///  Note that the `[#number of coefficients]` and `[0th coefficient]`
-    ///  are divided by two spaces.
+    ///
+    /// Note that the `[#number of coefficients]` and `[0th coefficient]`
+    /// are divided by two spaces and the input string is trimmed, i.e. all whitespaces
+    /// before and after are removed.
     ///
     /// Returns a [`PolyOverZ`] or an error, if the provided string was not formatted
     /// correctly.
@@ -136,5 +138,13 @@ mod test_from_str {
     #[test]
     fn false_number_of_coefficient() {
         assert!(PolyOverZ::from_str("4  1 2 -3").is_err());
+    }
+
+    /// ensure that the input works with strings that have to be trimmed
+    #[test]
+    fn trim_input() {
+        let poly = PolyOverZ::from_str("                   4  1 2 3 -4                  ");
+        assert!(poly.is_ok());
+        assert_eq!(PolyOverZ::from_str("4  1 2 3 -4").unwrap(), poly.unwrap());
     }
 }

--- a/src/integer/poly_over_z/set.rs
+++ b/src/integer/poly_over_z/set.rs
@@ -117,7 +117,7 @@ mod test_set_coeff {
     /// ensure that the correct coefficient is set and all others are set to `0`
     #[test]
     fn set_coeff_rest_zero() {
-        let mut poly = PolyOverZ::from_str("0").unwrap();
+        let mut poly = PolyOverZ::default();
 
         poly.set_coeff(4, -10).unwrap();
         assert_eq!(PolyOverZ::from_str("5  0 0 0 0 -10").unwrap(), poly);
@@ -126,7 +126,7 @@ mod test_set_coeff {
     /// ensure that setting with a z works
     #[test]
     fn set_coeff_z() {
-        let mut poly = PolyOverZ::from_str("0").unwrap();
+        let mut poly = PolyOverZ::default();
 
         poly.set_coeff(4, Z::from(123)).unwrap();
         assert_eq!(PolyOverZ::from_str("5  0 0 0 0 123").unwrap(), poly);

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -58,8 +58,8 @@ impl FromStr for PolyOverZq {
     /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
     /// if the provided modulus is not greater than `0`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (poly_s, modulus) = match s.split_once(" mod ") {
-            Some((poly_s, modulus)) => (poly_s, modulus),
+        let (poly_s, modulus) = match s.split_once("mod") {
+            Some((poly_s, modulus)) => (poly_s, modulus.trim()),
             None => return Err(MathError::InvalidStringToPolyModulusInput(s.to_owned())),
         };
 
@@ -143,7 +143,12 @@ mod test_from_str {
     /// an error
     #[test]
     fn missing_whitespace() {
-        assert!(PolyOverZq::from_str("4 0 1 -2 3 mod 42").is_err());
+        assert!(PolyOverZq::from_str("3 12 2 -3 mod 42").is_err());
+        assert!(PolyOverZq::from_str("2 17 42 mod 42").is_err());
+        assert!(PolyOverZq::from_str("2 17  42 mod 42").is_err());
+        assert!(PolyOverZq::from_str("2 17 42   mod 42").is_err());
+        assert!(PolyOverZq::from_str("  2 17 42 mod 42").is_err());
+        assert!(PolyOverZq::from_str("2 17 42 mod 42  ").is_err());
     }
 
     /// tests whether a falsely formatted string (too many whitespaces) returns

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -27,7 +27,8 @@ impl FromStr for PolyOverZq {
     /// - `s`: the polynomial of form:
     /// "`[#number of coefficients]⌴⌴[0th coefficient]⌴[1st coefficient]⌴...⌴mod⌴[modulus]`".
     /// Note that the `[#number of coefficients]` and `[0th coefficient]`
-    /// are divided by two spaces.
+    /// are divided by two spaces and the string for the polynomial is trimmed,
+    /// i.e. all whitespaces before around the polynomial and the modulus are removed.
     ///
     /// Returns a [`PolyOverZq`] or an error, if the provided string was not
     /// formatted correctly.
@@ -156,5 +157,16 @@ mod test_from_str {
     #[test]
     fn too_many_whitespaces() {
         assert!(PolyOverZq::from_str("4  0  1  -2  3 mod 42").is_err());
+    }
+
+    /// ensure that the input works with strings that have to be trimmed
+    #[test]
+    fn trim_input() {
+        let poly = PolyOverZq::from_str("                   4  1 2 3 -4                  mod              17                     ");
+        assert!(poly.is_ok());
+        assert_eq!(
+            PolyOverZq::from_str("4  1 2 3 -4 mod 17").unwrap(),
+            poly.unwrap()
+        );
     }
 }

--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -118,6 +118,12 @@ mod test_from_str {
     #[test]
     fn missing_whitespace() {
         assert!(PolyOverQ::from_str("3 1 2/5 -3/2").is_err());
+        assert!(PolyOverQ::from_str("3 12/5 2 -3").is_err());
+        assert!(PolyOverQ::from_str("2 17 42/4").is_err());
+        assert!(PolyOverQ::from_str("2 17 42").is_err());
+        assert!(PolyOverQ::from_str("2 17/1 42").is_err());
+        assert!(PolyOverQ::from_str("2 17/13 42  ").is_err());
+        assert!(PolyOverQ::from_str("  2 17/5 42").is_err());
     }
 
     /// tests whether a falsely formatted string (too many whitespaces) returns

--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -25,8 +25,10 @@ impl FromStr for PolyOverQ {
     ///
     /// Parameters:
     /// - `s`: the polynomial of form: "`[#number of coefficients]⌴⌴[0th coefficient]⌴[1st coefficient]⌴...`"
+    ///
     /// Note that the `[#number of coefficients]` and `[0th coefficient]`
-    /// are divided by two spaces.
+    /// are divided by two spaces and the input string is trimmed, i.e. all whitespaces
+    /// before and after are removed.
     ///
     /// Returns a [`PolyOverQ`] or an error, if the provided string was not formatted
     /// correctly.
@@ -52,7 +54,7 @@ impl FromStr for PolyOverQ {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut res = Self::default();
 
-        let c_string = CString::new(s)?;
+        let c_string = CString::new(s.trim())?;
 
         // `0` is returned if the string is a valid input
         // additionally if it was not successfully, test if the provided value 's' actually
@@ -145,5 +147,16 @@ mod test_from_str {
     #[test]
     fn too_many_divisors() {
         assert!(PolyOverQ::from_str("3  1 2/5 -3/2/3").is_err());
+    }
+
+    /// ensure that the input works with strings that have to be trimmed
+    #[test]
+    fn trim_input() {
+        let poly = PolyOverQ::from_str("                   4  1/2 2/3 3/4 -4                  ");
+        assert!(poly.is_ok());
+        assert_eq!(
+            PolyOverQ::from_str("4  1/2 2/3 3/4 -4").unwrap(),
+            poly.unwrap()
+        );
     }
 }


### PR DESCRIPTION
This closes #183.

The problem: fmpz_poly_set_str ignores both symbols after the number of coefficients, this is now fixed with a dedicated string. This issue does not occur for PolyOverQ. I added according tests in the from-methods