### PR TITLE
Add get_denominator and get_numerator for Q

### DIFF
--- a/src/rational/q.rs
+++ b/src/rational/q.rs
@@ -17,6 +17,7 @@ mod default;
 mod distance;
 mod exp;
 mod from;
+mod get;
 mod ownership;
 mod properties;
 mod rounding;

--- a/src/rational/q/get.rs
+++ b/src/rational/q/get.rs
@@ -6,7 +6,7 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! Get elements of Q like the numerator and denominator.
+//! Get elements of [`Q`] like the numerator and denominator.
 
 use super::Q;
 use crate::integer::Z;
@@ -25,7 +25,6 @@ impl Q {
     /// let den = value.get_denominator();
     ///
     /// assert_eq!(den, Z::from(10));
-    ///
     /// ```
     pub fn get_denominator(&self) -> Z {
         let mut result = Z::default();
@@ -45,7 +44,6 @@ impl Q {
     /// let num = value.get_numerator();
     ///
     /// assert_eq!(num, Z::from(1));
-    ///
     /// ```
     pub fn get_numerator(&self) -> Z {
         let mut result = Z::default();

--- a/src/rational/q/get.rs
+++ b/src/rational/q/get.rs
@@ -15,7 +15,7 @@ use flint_sys::fmpz::fmpz_set;
 impl Q {
     /// Returns the denominator
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use qfall_math::rational::Q;
     /// use qfall_math::integer::Z;
@@ -35,7 +35,7 @@ impl Q {
 
     /// Returns the numerator
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use qfall_math::rational::Q;
     /// use qfall_math::integer::Z;

--- a/src/rational/q/get.rs
+++ b/src/rational/q/get.rs
@@ -56,6 +56,7 @@ impl Q {
 mod test_get_denominator {
     use crate::{integer::Z, rational::Q};
 
+    /// get a small denominator
     #[test]
     fn get_small() {
         let value = Q::try_from((&2, &20)).unwrap();
@@ -63,6 +64,7 @@ mod test_get_denominator {
         assert_eq!(den, Z::from(10));
     }
 
+    /// get a large denominator (uses FLINT's pointer representation)
     #[test]
     fn get_large() {
         let value = Q::try_from((&1, &i64::MAX)).unwrap();
@@ -75,6 +77,7 @@ mod test_get_denominator {
 mod test_get_numerator {
     use crate::{integer::Z, rational::Q};
 
+    /// get a small numerator
     #[test]
     fn get_small() {
         let value = Q::try_from((&2, &20)).unwrap();
@@ -82,6 +85,7 @@ mod test_get_numerator {
         assert_eq!(num, Z::from(1));
     }
 
+    /// get a large numerator (uses FLINT's pointer representation)
     #[test]
     fn get_large() {
         let value = Q::try_from((&i64::MAX, &1)).unwrap();

--- a/src/rational/q/get.rs
+++ b/src/rational/q/get.rs
@@ -1,0 +1,93 @@
+// Copyright © 2023 Sven Moog
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Get elements of Q like the numerator and denominator.
+
+use super::Q;
+use crate::integer::Z;
+use flint_sys::fmpz::fmpz_set;
+
+impl Q {
+    /// Returns the denominator
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::rational::Q;
+    /// use qfall_math::integer::Z;
+    ///
+    /// let value = Q::try_from((&2,&20)).unwrap();
+    ///
+    /// let den = value.get_denominator();
+    ///
+    /// assert_eq!(den, Z::from(10));
+    ///
+    /// ```
+    pub fn get_denominator(&self) -> Z {
+        let mut result = Z::default();
+        unsafe { fmpz_set(&mut result.value, &self.value.den) };
+        result
+    }
+
+    /// Returns the numerator
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::rational::Q;
+    /// use qfall_math::integer::Z;
+    ///
+    /// let value = Q::try_from((&2,&20)).unwrap();
+    ///
+    /// let num = value.get_numerator();
+    ///
+    /// assert_eq!(num, Z::from(1));
+    ///
+    /// ```
+    pub fn get_numerator(&self) -> Z {
+        let mut result = Z::default();
+        unsafe { fmpz_set(&mut result.value, &self.value.num) };
+        result
+    }
+}
+
+#[cfg(test)]
+mod test_get_denominator {
+    use crate::{integer::Z, rational::Q};
+
+    #[test]
+    fn get_small() {
+        let value = Q::try_from((&2, &20)).unwrap();
+        let den = value.get_denominator();
+        assert_eq!(den, Z::from(10));
+    }
+
+    #[test]
+    fn get_large() {
+        let value = Q::try_from((&1, &i64::MAX)).unwrap();
+        let den = value.get_denominator();
+        assert_eq!(den, Z::from(i64::MAX));
+    }
+}
+
+#[cfg(test)]
+mod test_get_numerator {
+    use crate::{integer::Z, rational::Q};
+
+    #[test]
+    fn get_small() {
+        let value = Q::try_from((&2, &20)).unwrap();
+        let num = value.get_numerator();
+        assert_eq!(num, Z::from(1));
+    }
+
+    #[test]
+    fn get_large() {
+        let value = Q::try_from((&i64::MAX, &1)).unwrap();
+        let num = value.get_numerator();
+        assert_eq!(num, Z::from(i64::MAX));
+    }
+}


### PR DESCRIPTION
**Description**

This PR implements
- [x] `get_denominator` and `get_numerator` for `Q`

**Testing**

- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
    - [x] `cargo doc` does not generate any errors
  - [x] I have credited related sources if needed
