### PR TITLE
Refactor from for z

### DIFF
--- a/src/integer/mat_z/sample.rs
+++ b/src/integer/mat_z/sample.rs
@@ -83,7 +83,7 @@ mod test_sample_uniform {
     use crate::traits::{GetEntry, GetNumColumns, GetNumRows};
     use crate::{
         integer::{MatZ, Z},
-        integer_mod_q::{Modulus, Zq},
+        integer_mod_q::Modulus,
     };
     use std::str::FromStr;
 
@@ -135,7 +135,6 @@ mod test_sample_uniform {
     #[test]
     fn availability() {
         let modulus = Modulus::from_str("7").unwrap();
-        let zq = Zq::from_str("7 mod 10").unwrap();
         let z = Z::from(7);
 
         let _ = MatZ::sample_uniform(1, 1, &0u16, &7u8);
@@ -147,7 +146,6 @@ mod test_sample_uniform {
         let _ = MatZ::sample_uniform(1, 1, &0i64, &7i32);
         let _ = MatZ::sample_uniform(1, 1, &Z::ZERO, &7i64);
         let _ = MatZ::sample_uniform(1, 1, &0u8, &modulus);
-        let _ = MatZ::sample_uniform(1, 1, &0, &zq);
         let _ = MatZ::sample_uniform(1, 1, &0, &z);
     }
 

--- a/src/integer/poly_over_z/sample/uniform.rs
+++ b/src/integer/poly_over_z/sample/uniform.rs
@@ -77,7 +77,7 @@ impl PolyOverZ {
 mod test_sample_uniform {
     use crate::{
         integer::{PolyOverZ, Z},
-        integer_mod_q::{Modulus, Zq},
+        integer_mod_q::Modulus,
         traits::GetCoefficient,
     };
     use std::str::FromStr;
@@ -146,7 +146,6 @@ mod test_sample_uniform {
     #[test]
     fn availability() {
         let modulus = Modulus::from_str("7").unwrap();
-        let zq = Zq::from_str("7 mod 10").unwrap();
         let z = Z::from(7);
 
         let _ = PolyOverZ::sample_uniform(1u64, &0u16, &7u8);
@@ -158,7 +157,6 @@ mod test_sample_uniform {
         let _ = PolyOverZ::sample_uniform(1i16, &0i64, &7i32);
         let _ = PolyOverZ::sample_uniform(1i8, &Z::ZERO, &7i64);
         let _ = PolyOverZ::sample_uniform(1, &0u8, &modulus);
-        let _ = PolyOverZ::sample_uniform(1, &0, &zq);
         let _ = PolyOverZ::sample_uniform(1, &0, &z);
     }
 }

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -172,7 +172,7 @@ unsafe impl AsInteger for fmpz {
 
     /// Documentation at [`AsInteger::get_fmpz_ref`]
     fn get_fmpz_ref(&self) -> Option<&fmpz> {
-        Some(&self)
+        Some(self)
     }
 }
 

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -165,9 +165,7 @@ unsafe impl AsInteger for &fmpz {
 unsafe impl AsInteger for fmpz {
     /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
-        let mut value = fmpz(0);
-        fmpz_set(&mut value, &self);
-        value
+        (&self).into_fmpz()
     }
 
     /// Documentation at [`AsInteger::get_fmpz_ref`]

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright © 2023 Niklas Siemer, Sven Moog
 //
 // This file is part of qFALL-math.
 //
@@ -145,6 +145,34 @@ unsafe impl AsInteger for &Z {
     /// Documentation at [`AsInteger::get_fmpz_ref`]
     fn get_fmpz_ref(&self) -> Option<&fmpz> {
         Some(&self.value)
+    }
+}
+
+unsafe impl AsInteger for &fmpz {
+    /// Documentation at [`AsInteger::into_fmpz`]
+    unsafe fn into_fmpz(self) -> fmpz {
+        let mut value = fmpz(0);
+        fmpz_set(&mut value, self);
+        value
+    }
+
+    /// Documentation at [`AsInteger::get_fmpz_ref`]
+    fn get_fmpz_ref(&self) -> Option<&fmpz> {
+        Some(self)
+    }
+}
+
+unsafe impl AsInteger for fmpz {
+    /// Documentation at [`AsInteger::into_fmpz`]
+    unsafe fn into_fmpz(self) -> fmpz {
+        let mut value = fmpz(0);
+        fmpz_set(&mut value, &self);
+        value
+    }
+
+    /// Documentation at [`AsInteger::get_fmpz_ref`]
+    fn get_fmpz_ref(&self) -> Option<&fmpz> {
+        Some(&self)
     }
 }
 

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -185,6 +185,8 @@ impl<Integer: AsInteger + IntoZ> From<Integer> for Z {
     /// # Parameters:
     /// `value` must be a rust integer, [`Modulus`], or a reference of these types.
     ///
+    /// Returns a new [`Z`] with the value specified in the parameter.
+    ///
     /// # Examples:
     /// ```
     /// use qfall_math::integer::Z;

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -14,86 +14,13 @@
 
 use super::Z;
 use crate::{
-    error::MathError,
-    integer_mod_q::{Modulus, Zq},
-    macros::from::{from_trait, from_type},
+    error::MathError, integer_mod_q::Modulus, macros::for_others::implement_empty_trait_owned_ref,
+    traits::AsInteger,
 };
-use flint_sys::fmpz::{
-    fmpz, fmpz_combit, fmpz_get_si, fmpz_init_set_si, fmpz_init_set_ui, fmpz_set, fmpz_set_str,
-};
+use flint_sys::fmpz::{fmpz, fmpz_combit, fmpz_get_si, fmpz_set, fmpz_set_str};
 use std::{ffi::CString, str::FromStr};
 
 impl Z {
-    /// Create a new Integer that can grow arbitrary large.
-    ///
-    /// Parameters:
-    /// - `value`: the initial value the integer should have
-    ///
-    /// Returns the new integer.
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::integer::Z;
-    ///
-    /// let a: Z = Z::from_i64(42);
-    /// ```
-    pub fn from_i64(value: i64) -> Self {
-        let mut ret_value = fmpz(0);
-        unsafe { fmpz_init_set_si(&mut ret_value, value) }
-        Z { value: ret_value }
-    }
-
-    /// Create a new Integer that can grow arbitrary large.
-    ///
-    /// Parameters:
-    /// - `value`: the initial value the integer should have
-    ///
-    /// Returns the new integer.
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::integer::Z;
-    ///
-    /// let a: Z = Z::from_u64(42);
-    /// ```
-    pub fn from_u64(value: u64) -> Self {
-        let mut ret_value = fmpz(0);
-        unsafe { fmpz_init_set_ui(&mut ret_value, value) }
-        Z { value: ret_value }
-    }
-
-    // Generate from_<type> functions for singed and unsigned source types.
-    from_type!(i32, i64, Z, Z::from_i64);
-    from_type!(i16, i64, Z, Z::from_i64);
-    from_type!(i8, i64, Z, Z::from_i64);
-
-    from_type!(u32, u64, Z, Z::from_u64);
-    from_type!(u16, u64, Z, Z::from_u64);
-    from_type!(u8, u64, Z, Z::from_u64);
-
-    /// Create a new Integer that can grow arbitrary large.
-    ///
-    /// Parameters:
-    /// - `value`: the initial value the integer should have
-    ///
-    /// Returns the new integer.
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::integer::Z;
-    /// use qfall_math::integer_mod_q::Modulus;
-    /// use std::str::FromStr;
-    ///
-    /// let m = Modulus::from_str("42").unwrap();
-    ///
-    /// let a: Z = Z::from_modulus(&m);
-    /// ```
-    pub fn from_modulus(value: &Modulus) -> Self {
-        let mut out = Z::default();
-        unsafe { fmpz_set(&mut out.value, &value.get_fmpz_mod_ctx_struct().n[0]) };
-        out
-    }
-
     #[allow(dead_code)]
     /// Create a new Integer that can grow arbitrary large.
     ///
@@ -123,7 +50,7 @@ impl Z {
     ///
     /// let a: Z = Z::from_fmpz_ref(&value);
     ///
-    /// unsafe{fmpz_clear(&value)}
+    /// unsafe{fmpz_clear(&mut value)}
     /// ```
     pub(crate) fn from_fmpz_ref(value: &fmpz) -> Self {
         let mut out = Z::default();
@@ -157,26 +84,6 @@ impl Z {
     /// ```
     pub(crate) fn from_fmpz(value: fmpz) -> Self {
         Z { value }
-    }
-
-    /// Create a new Integer that can grow arbitrary large.
-    ///
-    /// Parameters:
-    /// - `value`: the initial value the integer should have
-    ///
-    /// Returns the new integer.
-    ///
-    /// ```
-    /// use qfall_math::integer::Z;
-    /// use qfall_math::integer_mod_q::Zq;
-    /// use std::str::FromStr;
-    ///
-    /// let m = Zq::from_str("13 mod 17").unwrap();
-    ///
-    /// let a: Z = Z::from_zq(m);
-    /// ```
-    pub fn from_zq(value: Zq) -> Self {
-        value.value
     }
 
     /// Create a [`Z`] integer from a [`String`]. This function takes a base in which the number is represented between `2` and `62`
@@ -265,32 +172,37 @@ impl Z {
     }
 }
 
-impl From<&Modulus> for Z {
-    /// Convert [`Modulus`] to [`Z`] using [`Z::from_modulus`].
-    fn from(value: &Modulus) -> Self {
-        Z::from_modulus(value)
+/// A trait that indicates for which types the `From for Z` should be implemented.
+/// It is used as a workaround to implement the [`From`] trait without colliding
+/// with the default implementation for [`Z`] and also to filter out [`Zq`](crate::integer_mod_q::Zq).
+trait IntoZ {}
+
+implement_empty_trait_owned_ref!(IntoZ for Modulus u8 u16 u32 u64 i8 i16 i32 i64);
+
+impl<Integer: AsInteger + IntoZ> From<Integer> for Z {
+    /// Convert an integer to [`Z`].
+    ///
+    /// # Parameters:
+    /// `value` must be a rust integer, [`Modulus`], or a reference of these types.
+    ///
+    /// # Examples:
+    /// ```
+    /// use qfall_math::integer::Z;
+    ///
+    /// let a = Z::from(10);
+    /// let b = Z::from(i64::MAX);
+    /// let c = Z::from(&u64::MAX);
+    /// ```
+    fn from(value: Integer) -> Self {
+        match value.get_fmpz_ref() {
+            Some(val) => Z::from_fmpz_ref(val),
+            None => unsafe {
+                let value = value.into_fmpz();
+                Z { value }
+            },
+        }
     }
 }
-
-impl From<Modulus> for Z {
-    /// Convert [`Modulus`] to [`Z`] using [`Z::from_modulus`].
-    fn from(value: Modulus) -> Self {
-        Z::from_modulus(&value)
-    }
-}
-
-// Generate [`From`] trait for the different types.
-from_trait!(i64, Z, Z::from_i64);
-from_trait!(i32, Z, Z::from_i32);
-from_trait!(i16, Z, Z::from_i16);
-from_trait!(i8, Z, Z::from_i8);
-
-from_trait!(u64, Z, Z::from_u64);
-from_trait!(u32, Z, Z::from_u32);
-from_trait!(u16, Z, Z::from_u16);
-from_trait!(u8, Z, Z::from_u8);
-
-from_trait!(Zq, Z, Z::from_zq);
 
 impl FromStr for Z {
     type Err = MathError;
@@ -435,79 +347,77 @@ mod test_from_bytes {
 }
 
 #[cfg(test)]
+/// Test the different implementations for types that implement [`AsInteger`] and [`IntoZ`]
 mod tests_from_int {
-    use super::Z;
-
-    /// Ensure that initialization with large numbers works.
-    /// Numbers larger than 2^62 bits are represented differently in FLINT.
-    #[test]
-    fn from_i64_max_positive() {
-        Z::from_i64(i64::MAX);
-    }
-
-    /// Ensure that initialization with large negative numbers works.
-    /// Numbers smaller than -2^62 bits are represented differently in FLINT.
-    #[test]
-    fn from_i64_max_negative() {
-        Z::from_i64(i64::MIN);
-    }
-
-    /// Ensure that the [`From`] trait is available for i64 values
-    #[test]
-    fn from_i64_trait() {
-        let _ = Z::from(-10i64);
-    }
-
-    /// Ensure that the `from_<type_name>` functions are available for
-    /// singed and unsigned integers of 8, 16, 32, and 64 bit length.
-    /// Tested with their maximum value.
-    #[test]
-    fn from_functions_max() {
-        // signed
-        let _ = Z::from_i8(i8::MAX);
-        let _ = Z::from_i16(i16::MAX);
-        let _ = Z::from_i32(i32::MAX);
-        let _ = Z::from_i64(i64::MAX);
-
-        // unsigned
-        let _ = Z::from_u8(u8::MAX);
-        let _ = Z::from_u16(u16::MAX);
-        let _ = Z::from_u32(u32::MAX);
-        let _ = Z::from_u64(u64::MAX);
-    }
+    use super::*;
+    use crate::integer_mod_q::Modulus;
 
     /// Ensure that the [`From`] trait is available for singed and unsigned integers
-    /// of 8, 16, 32, and 64 bit length. Tested with their maximum value.
+    /// of 8, 16, 32, and 64 bit length and for their owned and borrowed variants.
+    /// Tested with their maximum value.
     #[test]
-    fn from_trait_max() {
+    fn rust_int_max() {
         // signed
         let _ = Z::from(i8::MAX);
         let _ = Z::from(i16::MAX);
         let _ = Z::from(i32::MAX);
         let _ = Z::from(i64::MAX);
+        let _ = Z::from(&i8::MAX);
+        let _ = Z::from(&i16::MAX);
+        let _ = Z::from(&i32::MAX);
+        let _ = Z::from(&i64::MAX);
 
         // unsigned
         let _ = Z::from(u8::MAX);
         let _ = Z::from(u16::MAX);
         let _ = Z::from(u32::MAX);
         let _ = Z::from(u64::MAX);
+        let _ = Z::from(&u8::MAX);
+        let _ = Z::from(&u16::MAX);
+        let _ = Z::from(&u32::MAX);
+        let _ = Z::from(&u64::MAX);
     }
 
     /// Ensure that the [`From`] trait is available for singed and unsigned integers
-    /// of 8, 16, 32, and 64 bit length. Tested with their minimum value.
+    /// of 8, 16, 32, and 64 bit length and for their owned and borrowed variants.
+    /// Tested with their minimum value.
     #[test]
-    fn from_trait_min() {
+    fn rust_int_min() {
         // signed
         let _ = Z::from(i8::MIN);
         let _ = Z::from(i16::MIN);
         let _ = Z::from(i32::MIN);
         let _ = Z::from(i64::MIN);
+        let _ = Z::from(&i8::MIN);
+        let _ = Z::from(&i16::MIN);
+        let _ = Z::from(&i32::MIN);
+        let _ = Z::from(&i64::MIN);
 
         // unsigned
         let _ = Z::from(u8::MIN);
         let _ = Z::from(u16::MIN);
         let _ = Z::from(u32::MIN);
         let _ = Z::from(u64::MIN);
+        let _ = Z::from(&u8::MIN);
+        let _ = Z::from(&u16::MIN);
+        let _ = Z::from(&u32::MIN);
+        let _ = Z::from(&u64::MIN);
+    }
+
+    /// Ensure that the [`From`] trait is available for small and large,
+    /// borrowed and owned [`Modulus`] instances.
+    #[test]
+    fn modulus() {
+        let val_1 = Z::from(u64::MAX);
+        let mod_1 = Modulus::try_from(&val_1).unwrap();
+        let val_2 = Z::from(10);
+        let mod_2 = Modulus::try_from(&val_2).unwrap();
+
+        assert_eq!(val_1, Z::from(&mod_1));
+        assert_eq!(val_2, Z::from(&mod_2));
+
+        assert_eq!(val_1, Z::from(mod_1));
+        assert_eq!(val_2, Z::from(mod_2));
     }
 }
 
@@ -618,36 +528,6 @@ mod test_from_str_b {
 }
 
 #[cfg(test)]
-mod test_from_modulus {
-    use super::Z;
-    use crate::integer_mod_q::Modulus;
-    use std::str::FromStr;
-
-    /// Ensure that `from_modulus` is available for small and large numbers
-    #[test]
-    fn large_and_small_numbers() {
-        let mod_1 = Modulus::from_str(&"1".repeat(65)).unwrap();
-        let mod_2 = Modulus::from_str("10").unwrap();
-
-        let _ = Z::from_modulus(&mod_1);
-        let _ = Z::from_modulus(&mod_2);
-    }
-
-    /// Ensure that the [`From`] trait is available for large
-    /// [`Modulus`] instances
-    #[test]
-    fn from_trait() {
-        let mod_1 = Modulus::from_str(&"1".repeat(65)).unwrap();
-        let mod_2 = Modulus::from_str("10").unwrap();
-
-        let _ = Z::from(&mod_1);
-        let _ = Z::from(&mod_2);
-        let _ = Z::from(mod_1);
-        let _ = Z::from(mod_2);
-    }
-}
-
-#[cfg(test)]
 mod test_from_fmpz {
     use flint_sys::fmpz::{fmpz, fmpz_set_ui};
 
@@ -685,34 +565,6 @@ mod test_from_fmpz_ref {
 
         let _ = Z::from_fmpz_ref(&mod_1.value);
         let _ = Z::from_fmpz_ref(&mod_2.value);
-    }
-}
-
-#[cfg(test)]
-mod test_from_zq {
-    use super::Z;
-    use crate::integer_mod_q::Zq;
-
-    /// Ensure that the `from_zq` function is available and works correctly for
-    /// small and large [`Zq`] entries.
-    #[test]
-    fn large_small_numbers() {
-        let zq_1 = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
-        let zq_2 = Zq::try_from((17, u64::MAX)).unwrap();
-
-        assert_eq!(Z::from(i64::MAX), Z::from_zq(zq_1));
-        assert_eq!(Z::from(17), Z::from_zq(zq_2));
-    }
-
-    /// Ensure that the [`From`] trait is available for small and large
-    /// [`Zq`] instances.
-    #[test]
-    fn from_trait() {
-        let zq_1 = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
-        let zq_2 = Zq::try_from((17, u64::MAX)).unwrap();
-
-        assert_eq!(Z::from(i64::MAX), Z::from(zq_1));
-        assert_eq!(Z::from(17), Z::from(zq_2));
     }
 }
 

--- a/src/integer/z/sample/uniform.rs
+++ b/src/integer/z/sample/uniform.rs
@@ -55,10 +55,7 @@ impl Z {
 
 #[cfg(test)]
 mod test_sample_uniform {
-    use crate::{
-        integer::Z,
-        integer_mod_q::{Modulus, Zq},
-    };
+    use crate::{integer::Z, integer_mod_q::Modulus};
     use std::str::FromStr;
 
     /// Checks whether the boundaries of the interval are kept for small intervals.
@@ -107,7 +104,6 @@ mod test_sample_uniform {
     #[test]
     fn availability() {
         let modulus = Modulus::from_str("7").unwrap();
-        let zq = Zq::from_str("7 mod 10").unwrap();
         let z = Z::from(7);
 
         let _ = Z::sample_uniform(&0u16, &7u8);
@@ -119,7 +115,6 @@ mod test_sample_uniform {
         let _ = Z::sample_uniform(&0i64, &7i32);
         let _ = Z::sample_uniform(&Z::ZERO, &7i64);
         let _ = Z::sample_uniform(&0u8, &modulus);
-        let _ = Z::sample_uniform(&0, &zq);
         let _ = Z::sample_uniform(&0, &z);
     }
 

--- a/src/integer_mod_q/mat_zq/sample.rs
+++ b/src/integer_mod_q/mat_zq/sample.rs
@@ -79,7 +79,7 @@ mod test_sample_uniform {
     use crate::traits::{GetEntry, GetNumColumns, GetNumRows};
     use crate::{
         integer::Z,
-        integer_mod_q::{MatZq, Modulus, Zq},
+        integer_mod_q::{MatZq, Modulus},
     };
     use std::str::FromStr;
 
@@ -127,7 +127,6 @@ mod test_sample_uniform {
     #[test]
     fn availability() {
         let modulus = Modulus::from_str("7").unwrap();
-        let zq = Zq::from_str("7 mod 10").unwrap();
         let z = Z::from(7);
 
         let _ = MatZq::sample_uniform(1, 1, &7u8);
@@ -139,7 +138,6 @@ mod test_sample_uniform {
         let _ = MatZq::sample_uniform(1, 1, &7i32);
         let _ = MatZq::sample_uniform(1, 1, &7i64);
         let _ = MatZq::sample_uniform(1, 1, &modulus);
-        let _ = MatZq::sample_uniform(1, 1, &zq);
         let _ = MatZq::sample_uniform(1, 1, &z);
     }
 

--- a/src/integer_mod_q/modulus.rs
+++ b/src/integer_mod_q/modulus.rs
@@ -18,6 +18,7 @@ use flint_sys::fmpz_mod::fmpz_mod_ctx;
 use std::rc::Rc;
 
 mod cmp;
+mod fmpz_helpers;
 mod from;
 mod get;
 mod ownership;

--- a/src/integer_mod_q/modulus/fmpz_helpers.rs
+++ b/src/integer_mod_q/modulus/fmpz_helpers.rs
@@ -1,0 +1,41 @@
+// Copyright © 2023 Sven Moog
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains functions that interact between [`fmpz`] and [`Modulus`].
+
+use super::Modulus;
+use crate::traits::AsInteger;
+use flint_sys::fmpz::{fmpz, fmpz_init_set};
+
+unsafe impl AsInteger for Modulus {
+    /// Documentation at [`AsInteger::into_fmpz`]
+    unsafe fn into_fmpz(self) -> fmpz {
+        let mut out = fmpz(0);
+        fmpz_init_set(&mut out, &self.modulus.n[0]);
+        out
+    }
+
+    /// Documentation at [`AsInteger::get_fmpz_ref`]
+    fn get_fmpz_ref(&self) -> Option<&fmpz> {
+        Some(&self.modulus.n[0])
+    }
+}
+
+unsafe impl AsInteger for &Modulus {
+    /// Documentation at [`AsInteger::into_fmpz`]
+    unsafe fn into_fmpz(self) -> fmpz {
+        let mut out = fmpz(0);
+        fmpz_init_set(&mut out, &self.modulus.n[0]);
+        out
+    }
+
+    /// Documentation at [`AsInteger::get_fmpz_ref`]
+    fn get_fmpz_ref(&self) -> Option<&fmpz> {
+        Some(&self.modulus.n[0])
+    }
+}

--- a/src/integer_mod_q/modulus/fmpz_helpers.rs
+++ b/src/integer_mod_q/modulus/fmpz_helpers.rs
@@ -15,9 +15,7 @@ use flint_sys::fmpz::{fmpz, fmpz_init_set};
 unsafe impl AsInteger for Modulus {
     /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
-        let mut out = fmpz(0);
-        fmpz_init_set(&mut out, &self.modulus.n[0]);
-        out
+        (&self).into_fmpz()
     }
 
     /// Documentation at [`AsInteger::get_fmpz_ref`]

--- a/src/integer_mod_q/poly_over_zq/sample/uniform.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/uniform.rs
@@ -74,7 +74,7 @@ impl PolyOverZq {
 mod test_sample_uniform {
     use crate::{
         integer::Z,
-        integer_mod_q::{Modulus, PolyOverZq, Zq},
+        integer_mod_q::{Modulus, PolyOverZq},
         traits::GetCoefficient,
     };
     use std::str::FromStr;
@@ -137,7 +137,6 @@ mod test_sample_uniform {
     #[test]
     fn availability() {
         let modulus = Modulus::from_str("7").unwrap();
-        let zq = Zq::from_str("7 mod 10").unwrap();
         let z = Z::from(7);
 
         let _ = PolyOverZq::sample_uniform(1u64, &0u16);
@@ -149,7 +148,6 @@ mod test_sample_uniform {
         let _ = PolyOverZq::sample_uniform(1i16, &0i64);
         let _ = PolyOverZq::sample_uniform(1i8, &Z::ONE);
         let _ = PolyOverZq::sample_uniform(1, &z);
-        let _ = PolyOverZq::sample_uniform(1, &zq);
         let _ = PolyOverZq::sample_uniform(1, &modulus);
     }
 }

--- a/src/integer_mod_q/z_q/distance.rs
+++ b/src/integer_mod_q/z_q/distance.rs
@@ -73,7 +73,7 @@ impl Distance<&Zq> for Zq {
     /// is calculated to `self`
     ///
     /// Returns the absolute minimum distance between the two given values as a new
-    /// [`Z`] instance or a [`MathError`] if the moduli mismatch.
+    /// [`Z`] instance.
     ///
     /// # Examples
     /// ```
@@ -98,6 +98,17 @@ impl Distance<&Zq> for Zq {
     }
 }
 
+impl Distance<Zq> for Zq {
+    type Output = Z;
+
+    // This reference links to the correct distance implementation
+    // just because the correct one is the first in this file.
+    /// Just calls [`Zq::distance<&Zq>`].
+    fn distance(&self, other: Zq) -> Self::Output {
+        self.distance(&other)
+    }
+}
+
 impl<T: Into<Z>> Distance<T> for Zq {
     type Output = Z;
 
@@ -108,7 +119,7 @@ impl<T: Into<Z>> Distance<T> for Zq {
     /// is calculated to `self`
     ///
     /// Returns the absolute minimum distance between the two given values as a new
-    /// [`Z`] instance or a [`MathError`] if the moduli mismatch.
+    /// [`Z`] instance.
     ///
     /// # Examples
     /// ```
@@ -126,9 +137,6 @@ impl<T: Into<Z>> Distance<T> for Zq {
     /// assert_eq!(Z::from(6), distance_0);
     /// assert_eq!(Z::from(2), distance_1);
     /// ```
-    ///
-    /// # Panics ...
-    /// - if the provided moduli mismatch.
     fn distance(&self, other: T) -> Self::Output {
         let other = Zq::from_z_modulus(&other.into(), &self.modulus.clone());
         self.distance(&other)

--- a/src/integer_mod_q/z_q/get.rs
+++ b/src/integer_mod_q/z_q/get.rs
@@ -16,6 +16,9 @@ use crate::{
 impl Zq {
     /// Returns the [`Z`] value of the [`Zq`] element.
     ///
+    /// The representation in the range `[0,modulus[` (`0` inclusive, `modulus` exclusive)
+    /// is returned.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::Zq;

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -102,7 +102,6 @@ mod test_sample_uniform {
     #[test]
     fn availability() {
         let modulus = Modulus::from_str("7").unwrap();
-        let zq = Zq::from_str("7 mod 10").unwrap();
         let z = Z::from(7);
 
         let _ = Zq::sample_uniform(&7u8);
@@ -114,7 +113,6 @@ mod test_sample_uniform {
         let _ = Zq::sample_uniform(&7i32);
         let _ = Zq::sample_uniform(&7i64);
         let _ = Zq::sample_uniform(&modulus);
-        let _ = Zq::sample_uniform(&zq);
         let _ = Zq::sample_uniform(&z);
     }
 

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -389,3 +389,22 @@ macro_rules! implement_for_owned {
 }
 
 pub(crate) use implement_for_owned;
+
+/// Implements a trait with an empty implementation for the specified types
+/// and their references.
+/// This macro be used for empty traits or to use just the
+/// default implementation of a trait.
+///
+/// # Examples
+/// ```compile_fail
+/// implement_empty_trait!(IntoZ for u8 u16 u32 u64 i8 i16 i32 i64);
+/// ```
+macro_rules! implement_empty_trait_owned_ref {
+    ($trait_name:ident for $($type:ty)*) => {
+      $(
+        impl $trait_name for $type {}
+        impl $trait_name for &$type {}
+      )*
+    };
+}
+pub(crate) use implement_empty_trait_owned_ref;


### PR DESCRIPTION
**Description**
1. Rework the `From` trait for `Z` to use generics.
As a result, the documentation is shorter and references of rust integers are now also supported.

2. `Zq` can no longer be converted into `Z` with the from trait.
The reason for this is, that it is unclear which representation will be taken.
e.g. 3 mod 5 into 3, 8, 13, or ...?
For this reason, we prefer a dedicated function with an appropriate documentation (`get_value`).
As discussed during lunch.
     => Remove uses of `Z::from(Zq)` and `Z::from(&Zq)` (Sampling and distance)
    
3. Also fix doc comment for `Zq::distance`.
**Testing**
Some test cases have been joined (Modulus test into tests_from_int since it uses that Generic implementation)
Added test cases for the reference types, otherwise relied on existing test cases.

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
