### PR TITLE
Rework qfromf64

### DIFF
--- a/src/rational/mat_q/arithmetic/mul_scalar.rs
+++ b/src/rational/mat_q/arithmetic/mul_scalar.rs
@@ -280,12 +280,12 @@ mod test_mul_q {
         let mat1 = MatQ::from_str("[[1/2],[0],[4]]").unwrap();
         let mat2 = MatQ::from_str("[[2,5,6],[1,3,1]]").unwrap();
         let mat3 = MatQ::from_str("[[5/4],[0],[10]]").unwrap();
-        let mat4 = MatQ::from_str("[[-1999/20],[0],[-3998/5]]").unwrap();
-        let mat5 = MatQ::from_str("[[357/5, 357/2, 1071/5],[357/10, 1071/10, 357/10]]").unwrap();
+        let mat4 = MatQ::from_str("[[-799/8],[0],[-799]]").unwrap();
+        let mat5 = MatQ::from_str("[[285/4, 1425/8, 855/4],[285/8, 855/8, 285/8]]").unwrap();
 
         assert_eq!(mat3, 2.5f32 * &mat1);
-        assert_eq!(mat4, -199.9f64 * mat1);
-        assert_eq!(mat5, mat2 * 35.7);
+        assert_eq!(mat4, -199.75f64 * mat1);
+        assert_eq!(mat5, mat2 * 35.625);
     }
 
     /// Checks if scalar multiplication works fine for matrices of different dimensions

--- a/src/rational/q/default.rs
+++ b/src/rational/q/default.rs
@@ -78,7 +78,8 @@ impl Q {
         },
     };
 
-    /// Returns an instantiation of [`Q`] with value `e ≈ 3.141592`.
+    /// Returns an instantiation of [`Q`] with value `e ≈ 2.718281...`
+    /// with a precision of ~ 10^-36.
     ///
     /// # Examples
     /// ```
@@ -87,13 +88,15 @@ impl Q {
     /// let a: Q = Q::E;
     /// ```
     pub const E: Q = Q {
+        // generated with continued fraction (40 factors)
         value: fmpq {
-            num: fmpz(543656365691809),
-            den: fmpz(200000000000000),
+            num: fmpz(2922842896378005707),
+            den: fmpz(1075253811351460636),
         },
     };
 
-    /// Returns an instantiation of [`Q`] with value `pi ≈ 3.141592`.
+    /// Returns an instantiation of [`Q`] with value `pi ≈ 3.141592...`
+    /// with a precision of ~ 10^-37.
     ///
     /// # Examples
     /// ```
@@ -102,9 +105,10 @@ impl Q {
     /// let a: Q = Q::PI;
     /// ```
     pub const PI: Q = Q {
+        // generated with continued fraction (33 factors)
         value: fmpq {
-            num: fmpz(3141592653589793),
-            den: fmpz(1000000000000000),
+            num: fmpz(2646693125139304345),
+            den: fmpz(842468587426513207),
         },
     };
 }
@@ -112,7 +116,6 @@ impl Q {
 #[cfg(test)]
 mod tests_init {
     use super::Q;
-    use std::f64::consts::{E, PI};
 
     /// Ensure that [`Default`] initializes [`Q`] with `0`.
     #[test]
@@ -136,17 +139,5 @@ mod tests_init {
     #[test]
     fn init_minus_one() {
         assert_eq!(Q::try_from((&-1, &1)).unwrap(), Q::MINUS_ONE);
-    }
-
-    /// Ensure that `E` initializes [`Q`] with `e ≈ 3.141592`.
-    #[test]
-    fn init_e() {
-        assert_eq!(Q::from(E), Q::E);
-    }
-
-    /// Ensure that `PI` initializes [`Q`] with `pi ≈ `.
-    #[test]
-    fn init_pi() {
-        assert_eq!(Q::from(PI), Q::PI);
     }
 }

--- a/src/rational/q/distance.rs
+++ b/src/rational/q/distance.rs
@@ -100,7 +100,7 @@ mod test_distance {
         let i_2 = a.distance(35_i32);
         let i_3 = a.distance(i64::MIN);
         let f_0 = a.distance(4.25_f32);
-        let f_1 = a.distance(15.7_f64);
+        let f_1 = a.distance(0.66015625_f64);
 
         assert_eq!(Q::ZERO, u_0);
         assert_eq!(Q::from(15), u_1);
@@ -111,6 +111,6 @@ mod test_distance {
         assert_eq!(Q::from(35), i_2);
         assert_eq!(Q::from(i64::MIN).abs(), i_3);
         assert_eq!(Q::try_from((&425, &100)).unwrap(), f_0);
-        assert_eq!(Q::try_from((&157, &10)).unwrap(), f_1);
+        assert_eq!(Q::try_from((&169, &256)).unwrap(), f_1);
     }
 }

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -199,9 +199,9 @@ impl Q {
     }
 
     /// Create a new rational number of type [`Q`] from a [`f64`].
-    /// This function works with the bit representation of the float it received as input.
-    /// Floats like `0.1` that are not completely representable,
-    /// will not be instantiated as `1/10`.
+    /// This function works with the exact float it received as input.
+    /// Many numbers like `0.1` are not exactly representable as floats and 
+    /// will therefore not be instantiated as `1/10`.
     ///
     /// Input parameters:
     /// - `value` : The value the rational number will have, provided as a [`f64`]
@@ -234,6 +234,7 @@ impl Q {
         // -52 because the mantissa is 52 bit long
         exponent -= 1023 + 52;
         let shift = match exponent {
+            // This could be optimized with `fmpz_lshift_mpn` once it is part of flint_sys.
             e if e >= 1 => Q::from(2).pow(e).unwrap(),
             e => Q::try_from((&1, &2)).unwrap().pow(e.abs()).unwrap(),
         };
@@ -627,15 +628,6 @@ mod test_from_float {
         f64::consts::{E, LN_10, LN_2},
         str::FromStr,
     };
-
-    /// test large fraction representation for float
-    #[test]
-    fn large_fractions() {
-        // can only be approximated, as it is not representable perfectly
-        let f = 0.000_400_000_000_000_000_1;
-        println!("{}", f);
-        println!("{}", Q::from(f));
-    }
 
     /// Test that a large number is correctly converted from float.
     #[test]

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -200,7 +200,7 @@ impl Q {
 
     /// Create a new rational number of type [`Q`] from a [`f64`].
     /// This function works with the exact float it received as input.
-    /// Many numbers like `0.1` are not exactly representable as floats and 
+    /// Many numbers like `0.1` are not exactly representable as floats and
     /// will therefore not be instantiated as `1/10`.
     ///
     /// Input parameters:

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -199,6 +199,9 @@ impl Q {
     }
 
     /// Create a new rational number of type [`Q`] from a [`f64`].
+    /// This function works with the bit representation of the float it received as input.
+    /// Floats like `0.1` that are not completely representable,
+    /// will not be instantiated as `1/10`.
     ///
     /// Input parameters:
     /// - `value` : The value the rational number will have, provided as a [`f64`]
@@ -298,6 +301,9 @@ impl<T: Into<Z>> From<T> for Q {
 
 impl From<f64> for Q {
     /// Create a new rational number of type [`Q`] from a [`f64`].
+    /// This function works with the bit representation of the float it received as input.
+    /// Floats like `0.1` that are not completely representable,
+    /// will not be instantiated as `1/10`.
     ///
     /// Input parameters:
     /// - `value` : The value the rational number will have, provided as a [`f64`]


### PR DESCRIPTION
**Description**

The current implementation of `Q::from_f64` was falty. This PR fixes it, such that all floats can be entered.
The new implementation looks at the value in memory, and takes the exact valeu represented. This means that values which can not be represented perfectly, will only use the bit represenatation from memory.
Subsequent changes had to be made to older tests, which either rounded or used lower precision.
This PR also updates the constant values for `e` and `pi` to 62 bit representation in denominator and numerator (more not possible due to Flints integer representation.

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements...
- [x] bugfix for `Q::from_f64`

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->
- [x] I adapted old tests
- [x] I added new tests for long floats

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
