### PR TITLE
From q refactor

### DIFF
--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -78,6 +78,7 @@ pub(crate) fn distance(value_1: &fmpz, value_2: &fmpz) -> Z {
 }
 
 unsafe impl AsInteger for u64 {
+    /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
         let mut ret_value = fmpz(0);
         fmpz_init_set_ui(&mut ret_value, self);
@@ -86,6 +87,7 @@ unsafe impl AsInteger for u64 {
 }
 
 unsafe impl AsInteger for &u64 {
+    /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
         let mut ret_value = fmpz(0);
         fmpz_init_set_ui(&mut ret_value, *self);
@@ -95,7 +97,9 @@ unsafe impl AsInteger for &u64 {
 
 macro_rules! AsInteger_singed {
     ($($type:ident)*) => {
-        $(unsafe impl AsInteger for $type {
+        $(
+        /// Documentation at [`AsInteger::into_fmpz`]
+        unsafe impl AsInteger for $type {
             unsafe fn into_fmpz(self) -> fmpz {
                 let mut ret_value = fmpz(0);
                 fmpz_init_set_si(&mut ret_value, self as i64);
@@ -103,6 +107,7 @@ macro_rules! AsInteger_singed {
             }
         }
 
+        /// Documentation at [`AsInteger::into_fmpz`]
         unsafe impl AsInteger for &$type {
             unsafe fn into_fmpz(self) -> fmpz {
                 let mut ret_value = fmpz(0);
@@ -117,24 +122,28 @@ macro_rules! AsInteger_singed {
 AsInteger_singed!(i8 u8 i16 u16 i32 u32 i64);
 
 unsafe impl AsInteger for Z {
+    /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(mut self) -> fmpz {
         let mut out = fmpz(0);
         fmpz_swap(&mut out, &mut self.value);
         out
     }
 
+    /// Documentation at [`AsInteger::get_fmpz_ref`]
     fn get_fmpz_ref(&self) -> Option<&fmpz> {
         Some(&self.value)
     }
 }
 
 unsafe impl AsInteger for &Z {
+    /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
         let mut value = fmpz(0);
         fmpz_set(&mut value, &self.value);
         value
     }
 
+    /// Documentation at [`AsInteger::get_fmpz_ref`]
     fn get_fmpz_ref(&self) -> Option<&fmpz> {
         Some(&self.value)
     }
@@ -189,14 +198,14 @@ mod test_as_integer_z {
             (&z).into_fmpz()
         }; // z is dropped here
 
+        // create a new `Z` to potentially overwrite the memory
         let _ = Z::from(12);
 
-        let copy = Z::from_fmpz_ref(&value);
+        let copy = Z::from_fmpz(value);
         assert_eq!(copy, Z::from(42));
-        unsafe { fmpz_clear(&mut value) };
     }
 
-    /// Assert that the new fmpz is not effected by the original for large numbers.
+    /// Assert that the new [`fmpz`] is not effected by the original for large numbers.
     /// This can not be tested for an owned [`Z`], since that would violate the
     /// ownership constrain -> not compiling.
     #[test]
@@ -210,7 +219,7 @@ mod test_as_integer_z {
         let _a = Z::from(u64::MAX);
         let _b = Z::from(u64::MAX);
 
-        assert_eq!(Z { value }, Z::from(i64::MAX));
+        assert_eq!(Z::from_fmpz(value), Z::from(i64::MAX));
     }
 
     /// Assert that the new [`fmpz`] is not effecting the original [`Z`].
@@ -240,9 +249,8 @@ mod test_as_integer_z {
         let z = Z::from(10);
 
         let z_ref = z.get_fmpz_ref().unwrap();
-        let mut cmp = Z::default();
-        unsafe { fmpz_set(&mut cmp.value, z_ref) };
 
+        let cmp = Z::from_fmpz_ref(z_ref);
         assert_eq!(cmp, z)
     }
 

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -123,7 +123,7 @@ unsafe impl AsInteger for Z {
         out
     }
 
-    unsafe fn get_fmpz_ref(&self) -> Option<&fmpz> {
+    fn get_fmpz_ref(&self) -> Option<&fmpz> {
         Some(&self.value)
     }
 }
@@ -135,7 +135,7 @@ unsafe impl AsInteger for &Z {
         value
     }
 
-    unsafe fn get_fmpz_ref(&self) -> Option<&fmpz> {
+    fn get_fmpz_ref(&self) -> Option<&fmpz> {
         Some(&self.value)
     }
 }

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -141,6 +141,41 @@ unsafe impl AsInteger for &Z {
 }
 
 #[cfg(test)]
+mod test_as_integer_rust_ints {
+    use crate::{integer::Z, traits::AsInteger};
+
+    /// Assert that rust integers don't have an internal fmpz
+    #[test]
+    fn get_fmpz_ref_none() {
+        assert!(10u8.get_fmpz_ref().is_none());
+        assert!(10u16.get_fmpz_ref().is_none());
+        assert!(10u32.get_fmpz_ref().is_none());
+        assert!(10u64.get_fmpz_ref().is_none());
+        assert!(10i8.get_fmpz_ref().is_none());
+        assert!(10i16.get_fmpz_ref().is_none());
+        assert!(10i32.get_fmpz_ref().is_none());
+        assert!(10i64.get_fmpz_ref().is_none());
+    }
+
+    /// Assert that into_fmpz works correctly for small values
+    #[test]
+    fn into_fmpz_small() {
+        let z = Z::from(10);
+
+        unsafe {
+            assert_eq!(z, Z::from_fmpz(10u8.into_fmpz()));
+            assert_eq!(z, Z::from_fmpz(10u16.into_fmpz()));
+            assert_eq!(z, Z::from_fmpz(10u32.into_fmpz()));
+            assert_eq!(z, Z::from_fmpz(10u64.into_fmpz()));
+            assert_eq!(z, Z::from_fmpz(10i8.into_fmpz()));
+            assert_eq!(z, Z::from_fmpz(10i16.into_fmpz()));
+            assert_eq!(z, Z::from_fmpz(10i32.into_fmpz()));
+            assert_eq!(z, Z::from_fmpz(10i64.into_fmpz()));
+        }
+    }
+}
+
+#[cfg(test)]
 mod test_as_integer_z {
     use flint_sys::fmpz::{fmpz_clear, fmpz_set_ui};
 
@@ -156,7 +191,7 @@ mod test_as_integer_z {
 
         let _ = Z::from(12);
 
-        let copy = Z::from_fmpz(&value);
+        let copy = Z::from_fmpz_ref(&value);
         assert_eq!(copy, Z::from(42));
         unsafe { fmpz_clear(&mut value) };
     }
@@ -199,7 +234,29 @@ mod test_as_integer_z {
         assert_eq!(z, Z::from(i64::MAX));
     }
 
-    // TODO: Add more test cases
+    /// Assert that `get_fmpz_ref` returns a correct reference for small values
+    #[test]
+    fn get_ref_small() {
+        let z = Z::from(10);
+
+        let z_ref = z.get_fmpz_ref().unwrap();
+        let mut cmp = Z::default();
+        unsafe { fmpz_set(&mut cmp.value, z_ref) };
+
+        assert_eq!(cmp, z)
+    }
+
+    /// Assert that `get_fmpz_ref` returns a correct reference for large values
+    #[test]
+    fn get_ref_large() {
+        let z = Z::from(u64::MAX);
+
+        let z_ref = z.get_fmpz_ref().unwrap();
+        let mut cmp = Z::default();
+        unsafe { fmpz_set(&mut cmp.value, z_ref) };
+
+        assert_eq!(cmp, z)
+    }
 }
 
 #[cfg(test)]

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -48,20 +48,24 @@ pub(crate) fn length(value: &fmpz, modulus: &fmpz) -> Z {
 }
 
 unsafe impl AsInteger for Zq {
+    /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
         AsInteger::into_fmpz(&self.value)
     }
 
+    /// Documentation at [`AsInteger::get_fmpz_ref`]
     fn get_fmpz_ref(&self) -> Option<&fmpz> {
         AsInteger::get_fmpz_ref(&self.value)
     }
 }
 
 unsafe impl AsInteger for &Zq {
+    /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
         AsInteger::into_fmpz(&self.value)
     }
 
+    /// Documentation at [`AsInteger::get_fmpz_ref`]
     fn get_fmpz_ref(&self) -> Option<&fmpz> {
         AsInteger::get_fmpz_ref(&self.value)
     }
@@ -69,7 +73,85 @@ unsafe impl AsInteger for &Zq {
 
 #[cfg(test)]
 mod test_as_integer_zq {
-    // TODO: Add tests
+    use flint_sys::fmpz::{fmpz_clear, fmpz_set, fmpz_set_ui};
+
+    use super::*;
+
+    // Assert that the new fmpz is not related to the old one
+    #[test]
+    fn small_into_fmpz() {
+        let mut value = unsafe {
+            let zq = Zq::try_from((Z::from(42), Z::from(100))).unwrap();
+            (&zq).into_fmpz()
+        }; // z is dropped here
+
+        // create a new `Z` to potentially overwrite the memory
+        let _ = Z::from(12);
+
+        let copy = Z::from_fmpz(value);
+        assert_eq!(copy, Z::from(42));
+    }
+
+    /// Assert that the new [`fmpz`] is not effected by the original for large numbers.
+    /// This can not be tested for an owned [`Zq`], since that would violate the
+    /// ownership constrain -> not compiling.
+    #[test]
+    fn original_not_effecting_new_large() {
+        let value = unsafe {
+            let zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+            (&zq).into_fmpz()
+        }; // z is dropped here
+
+        // Create new Z values that would likely overwrite the memory of the original `Zq`.
+        let _a = Z::from(u64::MAX);
+        let _b = Z::from(u64::MAX);
+
+        assert_eq!(Z::from_fmpz(value), Z::from(i64::MAX - 1));
+    }
+
+    /// Assert that the new [`fmpz`] is not effecting the original [`Zq`].
+    #[test]
+    fn new_not_effecting_original_large() {
+        let zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let zq_copy = zq.clone();
+        let mut value = unsafe { (&zq).into_fmpz() };
+
+        // Setting the result of into_fmpz to a different value
+        // is not effecting the original.
+        unsafe { fmpz_set_ui(&mut value, u64::MAX) }
+        assert_eq!(zq, zq_copy);
+
+        // Clearing the new fmpz and creating new values that likely
+        // occupy the memory of the just cleared value.
+        unsafe { fmpz_clear(&mut value) };
+        let _ = Z::from(u64::MAX - 1);
+        let _ = Z::from(u64::MAX);
+
+        assert_eq!(zq, zq_copy);
+    }
+
+    /// Assert that `get_fmpz_ref` returns a correct reference for small values
+    #[test]
+    fn get_ref_small() {
+        let zq = Zq::try_from((10, 100)).unwrap();
+
+        let z_ref = zq.get_fmpz_ref().unwrap();
+
+        let cmp = Z::from_fmpz_ref(z_ref);
+        assert_eq!(cmp, Z::from(10))
+    }
+
+    /// Assert that `get_fmpz_ref` returns a correct reference for large values
+    #[test]
+    fn get_ref_large() {
+        let z = Z::from(u64::MAX);
+
+        let z_ref = z.get_fmpz_ref().unwrap();
+        let mut cmp = Z::default();
+        unsafe { fmpz_set(&mut cmp.value, z_ref) };
+
+        assert_eq!(cmp, z)
+    }
 }
 
 #[cfg(test)]

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -8,7 +8,11 @@
 
 //! This module contains helpful functions on [`fmpz`] values in a ring/`modulus` context.
 
-use crate::integer::{fmpz_helpers::distance, Z};
+use super::Zq;
+use crate::{
+    integer::{fmpz_helpers::distance, Z},
+    traits::AsInteger,
+};
 use flint_sys::fmpz::fmpz;
 
 const ZERO_FMPZ: fmpz = fmpz(0);
@@ -41,6 +45,31 @@ pub(crate) fn length(value: &fmpz, modulus: &fmpz) -> Z {
     } else {
         distance_modulus
     }
+}
+
+unsafe impl AsInteger for Zq {
+    unsafe fn into_fmpz(self) -> fmpz {
+        AsInteger::into_fmpz(&self.value)
+    }
+
+    unsafe fn get_fmpz_ref(&self) -> Option<&fmpz> {
+        AsInteger::get_fmpz_ref(&self.value)
+    }
+}
+
+unsafe impl AsInteger for &Zq {
+    unsafe fn into_fmpz(self) -> fmpz {
+        AsInteger::into_fmpz(&self.value)
+    }
+
+    unsafe fn get_fmpz_ref(&self) -> Option<&fmpz> {
+        AsInteger::get_fmpz_ref(&self.value)
+    }
+}
+
+#[cfg(test)]
+mod test_as_integer_zq {
+    // TODO: Add tests
 }
 
 #[cfg(test)]

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -52,7 +52,7 @@ unsafe impl AsInteger for Zq {
         AsInteger::into_fmpz(&self.value)
     }
 
-    unsafe fn get_fmpz_ref(&self) -> Option<&fmpz> {
+    fn get_fmpz_ref(&self) -> Option<&fmpz> {
         AsInteger::get_fmpz_ref(&self.value)
     }
 }
@@ -62,7 +62,7 @@ unsafe impl AsInteger for &Zq {
         AsInteger::into_fmpz(&self.value)
     }
 
-    unsafe fn get_fmpz_ref(&self) -> Option<&fmpz> {
+    fn get_fmpz_ref(&self) -> Option<&fmpz> {
         AsInteger::get_fmpz_ref(&self.value)
     }
 }

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -50,7 +50,7 @@ pub(crate) fn length(value: &fmpz, modulus: &fmpz) -> Z {
 unsafe impl AsInteger for Zq {
     /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
-        (&self.value).into_fmpz()
+        AsInteger::into_fmpz(self.value)
     }
 
     /// Documentation at [`AsInteger::get_fmpz_ref`]

--- a/src/rational/q.rs
+++ b/src/rational/q.rs
@@ -40,7 +40,7 @@ mod to_string;
 ///
 /// // instantiations
 /// let a = Q::from_str("-876543/235")?;
-/// let b = Q::try_from((&21, &1))?;
+/// let b = Q::from((21, 1));
 /// let zero = Q::default();
 /// let _ = a.clone();
 ///

--- a/src/rational/q/cmp.rs
+++ b/src/rational/q/cmp.rs
@@ -61,8 +61,8 @@ impl PartialOrd for Q {
     /// # use qfall_math::error::MathError;
     /// use qfall_math::rational::Q;
     ///
-    /// let a: Q = Q::try_from((&1,&10))?;
-    /// let b: Q = Q::try_from((&2,&10))?;
+    /// let a: Q = Q::from((1,10));
+    /// let b: Q = Q::from((2,10));
     ///
     /// assert!(a < b);
     /// assert!(a <= b);

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -598,16 +598,12 @@ mod test_try_from_int_int {
 
     /// Test with zero denominator (not valid -> should lead to an error)
     #[test]
-    // TODO: Should this test case really panic?
-    // If not, it is necessary to implement try_from with a macro
     #[should_panic]
     fn divide_by_zero() {
         let numerator = 10;
         let denominator = 0;
 
         let _ = Q::try_from((&numerator, &denominator));
-
-        //assert!(new_q.is_err());
     }
 
     /// Test with either negative denominator or numerator

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -234,12 +234,7 @@ pub(crate) unsafe trait AsInteger {
     /// for a Flint function call.
     /// If the data type does not contain a [`fmpz`], [`into_fmpz`](AsInteger::into_fmpz)
     /// can be used instead.
-    ///
-    /// # Safety
-    /// Modifying the returned [`fmpz`] may also also modify the original object.
-    /// This depends on the size of the value and the data type.
-    /// In general, the returned [`fmpz`] should just be read and not written to.
-    unsafe fn get_fmpz_ref(&self) -> Option<&fmpz> {
+    fn get_fmpz_ref(&self) -> Option<&fmpz> {
         None
     }
 }


### PR DESCRIPTION
**Description**
The `AsInteger` trait is intended to be used in other parts of the code as well.
It abstracts rust integers, `Z` and `Zq` into something that can be converted to `fmpz`.

Intended pattern if just a `&fmpz` is required (does not compile):
```rust
match a.get_fmpz_ref(){
    None => let v = a.into_fmpz(); [...]; fmpz_clear(v),
    v => [...]
}
```
Maybe a better syntax is possible with closures?


This PR ...
- [x] Adds `AsInteger` trait.
    - [x] Implements `AsInteger` for rust integers
    - [x] Implements `AsInteger` for `Z`
    - [x] Implements `AsInteger` for `Zq`
- [x] Reworks `Q::from((a,b))` to accept all combinations of borrowed/owned and the different Integer types.


**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
