### PR TITLE
MatZ `sample_discrete_gauss`

### DIFF
--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -13,7 +13,7 @@ use crate::{
     integer::{MatZ, Z},
     rational::{MatQ, Q},
     traits::{GetNumColumns, GetNumRows, SetEntry},
-    utils::sample::discrete_gauss::sample_d,
+    utils::sample::discrete_gauss::{sample_d, sample_z},
 };
 use std::fmt::Display;
 
@@ -37,7 +37,7 @@ impl MatZ {
     /// ```
     /// use qfall_math::integer::MatZ;
     ///
-    /// let sample = MatZ::sample_discrete_gauss(3, 1, &1024, &0, &1.25f32).unwrap();
+    /// let sample = MatZ::sample_discrete_gauss(3, 1, 1024, 0, 1.25f32).unwrap();
     /// ```
     ///
     /// # Errors and Failures
@@ -51,20 +51,23 @@ impl MatZ {
     pub fn sample_discrete_gauss<T1, T2, T3>(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
-        n: &T1,
-        center: &T2,
-        s: &T3,
+        n: T1,
+        center: T2,
+        s: T3,
     ) -> Result<MatZ, MathError>
     where
-        T1: Into<Z> + Clone,
-        T2: Into<Q> + Clone,
-        T3: Into<Q> + Clone,
+        T1: Into<Z>,
+        T2: Into<Q>,
+        T3: Into<Q>,
     {
         let mut out = Self::new(num_rows, num_cols)?;
+        let n: Z = n.into();
+        let center: Q = center.into();
+        let s: Q = s.into();
 
         for row in 0..out.get_num_rows() {
             for col in 0..out.get_num_columns() {
-                let sample = Z::sample_discrete_gauss(n, center, s)?;
+                let sample = sample_z(&n, &center, &s)?;
                 out.set_entry(row, col, sample)?;
             }
         }
@@ -92,7 +95,7 @@ impl MatZ {
     /// let basis = MatZ::identity(5, 5).unwrap();
     /// let center = MatQ::new(5, 1).unwrap();
     ///
-    /// let sample = MatZ::sample_d(&basis, &1024, &center, &1.25f32).unwrap();
+    /// let sample = MatZ::sample_d(&basis, 1024, &center, 1.25f32).unwrap();
     /// ```
     ///
     /// # Errors and Failures
@@ -108,13 +111,13 @@ impl MatZ {
     /// Trapdoors for hard lattices and new cryptographic constructions.
     /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
     /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
-    pub fn sample_d<T1, T2>(basis: &MatZ, n: &T1, center: &MatQ, s: &T2) -> Result<Self, MathError>
+    pub fn sample_d<T1, T2>(basis: &MatZ, n: T1, center: &MatQ, s: T2) -> Result<Self, MathError>
     where
-        T1: Into<Z> + Clone,
-        T2: Into<Q> + Clone,
+        T1: Into<Z>,
+        T2: Into<Q>,
     {
-        let n: Z = n.to_owned().into();
-        let s: Q = s.to_owned().into();
+        let n: Z = n.into();
+        let s: Q = s.into();
 
         sample_d(basis, &n, center, &s)
     }
@@ -130,8 +133,8 @@ mod test_sample_discrete_gauss {
     // This function only allows for a broader availability, which is tested here.
 
     /// Checks whether `sample_discrete_gauss` is available for all types
-    /// implementing Into<Z> + Clone, i.e. u8, u16, u32, u64, i8, ...
-    /// or Into<Q> + Clone, i.e. u8, i16, f32, Z, Q, ...
+    /// implementing Into<Z>, i.e. u8, u16, u32, u64, i8, ...
+    /// or Into<Q>, i.e. u8, i16, f32, Z, Q, ...
     #[test]
     fn availability() {
         let n = Z::from(1024);
@@ -139,18 +142,20 @@ mod test_sample_discrete_gauss {
         let s = Q::ONE;
 
         let _ = MatZ::sample_discrete_gauss(2u64, 3i8, &16u16, &center, &1u16);
-        let _ = MatZ::sample_discrete_gauss(3u8, 2i16, &2u32, &center, &1u8);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2u64, &center, &1u32);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2i8, &center, &1u64);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2i16, &center, &1i64);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2i32, &center, &1i32);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2i64, &center, &1i16);
+        let _ = MatZ::sample_discrete_gauss(3u8, 2i16, &200u32, &center, &1u8);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &200u64, &center, 1u32);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &40i8, &center, &1u64);
+        let _ = MatZ::sample_discrete_gauss(1, 1, 200i16, &center, &1i64);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &200i32, &center, &1i32);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &200i64, &center, &1i16);
         let _ = MatZ::sample_discrete_gauss(1, 1, &n, &center, &1i8);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2u8, &center, &1i64);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2, &center, &n);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2, &center, &s);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2, &center, &1.25f64);
-        let _ = MatZ::sample_discrete_gauss(1, 1, &2, &center, &15.75f32);
+        let _ = MatZ::sample_discrete_gauss(1, 1, 2u8, &center, &1i64);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &200, &center, &n);
+        let _ = MatZ::sample_discrete_gauss(1, 1, 200, &center, &s);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &200, &1, &s);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &200, 2.25, &s);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &200, &center, 1.25f64);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &200, &center, 15.75f32);
     }
 }
 
@@ -165,8 +170,8 @@ mod test_sample_d {
     // This function only allows for a broader availability, which is tested here.
 
     /// Checks whether `sample_d` is available for all types
-    /// implementing Into<Z> + Clone, i.e. u8, u16, u32, u64, i8, ...
-    /// or Into<Q> + Clone, i.e. u8, i16, f32, Z, Q, ...
+    /// implementing Into<Z>, i.e. u8, u16, u32, u64, i8, ...
+    /// or Into<Q>, i.e. u8, i16, f32, Z, Q, ...
     #[test]
     fn availability() {
         let basis = MatZ::identity(5, 5).unwrap();
@@ -185,7 +190,7 @@ mod test_sample_d {
         let _ = MatZ::sample_d(&basis, &2u8, &center, &1i64);
         let _ = MatZ::sample_d(&basis, &2, &center, &n);
         let _ = MatZ::sample_d(&basis, &2, &center, &s);
-        let _ = MatZ::sample_d(&basis, &2, &center, &1.25f64);
-        let _ = MatZ::sample_d(&basis, &2, &center, &15.75f32);
+        let _ = MatZ::sample_d(&basis, &2, &center, 1.25f64);
+        let _ = MatZ::sample_d(&basis, &2, &center, 15.75f32);
     }
 }

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -12,10 +12,66 @@ use crate::{
     error::MathError,
     integer::{MatZ, Z},
     rational::{MatQ, Q},
+    traits::{GetNumColumns, GetNumRows, SetEntry},
     utils::sample::discrete_gauss::sample_d,
 };
+use std::fmt::Display;
 
 impl MatZ {
+    /// Initializes a new matrix with dimensions `num_rows` x `num_columns` and with each entry
+    /// sampled independently according to the discrete Gaussian distribution,
+    /// using [`Z::sample_discrete_gauss`].
+    ///
+    /// Parameters:
+    /// - `num_rows`: specifies the number of rows the new matrix should have
+    /// - `num_cols`: specifies the number of columns the new matrix should have
+    /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
+    /// - `center`: specifies the positions of the center with peak probability
+    /// - `s`: specifies the Gaussian parameter, which is proportional
+    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///
+    /// Returns a matrix with each entry sampled independently from the
+    /// specified discrete Gaussian distribution.
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::integer::MatZ;
+    ///
+    /// let sample = MatZ::sample_discrete_gauss(3, 1, &1024, &0, &1.25f32).unwrap();
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type
+    /// [`InvalidMatrix`](MathError::InvalidMatrix)
+    /// if the number of rows or columns is `0`.
+    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
+    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
+    /// if the `n <= 1` or `s <= 0`.
+    pub fn sample_discrete_gauss<T1, T2, T3>(
+        num_rows: impl TryInto<i64> + Display,
+        num_cols: impl TryInto<i64> + Display,
+        n: &T1,
+        center: &T2,
+        s: &T3,
+    ) -> Result<MatZ, MathError>
+    where
+        T1: Into<Z> + Clone,
+        T2: Into<Q> + Clone,
+        T3: Into<Q> + Clone,
+    {
+        let mut out = Self::new(num_rows, num_cols)?;
+
+        for row in 0..out.get_num_rows() {
+            for col in 0..out.get_num_columns() {
+                let sample = Z::sample_discrete_gauss(n, center, s)?;
+                out.set_entry(row, col, sample)?;
+            }
+        }
+
+        Ok(out)
+    }
+
     /// SampleD samples a discrete Gaussian from the lattice with a provided `basis`.
     ///
     /// We do not check whether `basis` is actually a basis. Hence, the callee is
@@ -66,6 +122,40 @@ impl MatZ {
 
 #[cfg(test)]
 mod test_sample_discrete_gauss {
+    use crate::{
+        integer::{MatZ, Z},
+        rational::Q,
+    };
+
+    // This function only allows for a broader availability, which is tested here.
+
+    /// Checks whether `sample_discrete_gauss` is available for all types
+    /// implementing Into<Z> + Clone, i.e. u8, u16, u32, u64, i8, ...
+    /// or Into<Q> + Clone, i.e. u8, i16, f32, Z, Q, ...
+    #[test]
+    fn availability() {
+        let n = Z::from(1024);
+        let center = Q::from(0);
+        let s = Q::ONE;
+
+        let _ = MatZ::sample_discrete_gauss(2u64, 3i8, &16u16, &center, &1u16);
+        let _ = MatZ::sample_discrete_gauss(3u8, 2i16, &2u32, &center, &1u8);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2u64, &center, &1u32);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2i8, &center, &1u64);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2i16, &center, &1i64);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2i32, &center, &1i32);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2i64, &center, &1i16);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &n, &center, &1i8);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2u8, &center, &1i64);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2, &center, &n);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2, &center, &s);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2, &center, &1.25f64);
+        let _ = MatZ::sample_discrete_gauss(1, 1, &2, &center, &15.75f32);
+    }
+}
+
+#[cfg(test)]
+mod test_sample_d {
     use crate::{
         integer::{MatZ, Z},
         rational::{MatQ, Q},


### PR DESCRIPTION
**Description**
This PR implements...
- [x] sample_discrete_gauss

for `MatZ`.

The implementation of sample_discrete_gauss is needed for a comfortable sampling of error vectors where e <- \chi^m.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide