### PR TITLE
CI Update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@ Please also include relevant motivation and context. List any dependencies that 
 
 This PR implements...
 - [ ] feature/ revision/ hotfix/ optimisation/ ...
+
 for/ of `Component`.
 
 <!--
@@ -34,5 +35,4 @@ Closes #(issue number)
     - [ ] The chosen implementation is not more complex than it has to be
   - [ ] My code should work as intended and no side effects occur (e.g. memory leaks)
   - [ ] The doc comments fit our style guide
-    - [ ] `cargo doc` does not generate any errors
   - [ ] I have credited related sources if needed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,4 @@
 name: Pipeline
-# consistency regarding formatting and idiomatic Rust
 
 on:
   push:
@@ -9,24 +8,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  update_build_test:
-    name: Update, Build, Test, and compute Test Coverage
+  full_pipeline:
+    name: Full Pipeline
     runs-on: ubuntu-latest
     
     steps:
       - uses: actions/checkout@v3
-      
-      # install action-rs toolchain 
-      # deprecated, but best tool for usage with clippy in PR context and only way to calculate test coverage
-      - uses: actions-rs/toolchain@v1
+
+      - name: Setup dtolnay/rust-toolchain 
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-          component: clippy, rustfmt
-      
-      # load cargo cache to reduce compilation time
-      - name: Set up cargo cache
+          components: clippy, rustfmt
+
+      # load project cache to reduce compilation time
+      - name: Setup project cache
         uses: actions/cache@v3
         continue-on-error: false
         with:
@@ -36,56 +32,45 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: main-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: main-${{ runner.os }}-cargo-
-      
+          key: release-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: release-${{ runner.os }}-cargo-
+
       - name: Set environment variables
         run: |
           echo "PROJECT_NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0] | [ .name ] | join("")')" >> $GITHUB_ENV
           echo "PROJECT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0] | [ .version ] | join("")')" >> $GITHUB_ENV
-      
-      - name: Update dependencies
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
 
-      # run tests, once normally, once to calculate code coverage
-      - name: Test
-        uses: actions-rs/cargo@v1
+      - name: Update dependencies
+        run: cargo update
+      - name: Build
+        run: cargo build --release
+
+      - name: Install cargo-tarpaulin
+        uses: baptiste0928/cargo-install@v2
         with:
-          command: test
-          args: --verbose
-      - name: Run tarpaulin to calculate code coverage
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.15.0'
-          args: '-- --test-threads 1'
-          out-type: Html
-      
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D warnings # escalate warnings s.t. pipeline fails
-      - name: Format
-        run:  cargo fmt --all -- --check
-      
-      # Cargo check for security issues
-      - name: Security audit
-        uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-        
+          crate: cargo-tarpaulin
+      - name: Calculate test coverage
+        run: cargo tarpaulin --out Html
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1
         with:
           name: ${{ env.PROJECT_NAME }}-code_coverage_report-v${{ env.PROJECT_VERSION }}
           path: tarpaulin-report.html
+
+      # Lints
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Format
+        run:  cargo fmt --all -- --check
+      
+      # Cargo check for security issues
+      - name: Install cargo-audit
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-audit
+      - name: Security audit
+        run: cargo audit
+
       - name: Archive release build
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,8 @@ jobs:
         run: cargo build --release
       - name: Generate docs
         run: cargo doc
+      - name: Run doc tests
+        run: cargo test --doc
 
       - name: Install cargo-tarpaulin
         uses: baptiste0928/cargo-install@v2
@@ -62,7 +64,7 @@ jobs:
           name: ${{ env.PROJECT_NAME }}-code_coverage_report-v${{ env.PROJECT_VERSION }}
           path: tarpaulin-report.html
 
-      # Lints
+      # Lints: Clippy and Fmt
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: Format

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,8 @@ jobs:
         run: cargo update
       - name: Build
         run: cargo build --release
+      - name: Generate docs
+        run: cargo doc
 
       - name: Install cargo-tarpaulin
         uses: baptiste0928/cargo-install@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,6 @@
+env:
+  RUSTDOCFLAGS: "-Dwarnings"
+
 name: Pipeline
 
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,3 +84,4 @@ jobs:
         with:
           name: ${{ env.PROJECT_NAME }}-release_build-v${{ env.PROJECT_VERSION }}
           path: target/release/${{ env.PROJECT_NAME }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,9 +71,14 @@ jobs:
       - name: Security audit
         run: cargo audit
 
+      # Check for outdated dependencies
+      - name: Install cargo-outdated
+        uses: dtolnay/install@cargo-outdated
+      - name: Outdated dependencies
+        run: cargo outdated --exit-code 1
+      
       - name: Archive release build
         uses: actions/upload-artifact@v1
         with:
           name: ${{ env.PROJECT_NAME }}-release_build-v${{ env.PROJECT_VERSION }}
           path: target/release/${{ env.PROJECT_NAME }}
-        

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,6 +43,8 @@ jobs:
         run: cargo update
       - name: Build
         run: cargo build
+      - name: Generate docs
+        run: cargo doc
       
       - name: Install cargo-tarpaulin
         uses: baptiste0928/cargo-install@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,24 +7,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  update_build_test:
-    name: Update, Build, Test, and compute Test Coverage
+  pipeline:
+    name: Pipeline - code coverage + dependency check
     runs-on: ubuntu-latest
     
     steps:
       - uses: actions/checkout@v3
 
-      # install action-rs toolchain 
-      # deprecated, but best tool for usage with clippy in PR context and only way to calculate test coverage
-      - uses: actions-rs/toolchain@v1
+      - name: Setup dtolnay/rust-toolchain 
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-          component: clippy, rustfmt
-      
-      # load cargo cache to reduce compilation time
-      - name: Set up cargo cache
+          components: clippy, rustfmt
+
+      # load project cache to reduce compilation time
+      - name: Setup project cache
         uses: actions/cache@v3
         continue-on-error: false
         with:
@@ -41,45 +38,34 @@ jobs:
         run: |
           echo "PROJECT_NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0] | [ .name ] | join("")')" >> $GITHUB_ENV
           echo "PROJECT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0] | [ .version ] | join("")')" >> $GITHUB_ENV
-        
-      - name: Update dependencies
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
 
-      # run tests, once normally, once to calculate code coverage
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
-      - name: Run tarpaulin to calculate code coverage
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.15.0'
-          args: '-- --test-threads 1'
-          out-type: Html
+      - name: Update dependencies
+        run: cargo update
+      - name: Build
+        run: cargo build
       
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1
+      - name: Install cargo-tarpaulin
+        uses: baptiste0928/cargo-install@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D warnings # escalate warnings s.t. pipeline fails
-      - name: Format
-        run:  cargo fmt --all -- --check
-      
-      # Cargo check for security issues
-      - name: Security audit
-        uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-        
+          crate: cargo-tarpaulin
+      - name: Calculate test coverage
+        run: cargo tarpaulin --out Html
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1
         with:
           name: ${{ env.PROJECT_NAME }}-code_coverage_report-v${{ env.PROJECT_VERSION }}
           path: tarpaulin-report.html
+
+      # Lints
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Format
+        run:  cargo fmt --all -- --check
+      
+      # Cargo check for security issues
+      - name: Install cargo-audit
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-audit
+      - name: Security audit
+        run: cargo audit

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -61,7 +61,7 @@ jobs:
           name: ${{ env.PROJECT_NAME }}-code_coverage_report-v${{ env.PROJECT_VERSION }}
           path: tarpaulin-report.html
 
-      # Lints
+      # Lints: Clippy and Fmt
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: Format

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -77,3 +77,4 @@ jobs:
         uses: dtolnay/install@cargo-outdated
       - name: Outdated dependencies
         run: cargo outdated --exit-code 1
+

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,3 +1,6 @@
+env:
+  RUSTDOCFLAGS: "-Dwarnings"
+
 name: Pipeline
 # consistency regarding formatting and idiomatic Rust
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,3 +69,9 @@ jobs:
           crate: cargo-audit
       - name: Security audit
         run: cargo audit
+
+      # Check for outdated dependencies
+      - name: Install cargo-outdated
+        uses: dtolnay/install@cargo-outdated
+      - name: Outdated dependencies
+        run: cargo outdated --exit-code 1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: Pipeline - test and lints
+name: Pipeline
 # consistency regarding formatting and idiomatic Rust
 
 on:
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test_and_lint_pipeline:
+  pipeline:
     name: Pipeline - test and lints
     runs-on: ubuntu-latest
     
@@ -41,6 +41,8 @@ jobs:
         run: cargo update
       - name: Build
         run: cargo build
+      - name: Generate docs
+        run: cargo doc
       
       - name: Test
         run: test --verbose

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: Pipeline
+name: Pipeline - test and lints
 # consistency regarding formatting and idiomatic Rust
 
 on:
@@ -10,24 +10,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  update_build_test:
-    name: Update, Build and Test
+  test_and_lint_pipeline:
+    name: Pipeline - test and lints
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      # install action-rs toolchain 
-      # deprecated, but best tool for usage with clippy in PR context and only way to calculate test coverage
-      - uses: actions-rs/toolchain@v1
+      - name: Setup dtolnay/rust-toolchain 
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
           components: clippy, rustfmt
 
-      # load cargo cache to reduce compilation time
-      - name: Set up cargo cache
+      # load project cache to reduce compilation time
+      - name: Setup project cache
         uses: actions/cache@v3
         continue-on-error: false
         with:
@@ -41,31 +38,15 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Update dependencies
-        uses: actions-rs/cargo@v1
-        with: 
-          command: update
+        run: cargo update
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: test --verbose
 
       # Lints
       - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D warnings # escalate warnings s.t. pipeline fails
+        run: cargo clippy -- -D warnings
       - name: Format
         run:  cargo fmt --all -- --check
-      
-      # Cargo check for security issues
-      - name: Security audit
-        uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,3 +1,6 @@
+env:
+  RUSTDOCFLAGS: "-Dwarnings"
+
 name: Pipeline
 # consistency regarding formatting and idiomatic Rust
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -52,3 +52,4 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Format
         run:  cargo fmt --all -- --check
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Test
         run: test --verbose
 
-      # Lints
+      # Lints: Clippy and Fmt
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: Format


### PR DESCRIPTION
This PR updates the CI by the following points:
- [x] Update toolchain to [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), which is maintained and not deprecated like [`action-rs`](https://github.com/actions-rs)
  - [x] This also solves the problem to update the `cargo-tarpaulin` version to correctly compute the code coverage
- [x] Add [`cargo-outdated`](https://crates.io/crates/cargo-outdated) to CI runs of `main` and PRs to check whether any dependencies of the project are outdated
- [x] Add `cargo doc` to check for errors in documentation generation