### PR TITLE
Simplification for Q

### DIFF
--- a/src/rational/q/rounding.rs
+++ b/src/rational/q/rounding.rs
@@ -217,11 +217,10 @@ mod test_simplify {
     /// ensure that large values with pointer representations are reduced
     #[test]
     fn large_pointer_representation() {
-        let value = Q::try_from((&(i64::MAX - 1), &i64::MAX)).unwrap();
+        let value = Q::try_from((&(u64::MAX - 1), &u64::MAX)).unwrap();
         let precision = Q::try_from((&1, &u64::MAX)).unwrap();
 
-        let simplified = Q::try_from(1).unwrap();
-        assert_eq!(simplified, value.simplify(&precision));
+        assert_eq!(Q::ONE, value.simplify(&precision));
     }
 
     /// ensure that the simplified value stays in range


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Q numerators and denominators may grow arbitrary large. The simplify method returns the simplest rational in a defined range . This allows to save some memory for very large values.

This PR implements...
- [x] a simplify method for Q.

for/ of `Component`.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
