### PR TITLE
Add PolyZq from PolyZ and Modulus

### DIFF
--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright © 2023 Marvin Beckmann and Sven Moog
 //
 // This file is part of qFALL-math.
 //
@@ -16,6 +16,44 @@ use super::PolyOverZq;
 use crate::{error::MathError, integer::PolyOverZ, integer_mod_q::modulus::Modulus};
 use flint_sys::fmpz_mod_poly::{fmpz_mod_poly_init, fmpz_mod_poly_set_fmpz_poly};
 use std::{mem::MaybeUninit, str::FromStr};
+
+impl From<(&PolyOverZ, &Modulus)> for PolyOverZq {
+    /// Create a [`PolyOverZq`] from a [`PolyOverZ`] and [`Modulus`].
+    ///
+    /// Parameters:
+    /// - `poly_modulus_tuple`: A tuple of the polynomial and the modulus.
+    ///
+    /// Examples:
+    /// ``` rust
+    /// use qfall_math::integer_mod_q::{PolyOverZq, Modulus};
+    /// use qfall_math::integer::PolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let poly = PolyOverZ::from_str("4  0 1 102 3").unwrap();
+    /// let modulus = Modulus::from_str("100").unwrap();
+    ///
+    /// let mod_poly = PolyOverZq::from((&poly, &modulus));
+    ///
+    /// # let cmp_poly = PolyOverZq::from_str("4  0 1 2 3 mod 100").unwrap();
+    /// # assert_eq!(cmp_poly, mod_poly);
+    /// ```
+    fn from(poly_modulus_tuple: (&PolyOverZ, &Modulus)) -> Self {
+        let modulus = poly_modulus_tuple.1.clone();
+        let mut poly = MaybeUninit::uninit();
+        unsafe {
+            fmpz_mod_poly_init(poly.as_mut_ptr(), modulus.get_fmpz_mod_ctx_struct());
+            let mut poly = poly.assume_init();
+
+            fmpz_mod_poly_set_fmpz_poly(
+                &mut poly,
+                &poly_modulus_tuple.0.poly,
+                modulus.get_fmpz_mod_ctx_struct(),
+            );
+
+            PolyOverZq { poly, modulus }
+        }
+    }
+}
 
 impl FromStr for PolyOverZq {
     type Err = MathError;
@@ -67,17 +105,56 @@ impl FromStr for PolyOverZq {
         let poly_over_z = PolyOverZ::from_str(poly_s)?;
         let modulus = Modulus::from_str(modulus)?;
 
-        let mut poly = MaybeUninit::uninit();
-        unsafe {
-            fmpz_mod_poly_init(poly.as_mut_ptr(), modulus.get_fmpz_mod_ctx_struct());
-            let mut poly = poly.assume_init();
-            fmpz_mod_poly_set_fmpz_poly(
-                &mut poly,
-                &poly_over_z.poly,
-                modulus.get_fmpz_mod_ctx_struct(),
-            );
-            Ok(Self { poly, modulus })
-        }
+        Ok(Self::from((&poly_over_z, &modulus)))
+    }
+}
+
+#[cfg(test)]
+mod test_from_poly_z_modulus {
+    use crate::{
+        integer::{PolyOverZ, Z},
+        integer_mod_q::Modulus,
+    };
+
+    use super::PolyOverZq;
+    use std::str::FromStr;
+
+    /// Test conversion of a [`PolyOverZ`] with small coefficients and small
+    /// [`Modulus`] into a [`PolyOverZq`].
+    #[test]
+    fn working_small() {
+        let poly = PolyOverZ::from_str("4  0 1 -2 3").unwrap();
+        let modulus = Modulus::try_from(&Z::from(100)).unwrap();
+
+        let mod_poly = PolyOverZq::from((&poly, &modulus));
+
+        let cmp_poly = PolyOverZq::from_str("4  0 1 -2 3 mod 100").unwrap();
+        assert_eq!(cmp_poly, mod_poly);
+    }
+
+    /// Test conversion of a [`PolyOverZ`] with large coefficients and large
+    /// [`Modulus`] into a [`PolyOverZq`].
+    #[test]
+    fn working_large() {
+        let poly = PolyOverZ::from_str(&format!("4  {} {} -2 3", u64::MAX - 1, u64::MAX)).unwrap();
+        let modulus = Modulus::try_from(&Z::from(u64::MAX)).unwrap();
+
+        let mod_poly = PolyOverZq::from((&poly, &modulus));
+
+        let cmp_poly = PolyOverZq::from_str(&format!("4  -1 0 -2 3 mod {}", u64::MAX)).unwrap();
+        assert_eq!(cmp_poly, mod_poly);
+    }
+
+    /// Test that the coefficients are reduced properly after the conversion.
+    #[test]
+    fn reduce() {
+        let poly = PolyOverZ::from_str("4  100 101 -102 103").unwrap();
+        let modulus = Modulus::try_from(&Z::from(100)).unwrap();
+
+        let mod_poly = PolyOverZq::from((&poly, &modulus));
+
+        let cmp_poly = PolyOverZq::from_str("4  0 1 -2 3 mod 100").unwrap();
+        assert_eq!(cmp_poly, mod_poly);
     }
 }
 

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -23,8 +23,8 @@ impl From<(&PolyOverZ, &Modulus)> for PolyOverZq {
     /// Parameters:
     /// - `poly_modulus_tuple`: A tuple of the polynomial and the modulus.
     ///
-    /// Examples:
-    /// ``` rust
+    /// # Examples:
+    /// ```
     /// use qfall_math::integer_mod_q::{PolyOverZq, Modulus};
     /// use qfall_math::integer::PolyOverZ;
     /// use std::str::FromStr;


### PR DESCRIPTION
**Description**
Added PolyZq from a tuple (&PolyZ, &Modulus). 
I did not implement it for owned parameters, because It will not lead to a (significant) performance improvement. This is because flint uses a different struct type for PolyZ and PolyZq => copying is necessary anyway.

**Testing**
<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
    - [x] `cargo doc` does not generate any errors
  - [x] I have credited related sources if needed