### PR TITLE
Sub between types

### DIFF
--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -9,11 +9,14 @@
 //! Implementation of the [`Add`] trait for [`Z`] values.
 
 use super::super::Z;
-use crate::macros::arithmetics::{
-    arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
-    arithmetic_trait_mixed_borrowed_owned,
+use crate::{
+    macros::arithmetics::{
+        arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
+    },
+    rational::Q,
 };
-use flint_sys::fmpz::fmpz_add;
+use flint_sys::{fmpq::fmpq_add_fmpz, fmpz::fmpz_add};
 use std::ops::Add;
 
 impl Add for &Z {
@@ -50,6 +53,43 @@ impl Add for &Z {
 arithmetic_trait_borrowed_to_owned!(Add, add, Z, Z, Z);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Z, Z, Z);
 arithmetic_between_types!(Add, add, Z, Z, i64 i32 i16 i8 u64 u32 u16 u8);
+
+impl Add<&Q> for &Z {
+    type Output = Q;
+
+    /// Implements the [`Add`] trait for [`Z`] and [`Q`] values.
+    /// [`Add`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both numbers as a [`Q`].
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::rational::Q;
+    /// use qfall_math::integer::Z;
+    /// use std::str::FromStr;
+    ///
+    /// let a: Z = Z::from_str("-42").unwrap();
+    /// let b: Q = Q::from_str("42/19").unwrap();
+    ///
+    /// let c: Q = &a + &b;
+    /// let d: Q = a + b;
+    /// let e: Q = &c + d;
+    /// let f: Q = c + &e;
+    /// ```
+    fn add(self, other: &Q) -> Self::Output {
+        let mut out = Q::default();
+        unsafe {
+            fmpq_add_fmpz(&mut out.value, &other.value, &self.value);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Add, add, Z, Q, Q);
+arithmetic_trait_mixed_borrowed_owned!(Add, add, Z, Q, Q);
 
 #[cfg(test)]
 mod test_add_between_types {
@@ -141,6 +181,70 @@ mod test_add_between_types {
         let _: Z = g + Z::from_str("42").unwrap();
         let _: Z = h + Z::from_str("42").unwrap();
         let _: Z = i + Z::from_str("42").unwrap();
+    }
+}
+
+#[cfg(test)]
+mod test_add_between_z_and_q {
+
+    use super::Z;
+    use crate::rational::Q;
+    use std::str::FromStr;
+
+    /// testing addition for [`Z`] and [`Q`]
+    #[test]
+    fn add() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = a + b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for both borrowed [`Z`] and [`Q`]
+    #[test]
+    fn add_borrow() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = &a + &b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for borrowed [`Z`] and [`Q`]
+    #[test]
+    fn add_first_borrowed() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = &a + b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for [`Z`] and borrowed [`Q`]
+    #[test]
+    fn add_second_borrowed() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = a + &b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for big numbers
+    #[test]
+    fn add_large_numbers() {
+        let a: Z = Z::from(u64::MAX);
+        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let c: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
+        let d: Q = &a + b;
+        let e: Q = a + c;
+        assert_eq!(
+            d,
+            Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
+                + Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
+        );
+        assert_eq!(
+            e,
+            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
+                + Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
+        );
     }
 }
 

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -81,8 +81,8 @@ impl Add<&Q> for &Z {
     ///
     /// let c: Q = &a + &b;
     /// let d: Q = a + b;
-    /// let e: Q = &c + d;
-    /// let f: Q = c + &e;
+    /// let e: Q = &Z::from(42) + d;
+    /// let f: Q = Z::from(42) + &e;
     /// ```
     fn add(self, other: &Q) -> Self::Output {
         let mut out = Q::default();
@@ -117,8 +117,8 @@ impl Add<&Zq> for &Z {
     ///
     /// let c: Zq = &a + &b;
     /// let d: Zq = a + b;
-    /// let e: Zq = &c + d;
-    /// let f: Zq = c + &e;
+    /// let e: Zq = &Z::from(42) + d;
+    /// let f: Zq = Z::from(42) + &e;
     /// ```
     fn add(self, other: &Zq) -> Self::Output {
         let mut out = fmpz(0);

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -9,11 +9,19 @@
 //! Implementation of the [`Sub`] trait for [`Z`] values.
 
 use super::super::Z;
-use crate::macros::arithmetics::{
-    arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
-    arithmetic_trait_mixed_borrowed_owned,
+use crate::{
+    integer_mod_q::Zq,
+    macros::arithmetics::{
+        arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
+    },
+    rational::Q,
 };
-use flint_sys::fmpz::fmpz_sub;
+use flint_sys::{
+    fmpq::{fmpq, fmpq_set_fmpz_frac, fmpq_sub},
+    fmpz::{fmpz, fmpz_sub},
+    fmpz_mod::fmpz_mod_sub_fmpz,
+};
 use std::ops::Sub;
 
 impl Sub for &Z {
@@ -50,6 +58,86 @@ impl Sub for &Z {
 arithmetic_trait_borrowed_to_owned!(Sub, sub, Z, Z, Z);
 arithmetic_trait_mixed_borrowed_owned!(Sub, sub, Z, Z, Z);
 arithmetic_between_types!(Sub, sub, Z, Z, i64 i32 i16 i8 u64 u32 u16 u8);
+
+impl Sub<&Q> for &Z {
+    type Output = Q;
+
+    /// Implements the [`Sub`] trait for [`Z`] and [`Q`] values.
+    /// [`Sub`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to subtract from `self`
+    ///
+    /// Returns the result of the subtraction as a [`Q`].
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::rational::Q;
+    /// use qfall_math::integer::Z;
+    /// use std::str::FromStr;
+    ///
+    /// let a: Z = Z::from_str("-42").unwrap();
+    /// let b: Q = Q::from_str("42/19").unwrap();
+    ///
+    /// let c: Q = &a - &b;
+    /// let d: Q = a - b;
+    /// let e: Q = &c - d;
+    /// let f: Q = c - &e;
+    /// ```
+    fn sub(self, other: &Q) -> Self::Output {
+        let mut out = Q::default();
+        let mut fmpq1 = fmpq::default();
+        unsafe { fmpq_set_fmpz_frac(&mut fmpq1, &self.value, &fmpz(1)) }
+        unsafe {
+            fmpq_sub(&mut out.value, &fmpq1, &other.value);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Sub, sub, Z, Q, Q);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, Z, Q, Q);
+
+impl Sub<&Zq> for &Z {
+    type Output = Zq;
+    /// Implements the [`Sub`] trait for [`Z`] and [`Zq`] values.
+    /// [`Sub`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to subtract from `self`
+    ///
+    /// Returns the result of subtraction of both numbers as a [`Zq`].
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::integer_mod_q::Zq;
+    /// use qfall_math::integer::Z;
+    /// use std::str::FromStr;
+    ///
+    /// let a: Z = Z::from(42);
+    /// let b: Zq = Zq::from_str("42 mod 19").unwrap();
+    ///
+    /// let c: Zq = &a - &b;
+    /// let d: Zq = a - b;
+    /// let e: Zq = &Z::from(42) - d;
+    /// let f: Zq = Z::from(42) - &e;
+    /// ```
+    fn sub(self, other: &Zq) -> Self::Output {
+        let mut out = fmpz(0);
+        unsafe {
+            fmpz_mod_sub_fmpz(
+                &mut out,
+                &self.value,
+                &other.value.value,
+                &*other.modulus.modulus,
+            );
+        }
+        Zq::from_z_modulus(&Z::from_fmpz(&out), &other.modulus)
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Sub, sub, Z, Zq, Zq);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, Z, Zq, Zq);
 
 #[cfg(test)]
 mod test_sub_between_types {
@@ -197,5 +285,130 @@ mod test_sub {
         assert_eq!(d, Z::from(i64::MAX));
         assert_eq!(e, Z::from(i64::MIN + 1));
         assert_eq!(f, Z::from(i64::MAX - 738201034));
+    }
+}
+
+#[cfg(test)]
+mod test_sub_between_z_and_q {
+
+    use super::Z;
+    use crate::rational::Q;
+    use std::str::FromStr;
+
+    /// testing subtraction for [`Z`] and [`Q`]
+    #[test]
+    fn sub() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = a - b;
+        assert_eq!(c, Q::from_str("23/7").unwrap());
+    }
+
+    /// testing subtraction for both borrowed [`Z`] and [`Q`]
+    #[test]
+    fn sub_borrow() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = &a - &b;
+        assert_eq!(c, Q::from_str("23/7").unwrap());
+    }
+
+    /// testing subtraction for borrowed [`Z`] and [`Q`]
+    #[test]
+    fn sub_first_borrowed() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = &a - b;
+        assert_eq!(c, Q::from_str("23/7").unwrap());
+    }
+
+    /// testing subtraction for [`Z`] and borrowed [`Q`]
+    #[test]
+    fn sub_second_borrowed() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = a - &b;
+        assert_eq!(c, Q::from_str("23/7").unwrap());
+    }
+
+    /// testing subtraction for big numbers
+    #[test]
+    fn sub_large_numbers() {
+        let a: Z = Z::from(u64::MAX);
+        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let c: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
+        let d: Q = &a - b;
+        let e: Q = a - c;
+
+        assert_eq!(
+            d,
+            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
+                - Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
+        );
+        assert_eq!(
+            e,
+            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
+                - Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_sub_between_z_and_zq {
+
+    use super::Z;
+    use crate::integer_mod_q::Zq;
+
+    /// testing subtraction for [`Z`] and [`Zq`]
+    #[test]
+    fn sub() {
+        let a: Z = Z::from(9);
+        let b: Zq = Zq::try_from((10, 11)).unwrap();
+        let c: Zq = a - b;
+        assert_eq!(c, Zq::try_from((10, 11)).unwrap());
+    }
+
+    /// testing subtraction for both borrowed [`Z`] and [`Zq`]
+    #[test]
+    fn sub_borrow() {
+        let a: Z = Z::from(9);
+        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let c: Zq = a - b;
+        assert_eq!(c, Zq::try_from((5, 11)).unwrap());
+    }
+
+    /// testing subtraction for borrowed [`Z`] and [`Zq`]
+    #[test]
+    fn sub_first_borrowed() {
+        let a: Z = Z::from(9);
+        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let c: Zq = a - b;
+        assert_eq!(c, Zq::try_from((5, 11)).unwrap());
+    }
+
+    /// testing subtraction for [`Z`] and borrowed [`Zq`]
+    #[test]
+    fn sub_second_borrowed() {
+        let a: Z = Z::from(9);
+        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let c: Zq = a - b;
+        assert_eq!(c, Zq::try_from((5, 11)).unwrap());
+    }
+
+    /// testing subtraction for big numbers
+    #[test]
+    fn sub_large_numbers() {
+        let a: Z = Z::from(u64::MAX);
+        let b: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
+        let c: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+
+        let d: Zq = &a - b;
+        let e: Zq = a - c;
+
+        assert_eq!(
+            d,
+            Zq::try_from(((u64::MAX - 1) / 2 + 1, u64::MAX - 58)).unwrap()
+        );
+        assert_eq!(e, Zq::try_from((2, i64::MAX)).unwrap());
     }
 }

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -43,8 +43,8 @@ impl Sub for &Z {
     ///
     /// let c: Z = &a - &b;
     /// let d: Z = a - b;
-    /// let e: Z = &c - d;
-    /// let f: Z = c - &e;
+    /// let e: Z = &Z::from(42) - d;
+    /// let f: Z = Z::from(42) - &e;
     /// ```
     fn sub(self, other: Self) -> Self::Output {
         let mut out = Z::default();
@@ -81,8 +81,8 @@ impl Sub<&Q> for &Z {
     ///
     /// let c: Q = &a - &b;
     /// let d: Q = a - b;
-    /// let e: Q = &c - d;
-    /// let f: Q = c - &e;
+    /// let e: Q = &Z::from(42) - d;
+    /// let f: Q = Z::from(42) - &e;
     /// ```
     fn sub(self, other: &Q) -> Self::Output {
         let mut out = Q::default();

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -122,8 +122,8 @@ impl Add<&Z> for &Zq {
     ///
     /// let c: Zq = &a + &b;
     /// let d: Zq = a + b;
-    /// let e: Zq = &c + d;
-    /// let f: Zq = c + &e;
+    /// let e: Zq = &c + Z::from(42);
+    /// let f: Zq = c + &Z::from(42);
     /// ```
     fn add(self, other: &Z) -> Self::Output {
         let mut out = fmpz(0);

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -13,7 +13,8 @@ use crate::{
     error::MathError,
     integer::Z,
     macros::arithmetics::{
-        arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+        arithmetic_between_types_zq, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
     },
 };
 use flint_sys::{
@@ -140,6 +141,8 @@ impl Add<&Z> for &Zq {
 arithmetic_trait_borrowed_to_owned!(Add, add, Zq, Z, Zq);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Zq, Z, Zq);
 
+arithmetic_between_types_zq!(Add, add, Zq, i64 i32 i16 i8 u64 u32 u16 u8);
+
 #[cfg(test)]
 mod test_add {
 
@@ -211,15 +214,13 @@ mod test_add {
     }
 }
 
-
 #[cfg(test)]
-mod test_add_between_z_and_zq {
+mod test_add_between_zq_and_z {
 
     use super::Z;
     use crate::integer_mod_q::Zq;
-    use std::str::FromStr;
 
-    /// testing addition for [`Q`] and [`Z`]
+    /// testing addition for [`Zq`] and [`Z`]
     #[test]
     fn add() {
         let a: Zq = Zq::try_from((4, 11)).unwrap();
@@ -228,50 +229,137 @@ mod test_add_between_z_and_zq {
         assert_eq!(c, Zq::try_from((2, 11)).unwrap());
     }
 
-    /// testing addition for both borrowed [`Q`] and [`Z`]
+    /// testing addition for both borrowed [`Zq`] and [`Z`]
     #[test]
     fn add_borrow() {
-        let a: Q = Q::from_str("5/7").unwrap();
-        let b: Z = Z::from(4);
-        let c: Q = &a + &b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Z = Z::from(9);
+        let c: Zq = a + b;
+        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
     }
 
-    /// testing addition for borrowed [`Q`] and [`Z`]
+    /// testing addition for borrowed [`Zq`] and [`Z`]
     #[test]
     fn add_first_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
-        let b: Z = Z::from(4);
-        let c: Q = &a + b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Z = Z::from(9);
+        let c: Zq = a + b;
+        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
     }
 
-    /// testing addition for [`Q`] and borrowed [`Z`]
+    /// testing addition for [`Zq`] and borrowed [`Z`]
     #[test]
     fn add_second_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
-        let b: Z = Z::from(4);
-        let c: Q = a + &b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Z = Z::from(9);
+        let c: Zq = a + b;
+        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
     }
 
     /// testing addition for big numbers
     #[test]
     fn add_large_numbers() {
-        let a: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
-        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let a: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
+        let b: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
         let c: Z = Z::from(u64::MAX);
-        let d: Q = a + &c;
-        let e: Q = b + c;
+        let d: Zq = a + &c;
+        let e: Zq = b + c;
         assert_eq!(
             d,
-            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-                + Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
+            Zq::try_from(((u64::MAX - 1) / 2 + 58, u64::MAX - 58)).unwrap()
         );
-        assert_eq!(
-            e,
-            Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
-                + Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-        );
+        assert_eq!(e, Zq::try_from((0, i64::MAX)).unwrap());
+    }
+}
+
+#[cfg(test)]
+mod test_add_between_types {
+
+    use crate::integer_mod_q::Zq;
+
+    /// testing addition between different types
+    #[test]
+    #[allow(clippy::op_ref)]
+    fn add() {
+        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: u64 = 1;
+        let c: u32 = 1;
+        let d: u16 = 1;
+        let e: u8 = 1;
+        let f: i64 = 1;
+        let g: i32 = 1;
+        let h: i16 = 1;
+        let i: i8 = 1;
+        let _: Zq = &a + &b;
+        let _: Zq = &a + &c;
+        let _: Zq = &a + &d;
+        let _: Zq = &a + &e;
+        let _: Zq = &a + &f;
+        let _: Zq = &a + &g;
+        let _: Zq = &a + &h;
+        let _: Zq = &a + &i;
+
+        let _: Zq = &b + &a;
+        let _: Zq = &c + &a;
+        let _: Zq = &d + &a;
+        let _: Zq = &e + &a;
+        let _: Zq = &f + &a;
+        let _: Zq = &g + &a;
+        let _: Zq = &h + &a;
+        let _: Zq = &i + &a;
+
+        let _: Zq = &a + b;
+        let _: Zq = &a + c;
+        let _: Zq = &a + d;
+        let _: Zq = &a + e;
+        let _: Zq = &a + f;
+        let _: Zq = &a + g;
+        let _: Zq = &a + h;
+        let _: Zq = &a + i;
+
+        let _: Zq = &b + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &c + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &d + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &e + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &f + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &g + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &h + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &i + Zq::try_from((4, 11)).unwrap();
+
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + &b;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + &c;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + &d;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + &e;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + &f;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + &g;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + &h;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + &i;
+
+        let _: Zq = b + &a;
+        let _: Zq = c + &a;
+        let _: Zq = d + &a;
+        let _: Zq = e + &a;
+        let _: Zq = f + &a;
+        let _: Zq = g + &a;
+        let _: Zq = h + &a;
+        let _: Zq = i + &a;
+
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + b;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + c;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + d;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + e;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + f;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + g;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + h;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() + i;
+
+        let _: Zq = b + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = c + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = d + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = e + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = f + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = g + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = h + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = i + Zq::try_from((4, 11)).unwrap();
     }
 }

--- a/src/integer_mod_q/z_q/arithmetic/sub.rs
+++ b/src/integer_mod_q/z_q/arithmetic/sub.rs
@@ -13,10 +13,15 @@ use crate::{
     error::MathError,
     integer::Z,
     macros::arithmetics::{
-        arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+        arithmetic_between_types_zq, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
     },
+    rational::Q,
 };
-use flint_sys::fmpz_mod::fmpz_mod_sub;
+use flint_sys::{
+    fmpz::fmpz,
+    fmpz_mod::{fmpz_mod_sub, fmpz_mod_sub_fmpz},
+};
 use std::ops::Sub;
 
 impl Sub for &Zq {
@@ -94,6 +99,82 @@ impl Zq {
 
 arithmetic_trait_borrowed_to_owned!(Sub, sub, Zq, Zq, Zq);
 arithmetic_trait_mixed_borrowed_owned!(Sub, sub, Zq, Zq, Zq);
+arithmetic_between_types_zq!(Sub, sub, Zq, i64 i32 i16 i8 u64 u32 u16 u8);
+
+impl Sub<&Z> for &Zq {
+    type Output = Zq;
+
+    /// Implements the [`Sub`] trait for [`Zq`] and [`Z`] values.
+    /// [`Sub`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to subtract from `self`
+    ///
+    /// Returns the result of the subtraction of both numbers as a [`Zq`].
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::integer_mod_q::Zq;
+    /// use qfall_math::integer::Z;
+    /// use std::str::FromStr;
+    ///
+    /// let a: Zq = Zq::from_str("42 mod 19").unwrap();
+    /// let b: Z = Z::from(42);
+    ///
+    /// let c: Zq = &a - &b;
+    /// let d: Zq = a - b;
+    /// let e: Zq = &c - Z::from(42);
+    /// let f: Zq = c - &Z::from(42);
+    /// ```
+    fn sub(self, other: &Z) -> Self::Output {
+        let mut out = fmpz(0);
+        unsafe {
+            fmpz_mod_sub_fmpz(
+                &mut out,
+                &self.value.value,
+                &other.value,
+                &*self.modulus.modulus,
+            );
+        }
+        Zq::from_z_modulus(&Z::from_fmpz(&out), &self.modulus)
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Sub, sub, Zq, Z, Zq);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, Zq, Z, Zq);
+
+impl Sub<&Q> for &Zq {
+    type Output = Q;
+
+    /// Implements the [`Sub`] trait for [`Zq`] and [`Q`] values.
+    /// [`Sub`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to subtract from `self`
+    ///
+    /// Returns the result of subtraction of both numbers as a [`Q`].
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::rational::Q;
+    /// use qfall_math::integer_mod_q::Zq;
+    /// use std::str::FromStr;
+    ///
+    /// let a: Zq = Zq::from_str("42 mod 11").unwrap();
+    /// let b: Q = Q::from_str("42/19").unwrap();
+    ///
+    /// let c: Q = &a - &b;
+    /// let d: Q = a - b;
+    /// let e: Q = &Zq::from_str("42 mod 11").unwrap() - d;
+    /// let f: Q = Zq::from_str("42 mod 11").unwrap() - &e;
+    /// ```
+    fn sub(self, other: &Q) -> Self::Output {
+        Z::from(self.clone()) - other // todo do it more efficient -> later
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Sub, sub, Zq, Q, Q);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, Zq, Q, Q);
 
 #[cfg(test)]
 mod test_sub {
@@ -163,5 +244,220 @@ mod test_sub {
         let a: Zq = Zq::try_from((4, 11)).unwrap();
         let b: Zq = Zq::try_from((1, 3)).unwrap();
         assert!(&a.sub_safe(&b).is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_sub_between_z_and_zq {
+
+    use super::Z;
+    use crate::integer_mod_q::Zq;
+
+    /// testing subtraction for [`Q`] and [`Z`]
+    #[test]
+    fn sub() {
+        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Z = Z::from(9);
+        let c: Zq = a - b;
+        assert_eq!(c, Zq::try_from((6, 11)).unwrap());
+    }
+
+    /// testing subtraction for both borrowed [`Q`] and [`Z`]
+    #[test]
+    fn sub_borrow() {
+        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Z = Z::from(9);
+        let c: Zq = &a - &b;
+        assert_eq!(c, Zq::try_from((6, 11)).unwrap());
+    }
+
+    /// testing subtraction for borrowed [`Q`] and [`Z`]
+    #[test]
+    fn sub_first_borrowed() {
+        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Z = Z::from(9);
+        let c: Zq = &a - b;
+        assert_eq!(c, Zq::try_from((6, 11)).unwrap());
+    }
+
+    /// testing subtraction for [`Q`] and borrowed [`Z`]
+    #[test]
+    fn sub_second_borrowed() {
+        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Z = Z::from(9);
+        let c: Zq = a - &b;
+        assert_eq!(c, Zq::try_from((6, 11)).unwrap());
+    }
+
+    /// testing subtraction for big numbers
+    #[test]
+    fn sub_large_numbers() {
+        let a: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
+        let b: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let c: Z = Z::from(u64::MAX);
+        let d: Zq = a - &c;
+        let e: Zq = b - c;
+        assert_eq!(
+            d,
+            Zq::try_from(((u64::MAX - 1) / 2 - 58, u64::MAX - 58)).unwrap()
+        );
+        assert_eq!(e, Zq::try_from((-2, i64::MAX)).unwrap());
+    }
+}
+
+#[cfg(test)]
+mod test_sub_between_zq_and_q {
+
+    use crate::integer_mod_q::Zq;
+    use crate::rational::Q;
+    use std::str::FromStr;
+
+    /// testing subtraction for [`Zq`] and [`Q`]
+    #[test]
+    fn sub() {
+        let a: Zq = Zq::try_from_int_int(4, 17).unwrap();
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = a - b;
+        assert_eq!(c, Q::from_str("23/7").unwrap());
+    }
+
+    /// testing subtraction for both borrowed [`Zq`] and [`Q`]
+    #[test]
+    fn sub_borrow() {
+        let a: Zq = Zq::try_from_int_int(4, 17).unwrap();
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = &a - &b;
+        assert_eq!(c, Q::from_str("23/7").unwrap());
+    }
+
+    /// testing subtraction for borrowed [`Zq`] and [`Q`]
+    #[test]
+    fn sub_first_borrowed() {
+        let a: Zq = Zq::try_from_int_int(4, 17).unwrap();
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = &a - b;
+        assert_eq!(c, Q::from_str("23/7").unwrap());
+    }
+
+    /// testing subtraction for [`Zq`] and borrowed [`Q`]
+    #[test]
+    fn sub_second_borrowed() {
+        let a: Zq = Zq::try_from_int_int(4, 17).unwrap();
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = a - &b;
+        assert_eq!(c, Q::from_str("23/7").unwrap());
+    }
+
+    /// testing subtraction for big numbers
+    #[test]
+    fn sub_large_numbers() {
+        let a: Zq = Zq::try_from_int_int(i64::MAX, u64::MAX - 58).unwrap();
+        let b: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
+        let c: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let d: Q = &a - b;
+        let e: Q = a - c;
+        assert_eq!(
+            d,
+            Q::from_str(&format!("{}/1", i64::MAX)).unwrap()
+                - Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
+        );
+        assert_eq!(
+            e,
+            Q::from_str(&format!("{}/1", i64::MAX)).unwrap()
+                - Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_add_between_types {
+
+    use crate::integer_mod_q::Zq;
+
+    /// testing addition between different types
+    #[test]
+    #[allow(clippy::op_ref)]
+    fn add() {
+        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: u64 = 1;
+        let c: u32 = 1;
+        let d: u16 = 1;
+        let e: u8 = 1;
+        let f: i64 = 1;
+        let g: i32 = 1;
+        let h: i16 = 1;
+        let i: i8 = 1;
+
+        let _: Zq = &a - &b;
+        let _: Zq = &a - &c;
+        let _: Zq = &a - &d;
+        let _: Zq = &a - &e;
+        let _: Zq = &a - &f;
+        let _: Zq = &a - &g;
+        let _: Zq = &a - &h;
+        let _: Zq = &a - &i;
+
+        let _: Zq = &b - &a;
+        let _: Zq = &c - &a;
+        let _: Zq = &d - &a;
+        let _: Zq = &e - &a;
+        let _: Zq = &f - &a;
+        let _: Zq = &g - &a;
+        let _: Zq = &h - &a;
+        let _: Zq = &i - &a;
+
+        let _: Zq = &a - b;
+        let _: Zq = &a - c;
+        let _: Zq = &a - d;
+        let _: Zq = &a - e;
+        let _: Zq = &a - f;
+        let _: Zq = &a - g;
+        let _: Zq = &a - h;
+        let _: Zq = &a - i;
+
+        let _: Zq = &b - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &c - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &d - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &e - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &f - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &g - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &h - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &i - Zq::try_from((4, 11)).unwrap();
+
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - &b;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - &c;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - &d;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - &e;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - &f;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - &g;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - &h;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - &i;
+
+        let _: Zq = b - &a;
+        let _: Zq = c - &a;
+        let _: Zq = d - &a;
+        let _: Zq = e - &a;
+        let _: Zq = f - &a;
+        let _: Zq = g - &a;
+        let _: Zq = h - &a;
+        let _: Zq = i - &a;
+
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - b;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - c;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - d;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - e;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - f;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - g;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - h;
+        let _: Zq = Zq::try_from((4, 11)).unwrap() - i;
+
+        let _: Zq = b - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = c - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = d - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = e - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = f - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = g - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = h - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = i - Zq::try_from((4, 11)).unwrap();
     }
 }

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -8,6 +8,8 @@
 
 //! This module implements macros which are used to implement arithmetic traits for data types.
 
+use crate::integer_mod_q::Zq;
+
 /// Implements the [`*trait*`] for [`*type*`] using the [`*trait*`] for
 /// [`&*type*`].
 ///
@@ -184,3 +186,68 @@ macro_rules! arithmetic_trait_reverse {
 }
 
 pub(crate) use arithmetic_trait_reverse;
+
+/// Implements the [`*trait*`] for owned [`Zq`] on borrowed [`*type*`] and
+/// reverse using the [`*trait*`] for [`Zq`].
+///
+/// Parameters:
+/// - `trait`: the trait that is implemented (e.g. [`Add`], [`Sub`], ...).
+/// - `trait_function`: the function the trait implements
+/// (e.g. add for [`Add`], ...).
+/// - `output_type`: one type that is part of the computation and it is the
+/// result type (e.g. [`Z`], [`Q`], ...).
+/// - `other_type*`: the other types that is part of the computation
+/// (e.g. [`Z`], [`Q`], ...).
+///
+/// Returns the owned and borrowed Implementation code for the
+/// [`*trait*`] trait with the signatures:
+/// ```impl *trait*<&*other_type*> for &*output_type*```
+///
+/// ```impl *trait*<*other_type*> for *output_type*```
+///
+/// ```impl *trait*<&*other_type*> for *output_type*```
+///
+/// ```impl *trait*<*other_type*> for &*output_type*```
+///
+/// ```impl *trait*<&*output_type*> for &*other_type*```
+///
+/// ```impl *trait*<*output_type*> for *other_type*```
+///
+/// ```impl *trait*<&*output_type*> for *other_type*```
+///
+/// ```impl *trait*<*output_type*> for &*other_type*```
+macro_rules! arithmetic_between_types_zq {
+    ($trait:ident, $trait_function:ident, $output_type:ident, $($other_type:ident)*) => {
+        $(
+            // #[doc(hidden)] //maybe also hide. current state: one doc per type
+            impl $trait<&$other_type> for &Zq {
+                type Output = $output_type;
+                paste::paste! {
+                    #[doc = "Documentation at [`Zq::" $trait_function "`]."]
+                    fn $trait_function(self, other: &$other_type) -> Self::Output {
+                    self.$trait_function(Zq::try_from_z_z(Z::from(*other),self.get_modulus()))
+                    }
+                }
+            }
+
+            arithmetic_trait_borrowed_to_owned!($trait,$trait_function,Zq,$other_type,$output_type);
+            arithmetic_trait_mixed_borrowed_owned!($trait,$trait_function,Zq,$other_type,$output_type);
+
+            #[doc(hidden)]
+            impl $trait<&$type> for &$other_type {
+                type Output = $output_type;
+                paste::paste! {
+                    #[doc = "Documentation at [`" $type "::" $trait_function "`]."]
+                    fn $trait_function(self, other: &$type) -> Self::Output {
+                    other.$trait_function(Zq::try_from_z_z(Z::from(*self),other.get_modulus()))
+                    }
+                }
+            }
+            arithmetic_trait_borrowed_to_owned!($trait,$trait_function,$other_type,Zq,$output_type);
+            arithmetic_trait_mixed_borrowed_owned!($trait,$trait_function,$other_type,Zq,$output_type);
+
+        )*
+    };
+}
+
+pub(crate) use arithmetic_between_types_zq;

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -8,8 +8,6 @@
 
 //! This module implements macros which are used to implement arithmetic traits for data types.
 
-use crate::integer_mod_q::Zq;
-
 /// Implements the [`*trait*`] for [`*type*`] using the [`*trait*`] for
 /// [`&*type*`].
 ///
@@ -225,7 +223,7 @@ macro_rules! arithmetic_between_types_zq {
                 paste::paste! {
                     #[doc = "Documentation at [`Zq::" $trait_function "`]."]
                     fn $trait_function(self, other: &$other_type) -> Self::Output {
-                    self.$trait_function(Zq::try_from_z_z(Z::from(*other),self.get_modulus()))
+                    self.$trait_function(Zq::from_z_modulus(&Z::from(*other),&self.modulus))
                     }
                 }
             }
@@ -234,12 +232,12 @@ macro_rules! arithmetic_between_types_zq {
             arithmetic_trait_mixed_borrowed_owned!($trait,$trait_function,Zq,$other_type,$output_type);
 
             #[doc(hidden)]
-            impl $trait<&$type> for &$other_type {
+            impl $trait<&Zq> for &$other_type {
                 type Output = $output_type;
                 paste::paste! {
-                    #[doc = "Documentation at [`" $type "::" $trait_function "`]."]
-                    fn $trait_function(self, other: &$type) -> Self::Output {
-                    other.$trait_function(Zq::try_from_z_z(Z::from(*self),other.get_modulus()))
+                    #[doc = "Documentation at [`Zq::" $trait_function "`]."]
+                    fn $trait_function(self, other: &Zq) -> Self::Output {
+                    other.$trait_function(Zq::from_z_modulus(&Z::from(*self),&other.modulus))
                     }
                 }
             }

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -199,21 +199,21 @@ pub(crate) use arithmetic_trait_reverse;
 ///
 /// Returns the owned and borrowed Implementation code for the
 /// [`*trait*`] trait with the signatures:
-/// ```impl *trait*<&*other_type*> for &*output_type*```
+/// ```impl *trait*<&*other_type*> for &[`Zq`]```
 ///
-/// ```impl *trait*<*other_type*> for *output_type*```
+/// ```impl *trait*<*other_type*> for [`Zq`]```
 ///
-/// ```impl *trait*<&*other_type*> for *output_type*```
+/// ```impl *trait*<&*other_type*> for [`Zq`]```
 ///
-/// ```impl *trait*<*other_type*> for &*output_type*```
+/// ```impl *trait*<*other_type*> for &[`Zq`]```
 ///
-/// ```impl *trait*<&*output_type*> for &*other_type*```
+/// ```impl *trait*<&[`Zq`]> for &*other_type*```
 ///
-/// ```impl *trait*<*output_type*> for *other_type*```
+/// ```impl *trait*<[`Zq`]> for *other_type*```
 ///
-/// ```impl *trait*<&*output_type*> for *other_type*```
+/// ```impl *trait*<&[`Zq`]> for *other_type*```
 ///
-/// ```impl *trait*<*output_type*> for &*other_type*```
+/// ```impl *trait*<[`Zq`]> for &*other_type*```
 macro_rules! arithmetic_between_types_zq {
     ($trait:ident, $trait_function:ident, $output_type:ident, $($other_type:ident)*) => {
         $(

--- a/src/rational/q/arithmetic/add.rs
+++ b/src/rational/q/arithmetic/add.rs
@@ -9,10 +9,14 @@
 //! Implementation of the [`Add`] trait for [`Q`] values.
 
 use super::super::Q;
-use crate::macros::arithmetics::{
-    arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+use crate::{
+    integer::Z,
+    macros::arithmetics::{
+        arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
+    },
 };
-use flint_sys::fmpq::fmpq_add;
+use flint_sys::fmpq::{fmpq_add, fmpq_add_fmpz};
 use std::ops::Add;
 
 impl Add for &Q {
@@ -31,7 +35,7 @@ impl Add for &Q {
     /// use qfall_math::rational::Q;
     /// use std::str::FromStr;
     ///
-    /// let a: Q = Q::from_str("42").unwrap();
+    /// let a: Q = Q::from(42);
     /// let b: Q = Q::from_str("-42/2").unwrap();
     ///
     /// let c: Q = &a + &b;
@@ -50,6 +54,44 @@ impl Add for &Q {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, Q, Q, Q);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Q, Q, Q);
+arithmetic_between_types!(Add, add, Q, Q,  i64 i32 i16 i8 u64 u32 u16 u8);
+
+impl Add<&Z> for &Q {
+    type Output = Q;
+
+    /// Implements the [`Add`] trait for [`Q`] and [`Z`] values.
+    /// [`Add`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both numbers as a [`Q`].
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::rational::Q;
+    /// use qfall_math::integer::Z;
+    /// use std::str::FromStr;
+    ///
+    /// let a: Q = Q::from_str("42/19").unwrap();
+    /// let b: Z = Z::from_str("-42").unwrap();
+    ///
+    /// let c: Q = &a + &b;
+    /// let d: Q = a + b;
+    /// let e: Q = &c + d;
+    /// let f: Q = c + &e;
+    /// ```
+    fn add(self, other: &Z) -> Self::Output {
+        let mut out = Q::default();
+        unsafe {
+            fmpq_add_fmpz(&mut out.value, &self.value, &other.value);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Add, add, Q, Z, Q);
+arithmetic_trait_mixed_borrowed_owned!(Add, add, Q, Z, Q);
 
 #[cfg(test)]
 mod test_add {
@@ -59,7 +101,7 @@ mod test_add {
     /// testing addition for two [`Q`]
     #[test]
     fn add() {
-        let a: Q = Q::from_str("42").unwrap();
+        let a: Q = Q::from(42);
         let b: Q = Q::from_str("42/2").unwrap();
         let c: Q = a + b;
         assert_eq!(c, Q::from_str("63").unwrap());
@@ -68,7 +110,7 @@ mod test_add {
     /// testing addition for two borrowed [`Q`]
     #[test]
     fn add_borrow() {
-        let a: Q = Q::from_str("42").unwrap();
+        let a: Q = Q::from(42);
         let b: Q = Q::from_str("42/2").unwrap();
         let c: Q = &a + &b;
         assert_eq!(c, Q::from_str("63").unwrap());
@@ -86,7 +128,7 @@ mod test_add {
     /// testing addition for [`Q`] and borrowed [`Q`]
     #[test]
     fn add_second_borrowed() {
-        let a: Q = Q::from_str("42").unwrap();
+        let a: Q = Q::from(42);
         let b: Q = Q::from_str("42/2").unwrap();
         let c: Q = a + &b;
         assert_eq!(c, Q::from_str("63").unwrap());
@@ -111,5 +153,161 @@ mod test_add {
             ))
             .unwrap()
         );
+    }
+}
+
+#[cfg(test)]
+mod test_add_between_z_and_q {
+
+    use super::Z;
+    use crate::rational::Q;
+    use std::str::FromStr;
+
+    /// testing addition for [`Q`] and [`Z`]
+    #[test]
+    fn add() {
+        let a: Q = Q::from_str("5/7").unwrap();
+        let b: Z = Z::from(4);
+        let c: Q = a + b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for both borrowed [`Q`] and [`Z`]
+    #[test]
+    fn add_borrow() {
+        let a: Q = Q::from_str("5/7").unwrap();
+        let b: Z = Z::from(4);
+        let c: Q = &a + &b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for borrowed [`Q`] and [`Z`]
+    #[test]
+    fn add_first_borrowed() {
+        let a: Q = Q::from_str("5/7").unwrap();
+        let b: Z = Z::from(4);
+        let c: Q = &a + b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for [`Q`] and borrowed [`Z`]
+    #[test]
+    fn add_second_borrowed() {
+        let a: Q = Q::from_str("5/7").unwrap();
+        let b: Z = Z::from(4);
+        let c: Q = a + &b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for big numbers
+    #[test]
+    fn add_large_numbers() {
+        let a: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
+        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let c: Z = Z::from(u64::MAX);
+        let d: Q = a + &c;
+        let e: Q = b + c;
+        assert_eq!(
+            d,
+            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
+                + Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
+        );
+        assert_eq!(
+            e,
+            Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
+                + Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_add_between_types {
+
+    use crate::rational::Q;
+
+    /// testing addition between different types
+    #[test]
+    #[allow(clippy::op_ref)]
+    fn add() {
+        let a: Q = Q::from(42);
+        let b: u64 = 1;
+        let c: u32 = 1;
+        let d: u16 = 1;
+        let e: u8 = 1;
+        let f: i64 = 1;
+        let g: i32 = 1;
+        let h: i16 = 1;
+        let i: i8 = 1;
+        let _: Q = &a + &b;
+        let _: Q = &a + &c;
+        let _: Q = &a + &d;
+        let _: Q = &a + &e;
+        let _: Q = &a + &f;
+        let _: Q = &a + &g;
+        let _: Q = &a + &h;
+        let _: Q = &a + &i;
+
+        let _: Q = &b + &a;
+        let _: Q = &c + &a;
+        let _: Q = &d + &a;
+        let _: Q = &e + &a;
+        let _: Q = &f + &a;
+        let _: Q = &g + &a;
+        let _: Q = &h + &a;
+        let _: Q = &i + &a;
+
+        let _: Q = &a + b;
+        let _: Q = &a + c;
+        let _: Q = &a + d;
+        let _: Q = &a + e;
+        let _: Q = &a + f;
+        let _: Q = &a + g;
+        let _: Q = &a + h;
+        let _: Q = &a + i;
+
+        let _: Q = &b + Q::from(42);
+        let _: Q = &c + Q::from(42);
+        let _: Q = &d + Q::from(42);
+        let _: Q = &e + Q::from(42);
+        let _: Q = &f + Q::from(42);
+        let _: Q = &g + Q::from(42);
+        let _: Q = &h + Q::from(42);
+        let _: Q = &i + Q::from(42);
+
+        let _: Q = Q::from(42) + &b;
+        let _: Q = Q::from(42) + &c;
+        let _: Q = Q::from(42) + &d;
+        let _: Q = Q::from(42) + &e;
+        let _: Q = Q::from(42) + &f;
+        let _: Q = Q::from(42) + &g;
+        let _: Q = Q::from(42) + &h;
+        let _: Q = Q::from(42) + &i;
+
+        let _: Q = b + &a;
+        let _: Q = c + &a;
+        let _: Q = d + &a;
+        let _: Q = e + &a;
+        let _: Q = f + &a;
+        let _: Q = g + &a;
+        let _: Q = h + &a;
+        let _: Q = i + &a;
+
+        let _: Q = Q::from(42) + b;
+        let _: Q = Q::from(42) + c;
+        let _: Q = Q::from(42) + d;
+        let _: Q = Q::from(42) + e;
+        let _: Q = Q::from(42) + f;
+        let _: Q = Q::from(42) + g;
+        let _: Q = Q::from(42) + h;
+        let _: Q = Q::from(42) + i;
+
+        let _: Q = b + Q::from(42);
+        let _: Q = c + Q::from(42);
+        let _: Q = d + Q::from(42);
+        let _: Q = e + Q::from(42);
+        let _: Q = f + Q::from(42);
+        let _: Q = g + Q::from(42);
+        let _: Q = h + Q::from(42);
+        let _: Q = i + Q::from(42);
     }
 }

--- a/src/rational/q/arithmetic/add.rs
+++ b/src/rational/q/arithmetic/add.rs
@@ -79,8 +79,8 @@ impl Add<&Z> for &Q {
     ///
     /// let c: Q = &a + &b;
     /// let d: Q = a + b;
-    /// let e: Q = &c + d;
-    /// let f: Q = c + &e;
+    /// let e: Q = &c + Z::from(42);
+    /// let f: Q = c + &Z::from(42);
     /// ```
     fn add(self, other: &Z) -> Self::Output {
         let mut out = Q::default();

--- a/src/rational/q/arithmetic/add.rs
+++ b/src/rational/q/arithmetic/add.rs
@@ -55,7 +55,7 @@ impl Add for &Q {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, Q, Q, Q);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Q, Q, Q);
-arithmetic_between_types!(Add, add, Q, Q, i64 i32 i16 i8 u64 u32 u16 u8);
+arithmetic_between_types!(Add, add, Q, Q, i64 i32 i16 i8 u64 u32 u16 u8 f32 f64);
 
 impl Add<&Z> for &Q {
     type Output = Q;
@@ -336,6 +336,8 @@ mod test_add_between_types {
         let g: i32 = 1;
         let h: i16 = 1;
         let i: i8 = 1;
+        let j: f32 = 0.3;
+        let k: f64 = 0.3;
         let _: Q = &a + &b;
         let _: Q = &a + &c;
         let _: Q = &a + &d;
@@ -344,6 +346,8 @@ mod test_add_between_types {
         let _: Q = &a + &g;
         let _: Q = &a + &h;
         let _: Q = &a + &i;
+        let _: Q = &a + &j;
+        let _: Q = &a + &k;
 
         let _: Q = &b + &a;
         let _: Q = &c + &a;
@@ -353,6 +357,8 @@ mod test_add_between_types {
         let _: Q = &g + &a;
         let _: Q = &h + &a;
         let _: Q = &i + &a;
+        let _: Q = &j + &a;
+        let _: Q = &k + &a;
 
         let _: Q = &a + b;
         let _: Q = &a + c;
@@ -362,6 +368,8 @@ mod test_add_between_types {
         let _: Q = &a + g;
         let _: Q = &a + h;
         let _: Q = &a + i;
+        let _: Q = &a + j;
+        let _: Q = &a + k;
 
         let _: Q = &b + Q::from(42);
         let _: Q = &c + Q::from(42);
@@ -371,6 +379,8 @@ mod test_add_between_types {
         let _: Q = &g + Q::from(42);
         let _: Q = &h + Q::from(42);
         let _: Q = &i + Q::from(42);
+        let _: Q = &j + Q::from(42);
+        let _: Q = &k + Q::from(42);
 
         let _: Q = Q::from(42) + &b;
         let _: Q = Q::from(42) + &c;
@@ -380,6 +390,8 @@ mod test_add_between_types {
         let _: Q = Q::from(42) + &g;
         let _: Q = Q::from(42) + &h;
         let _: Q = Q::from(42) + &i;
+        let _: Q = Q::from(42) + &j;
+        let _: Q = Q::from(42) + &k;
 
         let _: Q = b + &a;
         let _: Q = c + &a;
@@ -389,6 +401,8 @@ mod test_add_between_types {
         let _: Q = g + &a;
         let _: Q = h + &a;
         let _: Q = i + &a;
+        let _: Q = j + &a;
+        let _: Q = k + &a;
 
         let _: Q = Q::from(42) + b;
         let _: Q = Q::from(42) + c;
@@ -398,6 +412,8 @@ mod test_add_between_types {
         let _: Q = Q::from(42) + g;
         let _: Q = Q::from(42) + h;
         let _: Q = Q::from(42) + i;
+        let _: Q = Q::from(42) + j;
+        let _: Q = Q::from(42) + k;
 
         let _: Q = b + Q::from(42);
         let _: Q = c + Q::from(42);
@@ -407,5 +423,7 @@ mod test_add_between_types {
         let _: Q = g + Q::from(42);
         let _: Q = h + Q::from(42);
         let _: Q = i + Q::from(42);
+        let _: Q = j + Q::from(42);
+        let _: Q = k + Q::from(42);
     }
 }

--- a/src/rational/q/arithmetic/add.rs
+++ b/src/rational/q/arithmetic/add.rs
@@ -54,7 +54,7 @@ impl Add for &Q {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, Q, Q, Q);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Q, Q, Q);
-arithmetic_between_types!(Add, add, Q, Q,  i64 i32 i16 i8 u64 u32 u16 u8);
+arithmetic_between_types!(Add, add, Q, Q, i64 i32 i16 i8 u64 u32 u16 u8);
 
 impl Add<&Z> for &Q {
     type Output = Q;


### PR DESCRIPTION
**Description**

this PR is an implementation for the Sub trait between different types

This PR implements...
- [x] Sub for Z and Zq -> Zq
- [x] Sub for Q and Zq -> Q
- [x] Sub for Z and Q -> Q
- [x] Sub for Z and Rust standard types (i8 i16 i32 i64 u8 u16 u32 u64) ->Z
- [x] Sub for Zq and Rust standard types (i8 i16 i32 i64 u8 u16 u32 u64) -> Zq
- [x] Sub for Q and Rust standard types (i8 i16 i32 i64 u8 u16 u32 u64 f32 f64) -> Q


**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
- [x] I tested whether each trait is implemented
<!-- Please add other tests if any other have been performed -->

**Checklist:**

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
