### PR TITLE
add Z between types

### DIFF
--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -9,11 +9,19 @@
 //! Implementation of the [`Add`] trait for [`Z`] values.
 
 use super::super::Z;
-use crate::macros::arithmetics::{
-    arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
-    arithmetic_trait_mixed_borrowed_owned,
+use crate::{
+    integer_mod_q::Zq,
+    macros::arithmetics::{
+        arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
+    },
+    rational::Q,
 };
-use flint_sys::fmpz::fmpz_add;
+use flint_sys::{
+    fmpq::fmpq_add_fmpz,
+    fmpz::{fmpz, fmpz_add},
+    fmpz_mod::fmpz_mod_add_fmpz,
+};
 use std::ops::Add;
 
 impl Add for &Z {
@@ -50,6 +58,84 @@ impl Add for &Z {
 arithmetic_trait_borrowed_to_owned!(Add, add, Z, Z, Z);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Z, Z, Z);
 arithmetic_between_types!(Add, add, Z, Z, i64 i32 i16 i8 u64 u32 u16 u8);
+
+impl Add<&Q> for &Z {
+    type Output = Q;
+
+    /// Implements the [`Add`] trait for [`Z`] and [`Q`] values.
+    /// [`Add`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both numbers as a [`Q`].
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::rational::Q;
+    /// use qfall_math::integer::Z;
+    /// use std::str::FromStr;
+    ///
+    /// let a: Z = Z::from_str("-42").unwrap();
+    /// let b: Q = Q::from_str("42/19").unwrap();
+    ///
+    /// let c: Q = &a + &b;
+    /// let d: Q = a + b;
+    /// let e: Q = &Z::from(42) + d;
+    /// let f: Q = Z::from(42) + &e;
+    /// ```
+    fn add(self, other: &Q) -> Self::Output {
+        let mut out = Q::default();
+        unsafe {
+            fmpq_add_fmpz(&mut out.value, &other.value, &self.value);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Add, add, Z, Q, Q);
+arithmetic_trait_mixed_borrowed_owned!(Add, add, Z, Q, Q);
+
+impl Add<&Zq> for &Z {
+    type Output = Zq;
+    /// Implements the [`Add`] trait for [`Z`] and [`Zq`] values.
+    /// [`Add`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both numbers as a [`Zq`].
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::integer_mod_q::Zq;
+    /// use qfall_math::integer::Z;
+    /// use std::str::FromStr;
+    ///
+    /// let a: Z = Z::from_str("42").unwrap();
+    /// let b: Zq = Zq::from_str("42 mod 19").unwrap();
+    ///
+    /// let c: Zq = &a + &b;
+    /// let d: Zq = a + b;
+    /// let e: Zq = &Z::from(42) + d;
+    /// let f: Zq = Z::from(42) + &e;
+    /// ```
+    fn add(self, other: &Zq) -> Self::Output {
+        let mut out = fmpz(0);
+        unsafe {
+            fmpz_mod_add_fmpz(
+                &mut out,
+                &other.value.value,
+                &self.value,
+                &*other.modulus.modulus,
+            );
+        }
+        Zq::from_z_modulus(&Z::from_fmpz(&out), &other.modulus)
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Add, add, Z, Zq, Zq);
+arithmetic_trait_mixed_borrowed_owned!(Add, add, Z, Zq, Zq);
 
 #[cfg(test)]
 mod test_add_between_types {
@@ -145,6 +231,70 @@ mod test_add_between_types {
 }
 
 #[cfg(test)]
+mod test_add_between_z_and_q {
+
+    use super::Z;
+    use crate::rational::Q;
+    use std::str::FromStr;
+
+    /// testing addition for [`Z`] and [`Q`]
+    #[test]
+    fn add() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = a + b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for both borrowed [`Z`] and [`Q`]
+    #[test]
+    fn add_borrow() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = &a + &b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for borrowed [`Z`] and [`Q`]
+    #[test]
+    fn add_first_borrowed() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = &a + b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for [`Z`] and borrowed [`Q`]
+    #[test]
+    fn add_second_borrowed() {
+        let a: Z = Z::from(4);
+        let b: Q = Q::from_str("5/7").unwrap();
+        let c: Q = a + &b;
+        assert_eq!(c, Q::from_str("33/7").unwrap());
+    }
+
+    /// testing addition for big numbers
+    #[test]
+    fn add_large_numbers() {
+        let a: Z = Z::from(u64::MAX);
+        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let c: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
+        let d: Q = &a + b;
+        let e: Q = a + c;
+        assert_eq!(
+            d,
+            Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
+                + Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
+        );
+        assert_eq!(
+            e,
+            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
+                + Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
+        );
+    }
+}
+
+#[cfg(test)]
 mod test_add {
 
     use super::Z;
@@ -195,5 +345,64 @@ mod test_add {
         let e: Z = a + c;
         assert_eq!(d, Z::from(u64::MAX - 221319874));
         assert_eq!(e, Z::from(i64::MAX));
+    }
+}
+
+#[cfg(test)]
+mod test_add_between_z_and_zq {
+
+    use super::Z;
+    use crate::integer_mod_q::Zq;
+
+    /// testing addition for [`Z`] and [`Zq`]
+    #[test]
+    fn add() {
+        let a: Z = Z::from(9);
+        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let c: Zq = a + b;
+        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+    }
+
+    /// testing addition for both borrowed [`Z`] and [`Zq`]
+    #[test]
+    fn add_borrow() {
+        let a: Z = Z::from(9);
+        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let c: Zq = a + b;
+        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+    }
+
+    /// testing addition for borrowed [`Z`] and [`Zq`]
+    #[test]
+    fn add_first_borrowed() {
+        let a: Z = Z::from(9);
+        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let c: Zq = a + b;
+        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+    }
+
+    /// testing addition for [`Z`] and borrowed [`Zq`]
+    #[test]
+    fn add_second_borrowed() {
+        let a: Z = Z::from(9);
+        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let c: Zq = a + b;
+        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+    }
+
+    /// testing addition for big numbers
+    #[test]
+    fn add_large_numbers() {
+        let a: Z = Z::from(u64::MAX);
+        let b: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
+        let c: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+
+        let d: Zq = &a + b;
+        let e: Zq = a + c;
+        assert_eq!(
+            d,
+            Zq::try_from(((u64::MAX - 1) / 2 + 58, u64::MAX - 58)).unwrap()
+        );
+        assert_eq!(e, Zq::try_from((0, i64::MAX)).unwrap());
     }
 }


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements...
- [x] the Add trait for Z + Zq
- [x] the Add trait for Z + Q
- [x] the Add trait for Zq and Standard types u64, u32, u16, u8, i64, i32, i16, i8

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
