### PR TITLE
change `from_fmpz` for `z`

### DIFF
--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -665,7 +665,7 @@ mod test_from_fmpz {
 
     /// Ensure that `from_fmpz` is available for small and large numbers
     #[test]
-    fn large_number() {
+    fn large_numbers() {
         let mut fmpz_1 = fmpz(0);
         unsafe { fmpz_set_ui(&mut fmpz_1, u64::MAX) }
 


### PR DESCRIPTION
**Description**

- rename `from_fmpz` to `from_fmpz_ref`
- Add `from_fmpz` that takes ownership. 

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
