### PR TITLE
Sqrt for `Q`

### DIFF
--- a/src/integer/z/arithmetic/root.rs
+++ b/src/integer/z/arithmetic/root.rs
@@ -60,7 +60,7 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::PrecisionNotPositive`]
-    ///   if the precision is negative.
+    ///   if the precision is not larger than zero.
     /// - Returns a [`MathError`] of type [`MathError::NegativeRootParameter`]
     ///   if the parameter of the square root is negative.
     pub fn sqrt_precision(&self, precision: &Z) -> Result<Q, MathError> {

--- a/src/integer/z/arithmetic/root.rs
+++ b/src/integer/z/arithmetic/root.rs
@@ -43,7 +43,7 @@ impl Z {
     ///
     /// Parameters:
     /// - `precision` specifies the upper limit of the error as `1/(2*precision)`.
-    ///   The precision must larger than zero.
+    ///   The precision must be larger than zero.
     ///
     /// Returns the square root with a specified minimum precision.
     ///

--- a/src/rational/q/arithmetic.rs
+++ b/src/rational/q/arithmetic.rs
@@ -14,4 +14,5 @@ mod div;
 mod exp;
 mod mul;
 mod pow;
+mod root;
 mod sub;

--- a/src/rational/q/arithmetic/root.rs
+++ b/src/rational/q/arithmetic/root.rs
@@ -7,6 +7,18 @@
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
 //! This module provides implementations for calculating roots on [`Q`].
+//!
+//! # Max Error Calculation:
+//! Notation:
+//! - `a/b` is the "correct" result
+//! - `e_a` and `e_b` are the error of `a` and `b` resp.
+//! - `p` is the maximum error of a sqrt on [`Z`] values
+//!  => `|e_a| <= p` and `|e_b| <= p`
+//!
+//! ```Q::sqrt(x/y) = (a+e_a)/(b+e_b) = a/b + (e_a*b - a*e_b)/(b*(b+e_b))```
+//!
+//! The Error is the largest with `e_a = p` and `e_b = -p`:
+//! ```|(e_a*b - a*e_b)/(b*(b+e_b))| <= (a/b + 1) * p/(b-p)```
 
 use crate::{error::MathError, integer::Z, rational::Q};
 
@@ -14,7 +26,8 @@ impl Q {
     /// Calculate the square root with a fixed relative precision.
     ///
     /// The maximum error can be described by:
-    /// `|sqrt_approximated(x/y)-sqrt(x/y) | <= x/y*10⁻⁹` ±?  
+    /// `Q::sqrt(x/y) = a/b` the maximum error to the true square root result
+    /// is limited by `(a/b + 1) * 10⁻⁹/(b-10⁻⁹)`
     /// The actual result may be more accurate.
     ///
     /// # Examples:
@@ -27,23 +40,26 @@ impl Q {
     /// assert_eq!(&root, &Q::try_from((&3,&2)).unwrap());
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::NegativeRootParameter`]
-    ///   if the parameter of the square root is negative.
-    pub fn sqrt(&self) -> Result<Q, MathError> {
-        let root_numerator = self.get_numerator().sqrt()?;
-        let root_denominator = self.get_denominator().sqrt()?;
+    /// # Panics ...
+    /// - if the provided value is negative.
+    pub fn sqrt(&self) -> Q {
+        let root_numerator = self.get_numerator().sqrt();
+        let root_denominator = self.get_denominator().sqrt();
 
-        Ok(root_numerator / root_denominator)
+        root_numerator / root_denominator
     }
 
     /// Calculate the square root with a specified minimum precision.
     ///
+    /// Given `Q::sqrt_precision(x/y,precision) = a/b` the maximum error to
+    /// the true square root result is `(a/b + 1) * p/(b-p)`
+    /// with `p = 1/(2*precision)`
     /// The actual result may be more accurate.
     ///
     /// Parameters:
-    /// - `precision` specifies the upper limit of the error as `1/(2*precision)`.
-    ///   A precision of less than one is treated the same as a precision of one.
+    /// - `precision` specifies the upper limit of the error.
+    ///
+    ///   The precision must larger than zero.
     ///
     /// # Examples
     /// ```
@@ -66,5 +82,85 @@ impl Q {
         let root_denominator = self.get_denominator().sqrt_precision(precision)?;
 
         Ok(root_numerator / root_denominator)
+    }
+}
+
+#[cfg(test)]
+mod test_sqrt {
+    use crate::{integer::Z, rational::Q};
+
+    /// Assert that sqrt of zero works correctly
+    #[test]
+    fn zero() {
+        let zero = Q::ZERO;
+
+        let res = zero.sqrt();
+
+        assert_eq!(res, Q::ZERO);
+    }
+
+    /// Assert that the root of a negative number results in an error.
+    #[test]
+    fn negative_value() {
+        let value = Q::from(-10);
+
+        let res = value.sqrt_precision(&Z::from(10));
+
+        assert!(res.is_err());
+    }
+
+    // TODO: this test might be correct, but fails because the f64 precision is to low.
+    /// Calculate sqrt of different values  with different precisions and
+    /// assert that the result meets the accuracy boundary.
+    #[test]
+    fn precision_correct() {
+        // TODO: add dividers
+        let values = vec![
+            Q::from(1),
+            Q::from(10),
+            Q::from(100000),
+            Q::from(i64::MAX),
+            Q::from(i64::MAX) * Q::from(i64::MAX),
+        ];
+        let precisions = vec![
+            Z::from(1),
+            Z::from(10),
+            Z::from(100000),
+            Z::from(i64::MAX),
+            // Z::from(i64::MAX) * Z::from(i64::MAX),
+        ];
+
+        // Test for all combinations of values and precisions
+        for value in values {
+            for precision in &precisions {
+                let root = value.sqrt_precision(precision).unwrap();
+
+                // Reasoning behind the following lines:
+                // v = value, p_q = max_allowed_error = (a/b + 1) * p_z/(b-p_z), r = root, |e|<= p_q (actual error)
+                // sqrt_precision(v,precision) = r = sqrt(x) + e
+                // => r^2 = x + 2*sqrt(x)*e + e^2
+                // => r^2-x = 2*sqrt(x)*e + e^2 = difference <= 2*sqrt(x)*p_q + p_q^2
+
+                let p_z = Q::try_from((&1, precision)).unwrap() / Q::from(2);
+
+                // TODO: clean up once arithmetic between Q and Z is better supported.
+                let p_q = (&root + Q::ONE) * &p_z / (Q::from(root.get_denominator()) - &p_z);
+
+                let root_squared = &root * &root;
+                let difference = root_squared - Q::from(value.clone());
+
+                // Use the root calculated with floating point numbers as
+                // an approximation of sqrt(x).
+                let root_from_float = Q::from((i64::MAX as f64).sqrt());
+                let precision_cmp = &Q::from(2) * &p_q * root_from_float + &p_q * &p_q;
+
+                println!(
+                    "value: {}\n result: {}\n difference: {} \n precision_cmp: {}",
+                    value, root, difference, precision_cmp
+                );
+                assert!(&difference > &(&Q::MINUS_ONE * &precision_cmp));
+                assert!(&difference < &precision_cmp);
+            }
+        }
     }
 }

--- a/src/rational/q/arithmetic/root.rs
+++ b/src/rational/q/arithmetic/root.rs
@@ -1,0 +1,70 @@
+// Copyright © 2023 Sven Moog
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module provides implementations for calculating roots on [`Q`].
+
+use crate::{error::MathError, integer::Z, rational::Q};
+
+impl Q {
+    /// Calculate the square root with a fixed relative precision.
+    ///
+    /// The maximum error can be described by:
+    /// `|sqrt_approximated(x/y)-sqrt(x/y) | <= x/y*10⁻⁹` ±?  
+    /// The actual result may be more accurate.
+    ///
+    /// # Examples:
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///
+    /// let value = Q::try_from((&9,&4)).unwrap();
+    /// let root = value.sqrt().unwrap();
+    ///
+    /// assert_eq!(&root, &Q::try_from((&3,&2)).unwrap());
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::NegativeRootParameter`]
+    ///   if the parameter of the square root is negative.
+    pub fn sqrt(&self) -> Result<Q, MathError> {
+        let root_numerator = self.get_numerator().sqrt()?;
+        let root_denominator = self.get_denominator().sqrt()?;
+
+        Ok(root_numerator / root_denominator)
+    }
+
+    /// Calculate the square root with a specified minimum precision.
+    ///
+    /// The actual result may be more accurate.
+    ///
+    /// Parameters:
+    /// - `precision` specifies the upper limit of the error as `1/(2*precision)`.
+    ///   A precision of less than one is treated the same as a precision of one.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::Z;
+    /// use qfall_math::rational::Q;
+    ///
+    /// let precision = Z::from(1000);
+    /// let value = Q::try_from((&9,&4)).unwrap();
+    ///
+    /// let root = value.sqrt_precision(&precision).unwrap();
+    ///
+    /// assert_eq!(&root, &Q::try_from((&3,&2)).unwrap());
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::NegativeRootParameter`]
+    ///   if the parameter of the square root is negative.
+    pub fn sqrt_precision(&self, precision: &Z) -> Result<Q, MathError> {
+        let root_numerator = self.get_numerator().sqrt_precision(precision)?;
+        let root_denominator = self.get_denominator().sqrt_precision(precision)?;
+
+        Ok(root_numerator / root_denominator)
+    }
+}

--- a/src/rational/q/arithmetic/root.rs
+++ b/src/rational/q/arithmetic/root.rs
@@ -54,12 +54,11 @@ impl Q {
     ///
     /// Given `Q::sqrt_precision(x/y,precision) = a/b` the maximum error to
     /// the true square root result is `a/b * (b + 1) * p/(b-p)`
-    /// with `p = 1/(2*precision)`
+    /// with `p = 1/(2*precision)`.
     /// The actual result may be more accurate.
     ///
     /// Parameters:
     /// - `precision` specifies the upper limit of the error.
-    ///
     ///   The precision must larger than zero.
     ///
     /// # Examples
@@ -76,6 +75,8 @@ impl Q {
     /// ```
     ///
     /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::PrecisionNotPositive`]
+    ///   if the precision is not larger than zero.
     /// - Returns a [`MathError`] of type [`MathError::NegativeRootParameter`]
     ///   if the parameter of the square root is negative.
     pub fn sqrt_precision(&self, precision: &Z) -> Result<Q, MathError> {
@@ -124,6 +125,7 @@ mod test_sqrt {
     #[test]
     fn square_rationals() {
         let values = vec![
+            Q::ZERO,
             Q::from((1, 3)),
             Q::from((10, 3)),
             Q::from((100000, 3)),
@@ -149,15 +151,16 @@ mod test_sqrt {
             Q::from((1, 3)),
             Q::from((10, 3)),
             Q::from((100000, 3)),
-            Q::from((i64::MAX, 1)),
-            Q::from((i64::MAX, i64::MAX - 1)) * Q::from(i64::MAX),
+            Q::from((u64::MAX, 1)),
+            Q::from((1, u64::MAX)),
+            Q::from((u64::MAX, u64::MAX - 1)) * Q::from(u64::MAX),
         ];
         let precisions = vec![
             Z::from(1),
             Z::from(10),
             Z::from(100000),
-            Z::from(i64::MAX),
-            Z::from(i64::MAX).pow(5).unwrap(),
+            Z::from(u64::MAX),
+            Z::from(u64::MAX).pow(5).unwrap(),
         ];
 
         // Test for all combinations of values and precisions


### PR DESCRIPTION
**Description**

Add `sqrt` and `sqrt_precision` for `Q` 

This PR implements...
- [x] `sqrt` for `Q` (fixed precision, panic) 
- [x] `sqrt_precision` for `Q` ( configurable precision, returns result)

Please also double check the calculation of the error bounds. It is in the module description.

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
