### PR TITLE
Change comments to remove doc warnings

### DIFF
--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -97,7 +97,7 @@ impl MatPolyOverZ {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix) or
     /// [`OutOfBounds`](MathError::OutOfBounds) if the provided number of rows and columns
-    /// are not suited to create a matrix. For further information see [`MatZ::new`].
+    /// are not suited to create a matrix. For further information see [`MatZ::new`](crate::integer::MatZ::new).
     pub fn identity(
         num_rows: impl TryInto<i64> + Display + Copy,
         num_cols: impl TryInto<i64> + Display + Copy,

--- a/src/integer/mat_z/inverse.rs
+++ b/src/integer/mat_z/inverse.rs
@@ -19,6 +19,7 @@ use flint_sys::fmpq_mat::fmpq_mat_inv;
 impl MatZ {
     /// Returns the inverse of the matrix if it exists (is square and
     /// has a determinant unequal to zero).
+    /// Otherwise, return [`None`].
     ///
     /// # Examples
     /// ```
@@ -29,12 +30,6 @@ impl MatZ {
     /// let mut matrix = MatZ::from_str("[[1,2],[3,4]]").unwrap();
     /// let matrix_invert = matrix.inverse().unwrap();
     /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows and columns is not equal.
-    /// - Returns a [`MathError`] of type [`NotInvertible`](MathError::NotInvertible)
-    /// if the determinant of the matrix is `0`.
     pub fn inverse(&self) -> Option<MatQ> {
         // check if matrix is square and compute determinant to check whether
         // the matrix is invertible or not


### PR DESCRIPTION
**Description**

Change comments to remove doc warnings

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
  - [x] The doc comments fit our style guide
    - [x] `cargo doc` does not generate any errors
