### PR TITLE
Conversions between PolyZ, PolyZq and PolynomialRingZq

### DIFF
--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -100,7 +100,7 @@ impl PolyOverZ {
     ///
     /// let poly = PolyOverZq::from_str("4  0 1 102 3 mod 101").unwrap();
     ///
-    /// let poly_z = PolyOverZ::from(&poly);
+    /// let poly_z = PolyOverZ::from_poly_over_zq(&poly);
     ///
     /// # let cmp_poly = PolyOverZ::from_str("4  0 1 1 3").unwrap();
     /// # assert_eq!(cmp_poly, poly_z);
@@ -130,9 +130,9 @@ impl PolyOverZ {
     ///
     /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
     /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
-    /// let poly_ring = PolynomialRingZq::from_poly_over_z_modulus_polynomial_ring_zq(&poly, &modulus);
+    /// let poly_ring = PolynomialRingZq::((&poly, &modulus));
     ///
-    /// let poly_z = PolyOverZ::from(&poly_ring);
+    /// let poly_z = PolyOverZ::from_polynomial_ring_zq(&poly_ring);
     ///
     /// # let cmp_poly = PolyOverZ::from_str("3  15 0 1").unwrap();
     /// # assert_eq!(cmp_poly, poly_z);
@@ -259,8 +259,7 @@ mod from_polynomial_ring_zq {
             ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX - 58))
                 .unwrap();
         let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
-        let poly_ring =
-            PolynomialRingZq::from_poly_over_z_modulus_polynomial_ring_zq(&poly, &modulus);
+        let poly_ring = PolynomialRingZq::from((&poly, &modulus));
 
         let poly_z = PolyOverZ::from(&poly_ring);
 

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -130,7 +130,7 @@ impl PolyOverZ {
     ///
     /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
     /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
-    /// let poly_ring = PolynomialRingZq::((&poly, &modulus));
+    /// let poly_ring = PolynomialRingZq::from((&poly, &modulus));
     ///
     /// let poly_z = PolyOverZ::from_polynomial_ring_zq(&poly_ring);
     ///

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -120,34 +120,6 @@ impl From<&PolyOverZq> for PolyOverZ {
     }
 }
 
-impl From<&PolynomialRingZq> for PolyOverZ {
-    /// Create a [`PolyOverZ`] from a [`PolynomialRingZq`].
-    ///
-    /// Parameters:
-    /// - `poly_ring`: the polynomial from which the coefficients are copied
-    ///
-    /// Returns the representative polynomial of the [`PolynomialRingZq`] element.
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::integer::PolyOverZ;
-    /// use qfall_math::integer_mod_q::{PolynomialRingZq, ModulusPolynomialRingZq};
-    /// use std::str::FromStr;
-    ///
-    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
-    /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
-    /// let poly_ring = PolynomialRingZq::from((&poly, &modulus));
-    ///
-    /// let poly_z = PolyOverZ::from(&poly_ring);
-    ///
-    /// # let cmp_poly = PolyOverZ::from_str("3  15 0 1").unwrap();
-    /// # assert_eq!(cmp_poly, poly_z);
-    /// ```
-    fn from(poly_ring: &PolynomialRingZq) -> Self {
-        poly_ring.poly.clone()
-    }
-}
-
 #[cfg(test)]
 mod test_from_str {
     use super::PolyOverZ;
@@ -230,29 +202,5 @@ mod test_from_poly_over_zq {
         let cmp_poly =
             PolyOverZ::from_str(&format!("4  0 1 102 {} mod {}", u64::MAX - 58, u64::MAX)).unwrap();
         assert_eq!(cmp_poly, poly_q);
-    }
-}
-
-#[cfg(test)]
-mod from_polynomial_ring_zq {
-    use crate::{
-        integer::PolyOverZ,
-        integer_mod_q::{ModulusPolynomialRingZq, PolynomialRingZq},
-    };
-    use std::str::FromStr;
-
-    /// ensure that the conversion works with positive large entries
-    #[test]
-    fn large_positive() {
-        let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX - 58))
-                .unwrap();
-        let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
-        let poly_ring = PolynomialRingZq::from((&poly, &modulus));
-
-        let poly_z = PolyOverZ::from(&poly_ring);
-
-        let cmp_poly = PolyOverZ::from_str(&format!("3  {} 0 1", u64::MAX - 60)).unwrap();
-        assert_eq!(cmp_poly, poly_z);
     }
 }

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -86,11 +86,13 @@ impl FromStr for PolyOverZ {
     }
 }
 
-impl PolyOverZ {
+impl From<&PolyOverZq> for PolyOverZ {
     /// Create a [`PolyOverZ`] from a [`PolyOverZq`].
     ///
     /// Parameters:
     /// - `poly`: the polynomial from which the coefficients are copied
+    ///
+    /// Returns representative polynomial of the [`PolyOverZq`] element.
     ///
     /// # Examples
     /// ```
@@ -100,12 +102,12 @@ impl PolyOverZ {
     ///
     /// let poly = PolyOverZq::from_str("4  0 1 102 3 mod 101").unwrap();
     ///
-    /// let poly_z = PolyOverZ::from_poly_over_zq(&poly);
+    /// let poly_z = PolyOverZ::from(&poly);
     ///
     /// # let cmp_poly = PolyOverZ::from_str("4  0 1 1 3").unwrap();
     /// # assert_eq!(cmp_poly, poly_z);
     /// ```
-    pub fn from_poly_over_zq(poly: &PolyOverZq) -> Self {
+    fn from(poly: &PolyOverZq) -> Self {
         let mut out = Self::default();
         unsafe {
             fmpz_mod_poly_get_fmpz_poly(
@@ -116,11 +118,15 @@ impl PolyOverZ {
         };
         out
     }
+}
 
+impl From<&PolynomialRingZq> for PolyOverZ {
     /// Create a [`PolyOverZ`] from a [`PolynomialRingZq`].
     ///
     /// Parameters:
     /// - `poly_ring`: the polynomial from which the coefficients are copied
+    ///
+    /// Returns the representative polynomial of the [`PolynomialRingZq`] element.
     ///
     /// # Examples
     /// ```
@@ -132,30 +138,13 @@ impl PolyOverZ {
     /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
     /// let poly_ring = PolynomialRingZq::from((&poly, &modulus));
     ///
-    /// let poly_z = PolyOverZ::from_polynomial_ring_zq(&poly_ring);
+    /// let poly_z = PolyOverZ::from(&poly_ring);
     ///
     /// # let cmp_poly = PolyOverZ::from_str("3  15 0 1").unwrap();
     /// # assert_eq!(cmp_poly, poly_z);
     /// ```
-    pub fn from_polynomial_ring_zq(poly_ring: &PolynomialRingZq) -> Self {
-        poly_ring.poly.clone()
-    }
-}
-
-impl From<&PolyOverZq> for PolyOverZ {
-    /// Converts a polynomial of type [`PolyOverZq`] to a [`PolyOverZ`] using
-    /// [`PolyOverZ::from_poly_over_zq`].
-    fn from(poly: &PolyOverZq) -> Self {
-        Self::from_poly_over_zq(poly)
-    }
-}
-
-impl From<&PolynomialRingZq> for PolyOverZ {
-    /// Converts a polynomial ring element
-    ///  of type [`PolynomialRingZq`] to a [`PolyOverZ`] using
-    /// [`PolyOverZ::from_polynomial_ring_zq`].
     fn from(poly_ring: &PolynomialRingZq) -> Self {
-        Self::from_polynomial_ring_zq(poly_ring)
+        poly_ring.poly.clone()
     }
 }
 

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -13,10 +13,7 @@
 //! The explicit functions contain the documentation.
 
 use super::PolyOverZ;
-use crate::{
-    error::MathError,
-    integer_mod_q::{PolyOverZq, PolynomialRingZq},
-};
+use crate::{error::MathError, integer_mod_q::PolyOverZq};
 use flint_sys::{fmpz_mod_poly::fmpz_mod_poly_get_fmpz_poly, fmpz_poly::fmpz_poly_set_str};
 use std::{ffi::CString, str::FromStr};
 
@@ -92,7 +89,8 @@ impl From<&PolyOverZq> for PolyOverZ {
     /// Parameters:
     /// - `poly`: the polynomial from which the coefficients are copied
     ///
-    /// Returns representative polynomial of the [`PolyOverZq`] element.
+    /// Returns representative polynomial (all reduced coefficients)
+    /// of the [`PolyOverZq`] as a [`PolyOverZ`].
     ///
     /// # Examples
     /// ```
@@ -100,7 +98,7 @@ impl From<&PolyOverZq> for PolyOverZ {
     /// use qfall_math::integer_mod_q::PolyOverZq;
     /// use std::str::FromStr;
     ///
-    /// let poly = PolyOverZq::from_str("4  0 1 102 3 mod 101").unwrap();
+    /// let poly = PolyOverZq::from_str("4  0 1 5 3 mod 4").unwrap();
     ///
     /// let poly_z = PolyOverZ::from(&poly);
     ///

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -197,10 +197,9 @@ mod test_from_poly_over_zq {
         let poly = PolyOverZq::from_str(&format!("4  0 1 102 {} mod {}", u64::MAX - 58, u64::MAX))
             .unwrap();
 
-        let poly_q = PolyOverZ::from(&poly);
+        let poly_z = PolyOverZ::from(&poly);
 
-        let cmp_poly =
-            PolyOverZ::from_str(&format!("4  0 1 102 {} mod {}", u64::MAX - 58, u64::MAX)).unwrap();
-        assert_eq!(cmp_poly, poly_q);
+        let cmp_poly = PolyOverZ::from_str(&format!("4  0 1 102 {}", u64::MAX - 58)).unwrap();
+        assert_eq!(cmp_poly, poly_z);
     }
 }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -30,7 +30,7 @@ impl ModulusPolynomialRingZq {
     ///
     /// let modulus = modulus_ring.get_q();
     ///
-    /// let cmp_modulus = Z:from(17);
+    /// let cmp_modulus = Z::from(17);
     /// assert_eq!(cmp_modulus, modulus);
     /// ```
     pub fn get_q(&self) -> Z {

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -9,12 +9,56 @@
 //! Implementations to get content of a
 //! [`ModulusPolynomialRingZq].
 
-use super::ModulusPolynomialRingZq;
-use flint_sys::fq::fq_ctx_struct;
+use crate::integer_mod_q::{Modulus, ModulusPolynomialRingZq};
+use flint_sys::{fmpz_mod::fmpz_mod_ctx_init, fq::fq_ctx_struct};
+use std::{mem::MaybeUninit, rc::Rc};
 
 impl ModulusPolynomialRingZq {
     /// Returns the [`fq_ctx_struct`] of a modulus and is only used internally.
     pub(crate) fn get_fq_ctx_struct(&self) -> &fq_ctx_struct {
         self.modulus.as_ref()
+    }
+
+    /// Returns a the prime q as a [`Modulus`]
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{ModulusPolynomialRingZq, Modulus};
+    /// use std::str::FromStr;
+    ///
+    /// let modulus_ring = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+    ///
+    /// let modulus = modulus_ring.get_q();
+    ///
+    /// # let cmp_modulus = Modulus::try_from(&17.into()).unwrap();
+    /// # assert_eq!(cmp_modulus, modulus);
+    /// ```
+    pub fn get_q(&self) -> Modulus {
+        let mut ctx = MaybeUninit::uninit();
+        unsafe {
+            fmpz_mod_ctx_init(ctx.as_mut_ptr(), &self.get_fq_ctx_struct().ctxp[0].n[0]);
+            Modulus {
+                modulus: Rc::new(ctx.assume_init()),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_get_q {
+    use crate::integer_mod_q::{Modulus, ModulusPolynomialRingZq};
+    use std::str::FromStr;
+
+    /// ensure that the same modulus is correctly returned for a large modulus
+    #[test]
+    fn correct_large() {
+        let modulus_ring =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX - 58))
+                .unwrap();
+
+        let modulus = modulus_ring.get_q();
+
+        let cmp_modulus = Modulus::try_from(&(u64::MAX - 58).into()).unwrap();
+        assert_eq!(cmp_modulus, modulus);
     }
 }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -18,7 +18,7 @@ impl ModulusPolynomialRingZq {
         self.modulus.as_ref()
     }
 
-    /// Returns the context integer as a [`Z`]
+    /// Returns the context integer as a [`Z`].
     ///
     /// # Examples
     /// ```
@@ -30,8 +30,8 @@ impl ModulusPolynomialRingZq {
     ///
     /// let modulus = modulus_ring.get_q();
     ///
-    /// # let cmp_modulus = Z:from(17);
-    /// # assert_eq!(cmp_modulus, modulus);
+    /// let cmp_modulus = Z:from(17);
+    /// assert_eq!(cmp_modulus, modulus);
     /// ```
     pub fn get_q(&self) -> Z {
         let mut out = Z::default();

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -18,7 +18,7 @@ impl ModulusPolynomialRingZq {
         self.modulus.as_ref()
     }
 
-    /// Returns a the prime q as a [`Modulus`]
+    /// Returns the context integer as a [`Z`]
     ///
     /// # Examples
     /// ```

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -90,6 +90,9 @@ impl From<&ModulusPolynomialRingZq> for PolyOverZq {
     /// - `modulus`: the context polynomial from which the coefficients are copied
     ///
     /// # Examples
+    ///
+    /// Returns the context [`PolyOverZq`] representing the modulus object
+    ///
     /// ```
     /// use qfall_math::integer_mod_q::{ModulusPolynomialRingZq, PolyOverZq};
     /// use std::str::FromStr;

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -91,7 +91,7 @@ impl From<&ModulusPolynomialRingZq> for PolyOverZq {
     ///
     /// # Examples
     ///
-    /// Returns the context [`PolyOverZq`] representing the modulus object
+    /// Returns the context [`PolyOverZq`] representing the modulus object.
     ///
     /// ```
     /// use qfall_math::integer_mod_q::{ModulusPolynomialRingZq, PolyOverZq};
@@ -101,8 +101,8 @@ impl From<&ModulusPolynomialRingZq> for PolyOverZq {
     ///
     /// let poly_zq = PolyOverZq::from(&modulus);
     ///
-    /// # let cmp_poly = PolyOverZq::from_str("4  1 0 0 1 mod 17").unwrap();
-    /// # assert_eq!(cmp_poly, poly_zq);
+    /// let cmp_poly = PolyOverZq::from_str("4  1 0 0 1 mod 17").unwrap();
+    /// assert_eq!(cmp_poly, poly_zq);
     /// ```
     fn from(modulus: &ModulusPolynomialRingZq) -> Self {
         let modulus_q = Modulus::try_from(&modulus.get_q()).unwrap();

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -96,7 +96,7 @@ impl PolyOverZq {
     ///
     /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
     ///
-    /// let poly_zq = PolyOverZq::from(&modulus);
+    /// let poly_zq = PolyOverZq::from_modulus_polynomial_ring_zq(&modulus);
     ///
     /// # let cmp_poly = PolyOverZq::from_str("4  1 0 0 1 mod 17").unwrap();
     /// # assert_eq!(cmp_poly, poly_zq);

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -83,7 +83,7 @@ impl From<(&PolyOverZ, &Modulus)> for PolyOverZq {
     }
 }
 
-impl PolyOverZq {
+impl From<&ModulusPolynomialRingZq> for PolyOverZq {
     /// Create a [`PolyOverZ`] from a [`ModulusPolynomialRingZq`].
     ///
     /// Parameters:
@@ -96,12 +96,12 @@ impl PolyOverZq {
     ///
     /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
     ///
-    /// let poly_zq = PolyOverZq::from_modulus_polynomial_ring_zq(&modulus);
+    /// let poly_zq = PolyOverZq::from(&modulus);
     ///
     /// # let cmp_poly = PolyOverZq::from_str("4  1 0 0 1 mod 17").unwrap();
     /// # assert_eq!(cmp_poly, poly_zq);
     /// ```
-    pub fn from_modulus_polynomial_ring_zq(modulus: &ModulusPolynomialRingZq) -> Self {
+    fn from(modulus: &ModulusPolynomialRingZq) -> Self {
         let mut out = PolyOverZq::from(&modulus.get_q());
         unsafe {
             fmpz_mod_poly_set(
@@ -111,15 +111,6 @@ impl PolyOverZq {
             )
         };
         out
-    }
-}
-
-impl From<&ModulusPolynomialRingZq> for PolyOverZq {
-    /// Converts a modulus of type [`ModulusPolynomialRingZq`]
-    /// to a [`PolyOverZq`] using
-    /// [`PolyOverZq::from_modulus_polynomial_ring_zq`].
-    fn from(modulus: &ModulusPolynomialRingZq) -> Self {
-        Self::from_modulus_polynomial_ring_zq(modulus)
     }
 }
 
@@ -179,12 +170,11 @@ impl FromStr for PolyOverZq {
 
 #[cfg(test)]
 mod test_from_poly_z_modulus {
+    use super::PolyOverZq;
     use crate::{
         integer::{PolyOverZ, Z},
         integer_mod_q::Modulus,
     };
-
-    use super::PolyOverZq;
     use std::str::FromStr;
 
     /// Test conversion of a [`PolyOverZ`] with small coefficients and small

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -102,7 +102,8 @@ impl From<&ModulusPolynomialRingZq> for PolyOverZq {
     /// # assert_eq!(cmp_poly, poly_zq);
     /// ```
     fn from(modulus: &ModulusPolynomialRingZq) -> Self {
-        let mut out = PolyOverZq::from(&modulus.get_q());
+        let modulus_q = Modulus::try_from(&modulus.get_q()).unwrap();
+        let mut out = PolyOverZq::from(&modulus_q);
         unsafe {
             fmpz_mod_poly_set(
                 &mut out.poly,

--- a/src/integer_mod_q/polynomial_ring_zq.rs
+++ b/src/integer_mod_q/polynomial_ring_zq.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 
 mod arithmetic;
 mod from;
+mod get;
 mod reduce;
 
 /// [`PolynomialRingZq`] represents polynomials over the finite field

--- a/src/integer_mod_q/polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/from.rs
@@ -36,37 +36,9 @@ impl From<(&PolyOverZ, &ModulusPolynomialRingZq)> for PolynomialRingZq {
     /// let poly_ring = PolynomialRingZq::from((&poly, &modulus));
     /// ```
     fn from(value: (&PolyOverZ, &ModulusPolynomialRingZq)) -> Self {
-        Self::from_poly_over_z_modulus_polynomial_ring_zq(value.0, value.1)
-    }
-}
-
-impl PolynomialRingZq {
-    /// Create a new polynomial ring object of type [`PolynomialRingZq`].
-    ///
-    /// Parameters:
-    /// - `poly`: the polynomial
-    /// - `modulus`: the modulus which defines the ring
-    ///
-    /// Returns a new element inside the polynomial ring.
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::integer_mod_q::PolynomialRingZq;
-    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
-    /// use qfall_math::integer::PolyOverZ;
-    /// use std::str::FromStr;
-    ///
-    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
-    /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
-    /// let poly_ring = PolynomialRingZq::from_poly_over_z_modulus_polynomial_ring_zq(&poly, &modulus);
-    /// ```
-    pub fn from_poly_over_z_modulus_polynomial_ring_zq(
-        poly: &PolyOverZ,
-        modulus: &ModulusPolynomialRingZq,
-    ) -> Self {
         let mut out = Self {
-            poly: poly.clone(),
-            modulus: modulus.clone(),
+            poly: value.0.clone(),
+            modulus: value.1.clone(),
         };
         out.reduce();
         out
@@ -90,12 +62,10 @@ mod test_from_poly_over_z_modulus_polynomial_ring_zq {
             ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
 
         let poly = PolyOverZ::from_str(&format!("4  {} {} 1 1", BITPRIME64 + 2, u64::MAX)).unwrap();
-        let poly_ring =
-            PolynomialRingZq::from_poly_over_z_modulus_polynomial_ring_zq(&poly, &modulus);
+        let poly_ring = PolynomialRingZq::from((&poly, &modulus));
 
         let cmp_poly = PolyOverZ::from_str("3  1 58 1").unwrap();
-        let cmp_poly_ring =
-            PolynomialRingZq::from_poly_over_z_modulus_polynomial_ring_zq(&cmp_poly, &modulus);
+        let cmp_poly_ring = PolynomialRingZq::from((&cmp_poly, &modulus));
 
         assert_eq!(poly_ring, cmp_poly_ring);
     }
@@ -107,10 +77,8 @@ mod test_from_poly_over_z_modulus_polynomial_ring_zq {
             ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
         let poly = PolyOverZ::from_str(&format!("4  {} {} 1 1", BITPRIME64 + 2, u64::MAX)).unwrap();
 
-        let poly_ring_1 =
-            PolynomialRingZq::from_poly_over_z_modulus_polynomial_ring_zq(&poly, &modulus);
-        let poly_ring_2 =
-            PolynomialRingZq::from_poly_over_z_modulus_polynomial_ring_zq(&poly, &modulus);
+        let poly_ring_1 = PolynomialRingZq::from((&poly, &modulus));
+        let poly_ring_2 = PolynomialRingZq::from((&poly, &modulus));
 
         assert_eq!(poly_ring_1, poly_ring_2);
     }

--- a/src/integer_mod_q/polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/get.rs
@@ -1,0 +1,99 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Implementations to get content of a
+//! [`PolynomialRingZq].
+
+use super::PolynomialRingZq;
+use crate::{integer::PolyOverZ, integer_mod_q::ModulusPolynomialRingZq};
+
+impl PolynomialRingZq {
+    /// Returns the modulus object of the [`PolynomialRingZq`] element.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::PolyOverZ;
+    /// use qfall_math::integer_mod_q::{PolynomialRingZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+    /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
+    /// let poly_ring = PolynomialRingZq::from((&poly, &modulus));
+    ///
+    /// # assert_eq!(modulus, poly_ring.get_mod());
+    /// ```
+    pub fn get_mod(&self) -> ModulusPolynomialRingZq {
+        self.modulus.clone()
+    }
+
+    /// Returns the representative polynomial of the [`PolynomialRingZq`] element.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::PolyOverZ;
+    /// use qfall_math::integer_mod_q::{PolynomialRingZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+    /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
+    /// let poly_ring = PolynomialRingZq::from((&poly, &modulus));
+    ///
+    /// let poly_z = poly_ring.get_value();
+    ///
+    /// # let cmp_poly = PolyOverZ::from_str("3  15 0 1").unwrap();
+    /// # assert_eq!(cmp_poly, poly_z);
+    /// ```
+    pub fn get_value(&self) -> PolyOverZ {
+        self.poly.clone()
+    }
+}
+
+#[cfg(test)]
+mod test_get_mod {
+    use crate::{
+        integer::PolyOverZ,
+        integer_mod_q::{ModulusPolynomialRingZq, PolynomialRingZq},
+    };
+    use std::str::FromStr;
+
+    /// ensure that the large modulus polynomial is returned correctly
+    #[test]
+    fn large_positive() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX - 58))
+                .unwrap();
+        let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
+        let poly_ring = PolynomialRingZq::from((&poly, &modulus));
+
+        assert_eq!(modulus, poly_ring.get_mod());
+    }
+}
+
+#[cfg(test)]
+mod test_get_value {
+    use crate::{
+        integer::PolyOverZ,
+        integer_mod_q::{ModulusPolynomialRingZq, PolynomialRingZq},
+    };
+    use std::str::FromStr;
+
+    /// ensure that the getter returns for large entries
+    #[test]
+    fn large_positive() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX - 58))
+                .unwrap();
+        let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
+        let poly_ring = PolynomialRingZq::from((&poly, &modulus));
+
+        let poly_z = poly_ring.get_value();
+
+        let cmp_poly = PolyOverZ::from_str(&format!("3  {} 0 1", u64::MAX - 60)).unwrap();
+        assert_eq!(cmp_poly, poly_z);
+    }
+}

--- a/src/integer_mod_q/polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/get.rs
@@ -85,9 +85,9 @@ mod test_get_value {
     /// ensure that the getter returns for large entries
     #[test]
     fn large_positive() {
+        let large_prime = u64::MAX - 58;
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX - 58))
-                .unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", large_prime)).unwrap();
         let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
         let poly_ring = PolynomialRingZq::from((&poly, &modulus));
 

--- a/src/integer_mod_q/polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/get.rs
@@ -25,7 +25,9 @@ impl PolynomialRingZq {
     /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
     /// let poly_ring = PolynomialRingZq::from((&poly, &modulus));
     ///
-    /// # assert_eq!(modulus, poly_ring.get_mod());
+    /// let poly_ring_mod = poly_ring.get_mod();
+    ///
+    /// assert_eq!(modulus, poly_ring_mod);
     /// ```
     pub fn get_mod(&self) -> ModulusPolynomialRingZq {
         self.modulus.clone()
@@ -43,12 +45,12 @@ impl PolynomialRingZq {
     /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
     /// let poly_ring = PolynomialRingZq::from((&poly, &modulus));
     ///
-    /// let poly_z = poly_ring.get_value();
+    /// let poly_z = poly_ring.get_poly();
     ///
-    /// # let cmp_poly = PolyOverZ::from_str("3  15 0 1").unwrap();
-    /// # assert_eq!(cmp_poly, poly_z);
+    /// let cmp_poly = PolyOverZ::from_str("3  15 0 1").unwrap();
+    /// assert_eq!(cmp_poly, poly_z);
     /// ```
-    pub fn get_value(&self) -> PolyOverZ {
+    pub fn get_poly(&self) -> PolyOverZ {
         self.poly.clone()
     }
 }
@@ -91,7 +93,7 @@ mod test_get_value {
         let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
         let poly_ring = PolynomialRingZq::from((&poly, &modulus));
 
-        let poly_z = poly_ring.get_value();
+        let poly_z = poly_ring.get_poly();
 
         let cmp_poly = PolyOverZ::from_str(&format!("3  {} 0 1", u64::MAX - 60)).unwrap();
         assert_eq!(cmp_poly, poly_z);


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Each PolynomialRingZq element consists of a modulus which is a PolyOverZq and a PolyOverZ. Users may want to access these polynomials. This PR makes it possible to get a copy of them in the repsective type. Additionally a PolyZq consists of a Modulus and a polynomial. This PR makes it possible to get a copy of the polynomial of the PolyZq.

This PR implements...
- [x] the `From` trait for `PolyOverZ` with input: `PolyOverZq`
- [x] the `From` trait for `PolyOverZ` with input: `PolynomialRingZq`
- [x] the `From` trait for `PolyOverZq` with input: `ModulusPolynomialRingZq`

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->
Mostly did one test for large positive integers and a test for small positive integers in the doctest.
Tests for negative integers are not needed, as the values are always positive for these three conversions.

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I included tests for all reasonable edge cases
- [x] I called the From-trait method
- [x] I called the `from_type` method
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
