### PR TITLE
Add_Zq_between_types

### DIFF
--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -233,7 +233,7 @@ mod test_add_between_zq_and_z {
     fn add_borrow() {
         let a: Zq = Zq::try_from((4, 11)).unwrap();
         let b: Z = Z::from(9);
-        let c: Zq = a + b;
+        let c: Zq = &a + &b;
         assert_eq!(c, Zq::try_from((2, 11)).unwrap());
     }
 
@@ -242,7 +242,7 @@ mod test_add_between_zq_and_z {
     fn add_first_borrowed() {
         let a: Zq = Zq::try_from((4, 11)).unwrap();
         let b: Z = Z::from(9);
-        let c: Zq = a + b;
+        let c: Zq = &a + b;
         assert_eq!(c, Zq::try_from((2, 11)).unwrap());
     }
 
@@ -251,7 +251,7 @@ mod test_add_between_zq_and_z {
     fn add_second_borrowed() {
         let a: Zq = Zq::try_from((4, 11)).unwrap();
         let b: Z = Z::from(9);
-        let c: Zq = a + b;
+        let c: Zq = a + &b;
         assert_eq!(c, Zq::try_from((2, 11)).unwrap());
     }
 

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -98,6 +98,7 @@ impl Zq {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, Zq, Zq, Zq);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Zq, Zq, Zq);
+arithmetic_between_types_zq!(Add, add, Zq, i64 i32 i16 i8 u64 u32 u16 u8);
 
 impl Add<&Z> for &Zq {
     type Output = Zq;
@@ -140,7 +141,6 @@ impl Add<&Z> for &Zq {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, Zq, Z, Zq);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Zq, Z, Zq);
-arithmetic_between_types_zq!(Add, add, Zq, i64 i32 i16 i8 u64 u32 u16 u8);
 
 #[cfg(test)]
 mod test_add {

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -184,3 +184,68 @@ macro_rules! arithmetic_trait_reverse {
 }
 
 pub(crate) use arithmetic_trait_reverse;
+
+/// Implements the [`*trait*`] for owned [`Zq`] on borrowed [`*type*`] and
+/// reverse using the [`*trait*`] for [`Zq`].
+///
+/// Parameters:
+/// - `trait`: the trait that is implemented (e.g. [`Add`], [`Sub`], ...).
+/// - `trait_function`: the function the trait implements
+/// (e.g. add for [`Add`], ...).
+/// - `output_type`: one type that is part of the computation and it is the
+/// result type (e.g. [`Z`], [`Q`], ...).
+/// - `other_type*`: the other types that is part of the computation
+/// (e.g. [`Z`], [`Q`], ...).
+///
+/// Returns the owned and borrowed Implementation code for the
+/// [`*trait*`] trait with the signatures:
+/// ```impl *trait*<&*other_type*> for &[`Zq`]```
+///
+/// ```impl *trait*<*other_type*> for [`Zq`]```
+///
+/// ```impl *trait*<&*other_type*> for [`Zq`]```
+///
+/// ```impl *trait*<*other_type*> for &[`Zq`]```
+///
+/// ```impl *trait*<&[`Zq`]> for &*other_type*```
+///
+/// ```impl *trait*<[`Zq`]> for *other_type*```
+///
+/// ```impl *trait*<&[`Zq`]> for *other_type*```
+///
+/// ```impl *trait*<[`Zq`]> for &*other_type*```
+macro_rules! arithmetic_between_types_zq {
+    ($trait:ident, $trait_function:ident, $output_type:ident, $($other_type:ident)*) => {
+        $(
+            // #[doc(hidden)] //maybe also hide. current state: one doc per type
+            impl $trait<&$other_type> for &Zq {
+                type Output = $output_type;
+                paste::paste! {
+                    #[doc = "Documentation at [`Zq::" $trait_function "`]."]
+                    fn $trait_function(self, other: &$other_type) -> Self::Output {
+                    self.$trait_function(Zq::from_z_modulus(&Z::from(*other),&self.modulus))
+                    }
+                }
+            }
+
+            arithmetic_trait_borrowed_to_owned!($trait,$trait_function,Zq,$other_type,$output_type);
+            arithmetic_trait_mixed_borrowed_owned!($trait,$trait_function,Zq,$other_type,$output_type);
+
+            #[doc(hidden)]
+            impl $trait<&Zq> for &$other_type {
+                type Output = $output_type;
+                paste::paste! {
+                    #[doc = "Documentation at [`Zq::" $trait_function "`]."]
+                    fn $trait_function(self, other: &Zq) -> Self::Output {
+                    other.$trait_function(Zq::from_z_modulus(&Z::from(*self),&other.modulus))
+                    }
+                }
+            }
+            arithmetic_trait_borrowed_to_owned!($trait,$trait_function,$other_type,Zq,$output_type);
+            arithmetic_trait_mixed_borrowed_owned!($trait,$trait_function,$other_type,Zq,$output_type);
+
+        )*
+    };
+}
+
+pub(crate) use arithmetic_between_types_zq;


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements...
- [x] the Add trait for Zq + Z
- [x] the Add trait for Zq and Standard types u64, u32, u16, u8, i64, i32, i16, i8
- [x] a macro for arithmetic and Zq using From


**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
