### PR TITLE
Refactor sprint 6 part 2

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ use thiserror::Error;
 /// - `InvalidIntegerInput` is thrown if an integer input is provided as parameter that
 /// does not meet the conditions of that function
 /// - `InvalidInterval` is thrown if an invalid interval, e.g. of negative size, is provided
-/// - `InvalidIntToModulus` is thrown if an integer is provided, which is not greater than `0`
+/// - `InvalidIntToModulus` is thrown if an integer is provided, which is not greater than `1`
 /// - `InvalidMatrix` is thrown if an invalid string input of a matrix is given
 /// - `InvalidStringToCStringInput` is thrown if an invalid string is given to
 /// construct a [`CString`](std::ffi::CString)
@@ -102,7 +102,7 @@ pub enum MathError {
     /// parse int to modulus error
     #[error(
         "invalid integer input to parse to a modulus {0}. \
-        The value must be larger than 0."
+        The value must be larger than 1."
     )]
     InvalidIntToModulus(String),
 

--- a/src/integer/mat_poly_over_z/default.rs
+++ b/src/integer/mat_poly_over_z/default.rs
@@ -51,8 +51,6 @@ impl MatPolyOverZ {
             )));
         }
 
-        // Initialize variable with MaybeUn-initialized value to check
-        // correctness of initialization later
         let mut matrix = MaybeUninit::uninit();
         unsafe {
             fmpz_poly_mat_init(matrix.as_mut_ptr(), num_rows_i64, num_cols_i64);

--- a/src/integer/mat_z/default.rs
+++ b/src/integer/mat_z/default.rs
@@ -50,8 +50,6 @@ impl MatZ {
             ));
         }
 
-        // initialize variable with MaybeUn-initialized value to check
-        // correctness of initialization later
         let mut matrix = MaybeUninit::uninit();
         unsafe {
             fmpz_mat_init(matrix.as_mut_ptr(), num_rows_i64, num_cols_i64);

--- a/src/integer/z/distance.rs
+++ b/src/integer/z/distance.rs
@@ -92,7 +92,7 @@ mod test_distance {
     #[test]
     fn availability() {
         let a = Z::ZERO;
-        let modulus = Modulus::try_from_z(&Z::ONE).unwrap();
+        let modulus = Modulus::try_from_z(&Z::from(2)).unwrap();
 
         let u_0 = a.distance(0_u8);
         let u_1 = a.distance(15_u16);
@@ -112,6 +112,6 @@ mod test_distance {
         assert_eq!(Z::from(15), i_1);
         assert_eq!(Z::from(35), i_2);
         assert_eq!(Z::from(i64::MIN).abs(), i_3);
-        assert_eq!(Z::ONE, dist_mod);
+        assert_eq!(Z::from(2), dist_mod);
     }
 }

--- a/src/integer_mod_q/mat_zq.rs
+++ b/src/integer_mod_q/mat_zq.rs
@@ -8,6 +8,10 @@
 
 //! [`MatZq`] is a type of matrix with integer entries of arbitrary length modulo `q`.
 //! This implementation uses the [FLINT](https://flintlib.org/) library.
+//!
+//! For **DEVELOPERS**: Many functions assume that the [`MatZq`] instances are reduced.
+//! To avoid unnecessary checks and reductions, always return canonical/reduced
+//! values. The end-user should be unable to obtain a non-reduced value.
 
 use crate::integer_mod_q::Modulus;
 use flint_sys::fmpz_mod_mat::fmpz_mod_mat_struct;

--- a/src/integer_mod_q/mat_zq/default.rs
+++ b/src/integer_mod_q/mat_zq/default.rs
@@ -182,7 +182,7 @@ mod test_identity {
         }
     }
 
-    /// Tests if an identity matrix can be created using a modulus of `1`.
+    /// Assert that a modulus of `1` is not allowed.
     #[test]
     fn modulus_one() {
         assert!(MatZq::identity(10, 10, 1).is_err());

--- a/src/integer_mod_q/mat_zq/default.rs
+++ b/src/integer_mod_q/mat_zq/default.rs
@@ -23,7 +23,7 @@ impl MatZq {
     /// - `modulus`: the common modulus of the matrix entries
     ///
     /// Returns a [`MatZq`] or an error, if the number of rows or columns is
-    /// less than `1`.
+    /// less than `1` or the modulus is less than `1`.
     ///
     /// # Examples
     /// ```
@@ -39,7 +39,7 @@ impl MatZq {
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
     /// if the number of rows or columns is negative or it does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the provided value is not greater than `0`.
+    /// if the provided value is not greater than `1`.
     pub fn new(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
@@ -58,12 +58,10 @@ impl MatZq {
 
         let modulus = std::convert::Into::<Z>::into(modulus);
 
-        if modulus < Z::ONE {
+        if modulus <= Z::ONE {
             return Err(MathError::InvalidIntToModulus(format!("{}", modulus)));
         }
 
-        // initialize variable with MaybeUn-initialized value to check
-        // correctness of initialization later
         let mut matrix = MaybeUninit::uninit();
         unsafe {
             fmpz_mod_mat_init(
@@ -75,7 +73,7 @@ impl MatZq {
 
             Ok(MatZq {
                 matrix: matrix.assume_init(),
-                // we can unwrap here since modulus > 0 was checked before
+                // we can unwrap here since modulus > 1 was checked before
                 modulus: Modulus::try_from(&modulus).unwrap(),
             })
         }
@@ -106,7 +104,7 @@ impl MatZq {
     /// [`OutOfBounds`](MathError::OutOfBounds) if the provided number of rows and columns
     /// are not suited to create a matrix. For further information see [`MatZq::new`].
     /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the modulus is not greater than `0`. For further information see [`MatZq::new`].
+    /// if the modulus is not greater than `1`. For further information see [`MatZq::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_zq/default.rs
+++ b/src/integer_mod_q/mat_zq/default.rs
@@ -185,13 +185,7 @@ mod test_identity {
     /// Tests if an identity matrix can be created using a modulus of `1`.
     #[test]
     fn modulus_one() {
-        let matrix = MatZq::identity(10, 10, 1).unwrap();
-
-        for i in 0..10 {
-            for j in 0..10 {
-                assert_eq!(Z::ZERO, matrix.get_entry(i, j).unwrap())
-            }
-        }
+        assert!(MatZq::identity(10, 10, 1).is_err());
     }
 }
 

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -107,7 +107,7 @@ impl FromStr for MatZq {
     /// if the modulus or an entry is not formatted correctly.
     /// - Returns a [`MathError`] of type
     /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the modulus is not greater than `0`.
+    /// if the modulus is not greater than `1`.
     fn from_str(string: &str) -> Result<Self, MathError> {
         let (matrix, modulus) = match string.split_once("mod") {
             Some((matrix, modulus)) => (matrix, modulus),

--- a/src/integer_mod_q/mat_zq/sample.rs
+++ b/src/integer_mod_q/mat_zq/sample.rs
@@ -51,7 +51,7 @@ impl MatZq {
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     /// if the given `modulus` is smaller than or equal to `1`.
     /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the provided modulus is not greater than `0`.
+    /// if the provided modulus is not greater than `1`.
     pub fn sample_uniform<T>(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/modulus.rs
+++ b/src/integer_mod_q/modulus.rs
@@ -6,9 +6,11 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! [`Modulus`] is a type of a positive non-zero integer that is used in order to
-//! do modulus operations. The modulus type itself is also used for
+//! [`Modulus`] is a type of a positive integer larger than `1` that is used in
+//! order to do modulus operations. The modulus type itself is also used for
 //! optimizations.
+//! A [`Modulus`] of `1` is not allowed, since operations would always just
+//! return `0`. This way, checks later in the code can be avoided.
 //!
 //! This implementation uses the [FLINT](https://flintlib.org/) library.
 
@@ -23,7 +25,7 @@ mod properties;
 mod serialize;
 mod to_string;
 
-/// [`Modulus`] is a type of a positive non-zero integer that is used
+/// [`Modulus`] is a type of a positive integer larger than `1` that is used
 /// to do modulus operations.
 ///
 /// Attributes:

--- a/src/integer_mod_q/modulus/cmp.rs
+++ b/src/integer_mod_q/modulus/cmp.rs
@@ -69,8 +69,8 @@ mod test_eq {
     /// Checks whether two equal, small Moduli created with different constructors are equal
     #[test]
     fn equal_small() {
-        let a = Modulus::from_str("1").unwrap();
-        let b = Modulus::try_from_z(&Z::from_str("1").unwrap()).unwrap();
+        let a = Modulus::from_str("2").unwrap();
+        let b = Modulus::try_from_z(&Z::from(2)).unwrap();
         let b_clone = b.clone();
 
         assert_eq!(a, b);
@@ -81,7 +81,7 @@ mod test_eq {
     /// Checks whether unequal Moduli are unequal
     #[test]
     fn unequal() {
-        let one = Modulus::from_str("1").unwrap();
+        let one = Modulus::from_str("3").unwrap();
         let two = Modulus::from_str("2").unwrap();
         let big = Modulus::from_str(&"1".repeat(65)).unwrap();
 

--- a/src/integer_mod_q/modulus/from.rs
+++ b/src/integer_mod_q/modulus/from.rs
@@ -35,7 +35,7 @@ impl Modulus {
     /// # Errors and Failures
     ///
     /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the provided value is not greater than `0`.
+    /// if the provided value is not greater than `1`.
     pub fn try_from_z(value: &Z) -> Result<Self, MathError> {
         let modulus = ctx_init(value);
         Ok(Self {
@@ -79,7 +79,7 @@ impl FromStr for Modulus {
     /// formatted [`Z`].
     /// - Returns a [`MathError`] of type
     /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the provided value is not greater than `0`.
+    /// if the provided value is not greater than `1`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let z = Z::from_str(s)?;
 
@@ -96,13 +96,13 @@ impl FromStr for Modulus {
 /// - `s`: the value the modulus should have as [`Z`]
 ///
 /// Returns an initialized context object [`fmpz_mod_ctx`] or an error, if the
-/// provided value was not greater than `0`.
+/// provided value was not greater than `1`.
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-/// if the provided value is not greater than `0`.
+/// if the provided value is not greater than `1`.
 fn ctx_init(n: &Z) -> Result<fmpz_mod_ctx, MathError> {
-    if n <= &Z::ZERO {
+    if n <= &Z::ONE {
         return Err(MathError::InvalidIntToModulus(n.to_string()));
     }
     let mut ctx = MaybeUninit::uninit();

--- a/src/integer_mod_q/poly_over_zq.rs
+++ b/src/integer_mod_q/poly_over_zq.rs
@@ -9,6 +9,10 @@
 //! [`PolyOverZq`] is a type of polynomial with arbitrarily many coefficients of type
 //! [`Zq`](crate::integer_mod_q::Zq).
 //! This implementation uses the [FLINT](https://flintlib.org/) library.
+//!
+//! For **DEVELOPERS**: Many functions assume that the [`PolyOverZq`] instances are reduced.
+//! To avoid unnecessary checks and reductions, always return canonical/reduced
+//! values. The end-user should be unable to obtain a non-reduced value.
 
 use super::modulus::Modulus;
 use flint_sys::fmpz_mod_poly::fmpz_mod_poly_struct;

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -49,9 +49,7 @@ impl From<(&PolyOverZ, &Modulus)> for PolyOverZq {
     /// Create a [`PolyOverZq`] from a [`PolyOverZ`] and [`Modulus`].
     ///
     /// Parameters:
-    /// - `poly_modulus_tuple` is a tuple of the polynomial and the modulus.
-    ///     - The first value is the polynomial.
-    ///     - The second value is the modulus.
+    /// - `poly_modulus_tuple` is a tuple `(polynomial, modulus)`
     ///
     /// # Examples:
     /// ```

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -118,7 +118,7 @@ impl FromStr for PolyOverZq {
     /// string was not formatted correctly to create a [`Z`](crate::integer::Z).
     /// - Returns a [`MathError`] of type
     /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the provided modulus is not greater than `0`.
+    /// if the provided modulus is not greater than `1`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (poly_s, modulus) = match s.split_once("mod") {
             Some((poly_s, modulus)) => (poly_s, modulus.trim()),

--- a/src/integer_mod_q/polynomial_ring_zq.rs
+++ b/src/integer_mod_q/polynomial_ring_zq.rs
@@ -10,11 +10,10 @@
 //! Where f(X) is a [`PolyOverZq`](crate::integer_mod_q::PolyOverZq).
 //! This implementation uses the [FLINT](https://flintlib.org/) library.
 //!
-//! **For Developers**: The [`ModulusPolynomialRingZq`] is not applied automatically, and
-//! has to be called in the functions individually. Additionally the comparisons
-//! assume that the entries are reduced, hence not reduction is performed in the check.
-//!
-//! The DEVELOPER has to call the [`PolynomialRingZq::reduce`], whenever
+//! For **DEVELOPERS**: Many functions assume that the [`PolynomialRingZq`] instances are reduced.
+//! To avoid unnecessary checks and reductions, always return canonical/reduced
+//! values. The end-user should be unable to obtain a non-reduced value.
+//! Therefore, the DEVELOPER has to call the [`PolynomialRingZq::reduce`], whenever
 //! a computation may exceed the modulus, because it is not reduced automatically
 
 use super::ModulusPolynomialRingZq;

--- a/src/integer_mod_q/polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/from.rs
@@ -19,9 +19,8 @@ impl From<(&PolyOverZ, &ModulusPolynomialRingZq)> for PolynomialRingZq {
     /// Create a new polynomial ring element of type [`PolynomialRingZq`].
     ///
     /// Parameters:
-    /// - `value`: is a tuple of `(poly, modulus)`
-    ///     - `poly`: defines the polynomial
-    ///     - `modulus`: the modulus which defines the ring
+    /// - `value` is a tuple `(polynomial, modulus)`
+    ///   The modulus defines the ring.
     ///
     /// Returns a new element inside the polynomial ring.
     ///

--- a/src/integer_mod_q/z_q.rs
+++ b/src/integer_mod_q/z_q.rs
@@ -14,8 +14,9 @@
 //! optimizing modulo operations.
 //! This struct is wrapped in [`Modulus`](super::Modulus) for easy use.
 //!
-//! For **DEVELOPERS**: The [`PartialEq`] trait expects the [`Zq`] instance to be reduced.
-//! Hence, apply `reduce` after every possible `value` change!
+//! For **DEVELOPERS**: Many functions assume that the [`Zq`] instances are reduced.
+//! To avoid unnecessary checks and reductions, always return canonical/reduced
+//! values. The end-user should be unable to obtain a non-reduced value.
 
 use super::Modulus;
 use crate::integer::Z;

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -48,7 +48,7 @@ impl Zq {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
     ///   [`InvalidIntToModulus`](MathError::InvalidIntToModulus) if the
-    ///   provided value is not greater than `0`.
+    ///   provided value is not greater than `1`.
     pub fn try_from_z_z(value: &Z, modulus: &Z) -> Result<Self, MathError> {
         let modulus = Modulus::try_from_z(modulus)?;
 
@@ -131,7 +131,7 @@ impl Zq {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
     ///   [`InvalidIntToModulus`](MathError::InvalidIntToModulus) if the
-    ///   provided value is not greater than `0`.
+    ///   provided value is not greater than `1`.
     pub fn try_from_int_int<T1: Into<Z>, T2: Into<Z>>(
         value: T1,
         modulus: T2,
@@ -175,7 +175,7 @@ impl<IntegerValue: Into<Z>, IntegerModulus: Into<Z>> TryFrom<(IntegerValue, Inte
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
     ///   [`InvalidIntToModulus`](MathError::InvalidIntToModulus) if the
-    ///   provided value is not greater than `0`.
+    ///   provided value is not greater than `1`.
     fn try_from(value_modulus_tuple: (IntegerValue, IntegerModulus)) -> Result<Self, Self::Error> {
         let modulus = value_modulus_tuple.1;
         let value = value_modulus_tuple.0;
@@ -217,7 +217,7 @@ impl FromStr for Zq {
     /// if the provided modulus was not formatted correctly to create a [`Z`]
     /// - Returns a [`MathError`] of type
     /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the provided value is not greater than `0`.
+    /// if the provided value is not greater than `1`.
     /// - Returns a [`MathError`] of type
     /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
     /// if the provided string contains a Nul byte.

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -142,19 +142,16 @@ impl Zq {
     }
 }
 
-impl<T1: Into<Z>, T2: Into<Z>> TryFrom<(T1, T2)> for Zq {
+impl<IntegerValue: Into<Z>, IntegerModulus: Into<Z>> TryFrom<(IntegerValue, IntegerModulus)>
+    for Zq
+{
     type Error = MathError;
     /// Implements the [`TryFrom`] trait. It is used to create [`Zq`] from a tuple
     /// with two values that can be converted into [`Z`].
     ///
-    /// The parameters have to implement the [`Into<Z>`] trait, which is
-    /// automatically the case if [`Z`] implements the [`From`] trait for this type.
-    /// The first and second element of the tuple may have different types.
-    ///
     /// Parameters:
-    /// - `value_modulus_tuple` is a tuple `(value, modulus)`:
-    ///     - The first value defines the value of the new [`Zq`].
-    ///     - The second value defines the new [`Modulus`], which is part of [`Zq`].
+    /// - `value_modulus_tuple` is a tuple of integers `(value, modulus)`
+    ///   The first and second element of the tuple may have different integer types.
     ///
     /// Returns the `value` mod `modulus` as a [`Zq`].
     ///
@@ -179,7 +176,7 @@ impl<T1: Into<Z>, T2: Into<Z>> TryFrom<(T1, T2)> for Zq {
     /// - Returns a [`MathError`] of type
     ///   [`InvalidIntToModulus`](MathError::InvalidIntToModulus) if the
     ///   provided value is not greater than `0`.
-    fn try_from(value_modulus_tuple: (T1, T2)) -> Result<Self, Self::Error> {
+    fn try_from(value_modulus_tuple: (IntegerValue, IntegerModulus)) -> Result<Self, Self::Error> {
         let modulus = value_modulus_tuple.1;
         let value = value_modulus_tuple.0;
         Zq::try_from_int_int(value, modulus)

--- a/src/rational/mat_q.rs
+++ b/src/rational/mat_q.rs
@@ -6,8 +6,12 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! `MatQ` is a type of matrix with rational entries of arbitrary length.
+//! [`MatQ`] is a type of matrix with rational entries of arbitrary length.
 //! This implementation uses the [FLINT](https://flintlib.org/) library.
+//!
+//! For **DEVELOPERS**: Many functions assume that the [`MatQ`] instances are reduced.
+//! To avoid unnecessary checks and reductions, always return canonical/reduced
+//! values. The end-user should be unable to obtain a non-reduced value.
 
 use flint_sys::fmpq_mat::fmpq_mat_struct;
 

--- a/src/rational/mat_q/default.rs
+++ b/src/rational/mat_q/default.rs
@@ -51,8 +51,6 @@ impl MatQ {
             )));
         }
 
-        // initialize variable with MaybeUn-initialized value to check
-        // correctness of initialization later
         let mut matrix = MaybeUninit::uninit();
         unsafe {
             fmpq_mat_init(matrix.as_mut_ptr(), num_rows_i64, num_cols_i64);

--- a/src/rational/poly_over_q.rs
+++ b/src/rational/poly_over_q.rs
@@ -9,6 +9,11 @@
 //! [`PolyOverQ`] is a type of polynomial with arbitrarily many coefficients of type
 //! [`Q`](crate::rational::Q).
 //! This implementation uses the [FLINT](https://flintlib.org/) library.
+//!
+//! For **DEVELOPERS**: Many functions assume that the [`PolyOverQ`] instances
+//! are reduced. To avoid unnecessary checks and reductions, always return
+//! canonical/reduced values. The end-user should be unable to obtain a
+//! non-reduced value.
 
 use flint_sys::fmpq_poly::fmpq_poly_struct;
 

--- a/src/rational/q.rs
+++ b/src/rational/q.rs
@@ -6,8 +6,12 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! `Q` is a type for rationals of arbitrary length.
+//! [`Q`] is a type for rationals of arbitrary length.
 //! This implementation uses the [FLINT](https://flintlib.org/) library.
+//!
+//! For **DEVELOPERS**: Many functions assume that the [`Q`] instances are reduced.
+//! To avoid unnecessary checks and reductions, always return canonical/reduced
+//! values. The end-user should be unable to obtain a non-reduced value.
 
 use flint_sys::fmpq::fmpq;
 

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -227,16 +227,17 @@ impl Q {
     from_type!(f32, f64, Q, Q::from_f64);
 }
 
-impl<T1: Into<Z> + Clone, T2: Into<Z> + Clone> TryFrom<(&T1, &T2)> for Q {
+impl<IntegerNumerator: Into<Z> + Clone, IntegerDenominator: Into<Z> + Clone>
+    TryFrom<(&IntegerNumerator, &IntegerDenominator)> for Q
+{
     type Error = MathError;
 
     /// Create a [`Q`] from two values that can be converted to [`Z`].
     /// For example, [`Z`] and [`u32`].
     ///
     /// Parameters:
-    /// - `num_den_tuple`
-    ///     - first value: numerator of the new [`Q`].
-    ///     - second value: denominator of the new [`Q`].
+    /// - `num_den_tuple` is a tuple of integers `(numerator, denominator)`
+    ///   The first and second element of the tuple may have different integer types.
     ///
     /// Returns a [`Q`] or a [`MathError`]
     ///
@@ -256,7 +257,9 @@ impl<T1: Into<Z> + Clone, T2: Into<Z> + Clone> TryFrom<(&T1, &T2)> for Q {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`DivisionByZeroError`](MathError::DivisionByZeroError)
     /// if the denominator is zero.
-    fn try_from(num_den_tuple: (&T1, &T2)) -> Result<Self, Self::Error> {
+    fn try_from(
+        num_den_tuple: (&IntegerNumerator, &IntegerDenominator),
+    ) -> Result<Self, Self::Error> {
         Q::try_from_int_int(num_den_tuple.0, num_den_tuple.1)
     }
 }


### PR DESCRIPTION
**Description**

This PR implements...
- [x] Modulus, exclude Modulus 1 (at least 2) -> also in MatZq:identity and other downstream changes
- [x] Consistent doc comment for tuple parameter (Zq::from, q::from, PolyOverZq::from)
- [x] Add a comment for developers in the structs of Q, MatQ, Zq and MqtZq, that they are not reduced in every function, since they are assumed to be already reduced (except in from methods)

Also removed a confusing comment.

**Checklist:**

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
