### PR TITLE
Zq `get_value` and `get_mod`

### DIFF
--- a/src/integer_mod_q/z_q/properties.rs
+++ b/src/integer_mod_q/z_q/properties.rs
@@ -9,7 +9,7 @@
 //! This module includes functionality about properties of [`Zq`] instances.
 
 use super::Zq;
-use crate::traits::Pow;
+use crate::{integer::Z, integer_mod_q::Modulus, traits::Pow};
 
 impl Zq {
     /// Returns the inverse of `self` as a fresh [`Zq`] instance.
@@ -26,6 +26,39 @@ impl Zq {
     /// ```
     pub fn inverse(&self) -> Option<Zq> {
         self.pow(-1).ok()
+    }
+
+    /// Returns the [`Z`] value of the [`Zq`] element.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::Zq;
+    /// use qfall_math::integer::Z;
+    /// let zq_value = Zq::try_from((4, 7)).unwrap();
+    ///
+    /// let z_value = zq_value.get_value();
+    ///
+    /// assert_eq!(Z::from(4), z_value);
+    /// ```
+    pub fn get_value(&self) -> Z {
+        self.value.clone()
+    }
+
+    /// Returns the [`Modulus`] of the [`Zq`] element.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{Zq, Modulus};
+    /// use std::str::FromStr;
+    /// let value = Zq::try_from((4, 7)).unwrap();
+    /// let cmp = Modulus::from_str("7").unwrap();
+    ///
+    /// let modulus = value.get_mod();
+    ///
+    /// assert_eq!(cmp, modulus);
+    /// ```
+    pub fn get_mod(&self) -> Modulus {
+        self.modulus.clone()
     }
 }
 


### PR DESCRIPTION
**Description**

This PR implements...
- [x] get_value
- [x] get_mod

for `Zq` to comfortably gather the `Z` and `Modulus` value of the given instance.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
  - Nothing else is needed for these very simple functions
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] The doc comments fit our style guide
    - [x] `cargo doc` does not generate any errors