### PR TITLE
Conversion from PolyOverZ to PolyOverQ

### DIFF
--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -88,7 +88,7 @@ impl PolyOverQ {
     ///
     /// let poly = PolyOverZ::from_str("4  0 1 102 3").unwrap();
     ///
-    /// let poly_q = PolyOverQ::from(&poly);
+    /// let poly_q = PolyOverQ::from_poly_over_z(&poly);
     ///
     /// # let cmp_poly = PolyOverQ::from_str("4  0 1 102 3").unwrap();
     /// # assert_eq!(cmp_poly, poly_q);


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

The coeffcients of a PolyOverQ are in Q, hence it makes sense to be able to convert a PolyOverZ into a PolyOverQ in a natural and easy way. This PR makes this easy conversion possible.

This PR implements...
- [x] the `From` trait for `PolyOverQ` with input: `PolyOverZ`

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I included tests for all reasonable edge cases
- [x] I called the From-trait method
- [x] I called the `from_type` method
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
