### PR TITLE
Unnecessary Results

### DIFF
--- a/benches/integer.rs
+++ b/benches/integer.rs
@@ -25,7 +25,7 @@ pub fn mat_z_4_4() -> Result<(), MathError> {
     let row_vector = MatZ::from_str("[[1,2,3,4]]")?;
     let col_vector = MatZ::from_str("[[1],[2],[3],[4]]")?;
     let mat_small = MatZ::from_str(mat_small_str)?;
-    let mat_large = MatZ::identity(4, 4)? * u64::MAX;
+    let mat_large = MatZ::identity(4, 4) * u64::MAX;
 
     let mat_res = &mat_small * &mat_large + &mat_large;
     let result: MatZ = &row_vector * (&mat_res * &col_vector);
@@ -43,10 +43,10 @@ pub fn mat_z_4_4() -> Result<(), MathError> {
 /// 2. multiply them together resulting in a 1x1 matrix
 /// 3. assert that the result is correct.
 pub fn mat_z_100_100() -> Result<(), MathError> {
-    let mat_a = 10 * MatZ::identity(100, 100)?;
-    let mut mat_b = MatZ::new(100, 100)?;
-    let mut row_vec_one = MatZ::new(1, 100)?;
-    let mut col_vec_one = MatZ::new(100, 1)?;
+    let mat_a = 10 * MatZ::identity(100, 100);
+    let mut mat_b = MatZ::new(100, 100);
+    let mut row_vec_one = MatZ::new(1, 100);
+    let mut col_vec_one = MatZ::new(100, 1);
     for i in 0..100 {
         col_vec_one.set_entry(i, 0, 1)?;
         row_vec_one.set_entry(0, i, 1)?;

--- a/src/integer/mat_poly_over_z/arithmetic/add.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/add.rs
@@ -84,7 +84,7 @@ impl MatPolyOverZ {
                 other.get_num_columns()
             )));
         }
-        let mut out = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpz_poly_mat_add(&mut out.matrix, &self.matrix, &other.matrix);
         }

--- a/src/integer/mat_poly_over_z/arithmetic/mul.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/mul.rs
@@ -85,7 +85,7 @@ impl MatPolyOverZ {
             )));
         }
 
-        let mut new = MatPolyOverZ::new(self.get_num_rows(), other.get_num_columns()).unwrap();
+        let mut new = MatPolyOverZ::new(self.get_num_rows(), other.get_num_columns());
         unsafe { fmpz_poly_mat_mul(&mut new.matrix, &self.matrix, &other.matrix) };
         Ok(new)
     }

--- a/src/integer/mat_poly_over_z/arithmetic/mul_scalar.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/mul_scalar.rs
@@ -40,7 +40,7 @@ impl Mul<&Z> for &MatPolyOverZ {
     /// let mat2 = &mat1 * &integer;
     /// ```
     fn mul(self, scalar: &Z) -> Self::Output {
-        let mut out = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpz_poly_mat_scalar_mul_fmpz(&mut out.matrix, &self.matrix, &scalar.value);
         }
@@ -78,7 +78,7 @@ impl Mul<&PolyOverZ> for &MatPolyOverZ {
     /// let mat2 = &mat1 * &integer;
     /// ```
     fn mul(self, scalar: &PolyOverZ) -> Self::Output {
-        let mut out = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpz_poly_mat_scalar_mul_fmpz_poly(&mut out.matrix, &self.matrix, &scalar.poly);
         }

--- a/src/integer/mat_poly_over_z/arithmetic/sub.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/sub.rs
@@ -85,7 +85,7 @@ impl MatPolyOverZ {
                 other.get_num_columns()
             )));
         }
-        let mut out = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpz_poly_mat_sub(&mut out.matrix, &self.matrix, &other.matrix);
         }

--- a/src/integer/mat_poly_over_z/concat.rs
+++ b/src/integer/mat_poly_over_z/concat.rs
@@ -31,8 +31,8 @@ impl Concatenate for &MatPolyOverZ {
     /// use qfall_math::traits::*;
     /// use qfall_math::integer::MatPolyOverZ;
     ///
-    /// let mat_1 = MatPolyOverZ::new(13, 5).unwrap();
-    /// let mat_2 = MatPolyOverZ::new(17, 5).unwrap();
+    /// let mat_1 = MatPolyOverZ::new(13, 5);
+    /// let mat_2 = MatPolyOverZ::new(17, 5);
     ///
     /// let mat_vert = mat_1.concat_vertical(&mat_2).unwrap();
     /// ```
@@ -54,8 +54,7 @@ impl Concatenate for &MatPolyOverZ {
         let mut out = MatPolyOverZ::new(
             self.get_num_rows() + other.get_num_rows(),
             self.get_num_columns(),
-        )
-        .unwrap();
+        );
         unsafe {
             fmpz_poly_mat_concat_vertical(&mut out.matrix, &self.matrix, &other.matrix);
         }
@@ -75,8 +74,8 @@ impl Concatenate for &MatPolyOverZ {
     /// use qfall_math::traits::*;
     /// use qfall_math::integer::MatPolyOverZ;
     ///
-    /// let mat_1 = MatPolyOverZ::new(17, 5).unwrap();
-    /// let mat_2 = MatPolyOverZ::new(17, 6).unwrap();
+    /// let mat_1 = MatPolyOverZ::new(17, 5);
+    /// let mat_2 = MatPolyOverZ::new(17, 6);
     ///
     /// let mat_vert = mat_1.concat_horizontal(&mat_2).unwrap();
     /// ```
@@ -98,8 +97,7 @@ impl Concatenate for &MatPolyOverZ {
         let mut out = MatPolyOverZ::new(
             self.get_num_rows(),
             self.get_num_columns() + other.get_num_columns(),
-        )
-        .unwrap();
+        );
         unsafe {
             fmpz_poly_mat_concat_horizontal(&mut out.matrix, &self.matrix, &other.matrix);
         }
@@ -119,9 +117,9 @@ mod test_concatenate {
     /// if the dimensions mismatch
     #[test]
     fn dimensions_vertical() {
-        let mat_1 = MatPolyOverZ::new(13, 5).unwrap();
-        let mat_2 = MatPolyOverZ::new(17, 5).unwrap();
-        let mat_3 = MatPolyOverZ::new(17, 6).unwrap();
+        let mat_1 = MatPolyOverZ::new(13, 5);
+        let mat_2 = MatPolyOverZ::new(17, 5);
+        let mat_3 = MatPolyOverZ::new(17, 6);
 
         let mat_vert = mat_1.concat_vertical(&mat_2).unwrap();
 
@@ -134,9 +132,9 @@ mod test_concatenate {
     /// if the dimensions mismatch
     #[test]
     fn dimensions_horizontal() {
-        let mat_1 = MatPolyOverZ::new(13, 5).unwrap();
-        let mat_2 = MatPolyOverZ::new(17, 5).unwrap();
-        let mat_3 = MatPolyOverZ::new(17, 6).unwrap();
+        let mat_1 = MatPolyOverZ::new(13, 5);
+        let mat_2 = MatPolyOverZ::new(17, 5);
+        let mat_3 = MatPolyOverZ::new(17, 6);
 
         let mat_hor = mat_2.concat_horizontal(&mat_3).unwrap();
 

--- a/src/integer/mat_poly_over_z/default.rs
+++ b/src/integer/mat_poly_over_z/default.rs
@@ -21,8 +21,7 @@ impl MatPolyOverZ {
     /// - `num_rows`: number of rows the new matrix should have
     /// - `num_cols`: number of columns the new matrix should have
     ///
-    /// Returns a [`MatPolyOverZ`] or an error, if the number of rows or columns is
-    /// less or equal to `0`.
+    /// Returns a new [`MatPolyOverZ`] instance of the provided dimensions.
     ///
     /// # Examples
     /// ```

--- a/src/integer/mat_poly_over_z/default.rs
+++ b/src/integer/mat_poly_over_z/default.rs
@@ -9,7 +9,7 @@
 //! Initialize a [`MatPolyOverZ`] with common defaults, e.g., zero and identity.
 
 use super::MatPolyOverZ;
-use crate::{error::MathError, utils::index::evaluate_index};
+use crate::utils::index::evaluate_indices;
 use flint_sys::fmpz_poly_mat::{fmpz_poly_mat_init, fmpz_poly_mat_one};
 use std::{fmt::Display, mem::MaybeUninit};
 
@@ -28,27 +28,19 @@ impl MatPolyOverZ {
     /// ```
     /// use qfall_math::integer::MatPolyOverZ;
     ///
-    /// let matrix = MatPolyOverZ::new(5, 10).unwrap();
+    /// let matrix = MatPolyOverZ::new(5, 10);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the number of rows or columns is `0`.
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
+    /// # Panics ...
+    /// - if the number of rows or columns is negative, zero, or does not fit into an [`i64`].
     pub fn new(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
-    ) -> Result<Self, MathError> {
-        let num_rows_i64 = evaluate_index(num_rows)?;
-        let num_cols_i64 = evaluate_index(num_cols)?;
+    ) -> Self {
+        let (num_rows_i64, num_cols_i64) = evaluate_indices(num_rows, num_cols).unwrap();
 
         if num_rows_i64 == 0 || num_cols_i64 == 0 {
-            return Err(MathError::InvalidMatrix(format!(
-                "The provided matrix has dimensions ({},{})",
-                num_rows_i64, num_cols_i64,
-            )));
+            panic!("A matrix can not contain 0 rows or 0 columns");
         }
 
         let mut matrix = MaybeUninit::uninit();
@@ -56,9 +48,9 @@ impl MatPolyOverZ {
             fmpz_poly_mat_init(matrix.as_mut_ptr(), num_rows_i64, num_cols_i64);
 
             // Construct MatPolyOverZ from previously initialized fmpz_poly_mat
-            Ok(MatPolyOverZ {
+            MatPolyOverZ {
                 matrix: matrix.assume_init(),
-            })
+            }
         }
     }
 
@@ -75,22 +67,21 @@ impl MatPolyOverZ {
     /// ```
     /// use qfall_math::integer::MatPolyOverZ;
     ///
-    /// let matrix = MatPolyOverZ::identity(2, 3).unwrap();
+    /// let matrix = MatPolyOverZ::identity(2, 3);
     ///
-    /// let identity = MatPolyOverZ::identity(10, 10).unwrap();
+    /// let identity = MatPolyOverZ::identity(10, 10);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix) or
-    /// [`OutOfBounds`](MathError::OutOfBounds) if the provided number of rows and columns
-    /// are not suited to create a matrix. For further information see [`MatZ::new`](crate::integer::MatZ::new).
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    /// For further information see [`MatPolyOverZ::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
-    ) -> Result<Self, MathError> {
-        let mut out = MatPolyOverZ::new(num_rows, num_cols)?;
+    ) -> Self {
+        let mut out = MatPolyOverZ::new(num_rows, num_cols);
         unsafe { fmpz_poly_mat_one(&mut out.matrix) };
-        Ok(out)
+        out
     }
 }
 
@@ -101,7 +92,7 @@ mod test_new {
     /// Ensure that entries of a new matrix are `0`.
     #[test]
     fn entry_zero() {
-        let matrix = MatPolyOverZ::new(2, 2).unwrap();
+        let matrix = MatPolyOverZ::new(2, 2);
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(0, 1).unwrap();
@@ -114,16 +105,18 @@ mod test_new {
         assert_eq!("0", entry4.to_string());
     }
 
-    /// Ensure that a new zero matrix fails with `0` as input.
+    /// Ensure that a new zero matrix fails with `0` as `num_cols`.
+    #[should_panic]
     #[test]
-    fn error_zero() {
-        let matrix1 = MatPolyOverZ::new(1, 0);
-        let matrix2 = MatPolyOverZ::new(0, 1);
-        let matrix3 = MatPolyOverZ::new(0, 0);
+    fn error_zero_num_cols() {
+        let _ = MatPolyOverZ::new(1, 0);
+    }
 
-        assert!(matrix1.is_err());
-        assert!(matrix2.is_err());
-        assert!(matrix3.is_err());
+    /// Ensure that a new zero matrix fails with `0` as `num_rows`.
+    #[should_panic]
+    #[test]
+    fn error_zero_num_rows() {
+        let _ = MatPolyOverZ::new(0, 1);
     }
 }
 
@@ -138,7 +131,7 @@ mod test_identity {
     /// Tests if an identity matrix is set from a zero matrix.
     #[test]
     fn identity() {
-        let matrix = MatPolyOverZ::identity(10, 10).unwrap();
+        let matrix = MatPolyOverZ::identity(10, 10);
 
         for i in 0..10 {
             for j in 0..10 {
@@ -157,7 +150,7 @@ mod test_identity {
     /// Tests if function works for a non-square matrix
     #[test]
     fn non_square_works() {
-        let matrix = MatPolyOverZ::identity(10, 7).unwrap();
+        let matrix = MatPolyOverZ::identity(10, 7);
 
         for i in 0..10 {
             for j in 0..7 {
@@ -172,7 +165,7 @@ mod test_identity {
             }
         }
 
-        let matrix = MatPolyOverZ::identity(7, 10).unwrap();
+        let matrix = MatPolyOverZ::identity(7, 10);
 
         for i in 0..7 {
             for j in 0..10 {

--- a/src/integer/mat_poly_over_z/evaluate.rs
+++ b/src/integer/mat_poly_over_z/evaluate.rs
@@ -32,7 +32,7 @@ impl Evaluate<&Z, MatZ> for MatPolyOverZ {
     /// ```
     fn evaluate(&self, value: &Z) -> MatZ {
         // we can unwrap since we know, that the dimensions of our current matrix are positive
-        let mut res = MatZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut res = MatZ::new(self.get_num_rows(), self.get_num_columns());
 
         unsafe { fmpz_poly_mat_evaluate_fmpz(&mut res.matrix, &self.matrix, &value.value) };
 

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -69,13 +69,16 @@ impl FromStr for MatPolyOverZ {
     /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
     /// if the entries are not formatted correctly. For further details see [`PolyOverZ::from_str`]
     /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the matrix is not formatted in a suitable way,
-    /// the number of rows or columns is too big (must fit into [`i64`]) or
+    /// if the matrix is not formatted in a suitable way, or
     /// if the number of entries in rows is unequal.
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    /// For further information see [`MatPolyOverZ::new`].
     fn from_str(string: &str) -> Result<Self, MathError> {
         let string_matrix = parse_matrix_string(string)?;
         let (num_rows, num_cols) = find_matrix_dimensions(&string_matrix)?;
-        let mut matrix = MatPolyOverZ::new(num_rows, num_cols)?;
+        let mut matrix = MatPolyOverZ::new(num_rows, num_cols);
 
         // fill entries of matrix according to entries in string_matrix
         for (row_num, row) in string_matrix.iter().enumerate() {

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -29,7 +29,7 @@ impl GetNumRows for MatPolyOverZ {
     /// use qfall_math::integer::MatPolyOverZ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatPolyOverZ::new(5,6).unwrap();
+    /// let matrix = MatPolyOverZ::new(5,6);
     /// let rows = matrix.get_num_rows();
     /// ```
     fn get_num_rows(&self) -> i64 {
@@ -45,7 +45,7 @@ impl GetNumColumns for MatPolyOverZ {
     /// use qfall_math::integer::MatPolyOverZ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatPolyOverZ::new(5,6).unwrap();
+    /// let matrix = MatPolyOverZ::new(5,6);
     /// let columns = matrix.get_num_columns();
     /// ```
     fn get_num_columns(&self) -> i64 {
@@ -69,7 +69,7 @@ impl GetEntry<PolyOverZ> for MatPolyOverZ {
     /// use qfall_math::integer::MatPolyOverZ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatPolyOverZ::new(5, 10).unwrap();
+    /// let matrix = MatPolyOverZ::new(5, 10);
     /// let entry = matrix.get_entry(0, 1).unwrap();
     /// ```
     ///
@@ -130,7 +130,7 @@ impl MatPolyOverZ {
             ));
         }
 
-        let out = MatPolyOverZ::new(1, self.get_num_columns()).unwrap();
+        let out = MatPolyOverZ::new(1, self.get_num_columns());
         for column in 0..self.get_num_columns() {
             unsafe {
                 fmpz_poly_set(
@@ -175,7 +175,7 @@ impl MatPolyOverZ {
             ));
         }
 
-        let out = MatPolyOverZ::new(self.get_num_rows(), 1).unwrap();
+        let out = MatPolyOverZ::new(self.get_num_rows(), 1);
         for row in 0..self.get_num_rows() {
             unsafe {
                 fmpz_poly_set(
@@ -229,7 +229,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large polynomials.
     #[test]
     fn max_int_positive() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", i64::MAX)).unwrap();
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -241,7 +241,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large polynomials (larger than [`i64`]).
     #[test]
     fn big_positive() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", u64::MAX)).unwrap();
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -253,7 +253,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large negative polynomials.
     #[test]
     fn max_int_negative() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", i64::MIN)).unwrap();
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -265,7 +265,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large negative polynomials (larger than [`i64`]).
     #[test]
     fn big_negative() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  -{} 1", u64::MAX)).unwrap();
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -277,7 +277,7 @@ mod test_get_entry {
     /// Ensure that polynomials with many entries are correctly retrieved
     #[test]
     fn large_poly() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value =
             PolyOverZ::from_str(&format!("10000  -{} 1{}", u64::MAX, " 17".repeat(9998))).unwrap();
         matrix.set_entry(1, 1, value).unwrap();
@@ -293,7 +293,7 @@ mod test_get_entry {
     /// Ensure that getting entries at (0,0) works.
     #[test]
     fn getting_at_zero() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", i64::MAX)).unwrap();
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -305,7 +305,7 @@ mod test_get_entry {
     /// Ensure that a wrong number of rows yields an Error.
     #[test]
     fn error_wrong_row() {
-        let matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let matrix = MatPolyOverZ::new(5, 10);
 
         assert!(matrix.get_entry(5, 1).is_err());
     }
@@ -313,7 +313,7 @@ mod test_get_entry {
     /// Ensure that a wrong number of columns yields an Error.
     #[test]
     fn error_wrong_column() {
-        let matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let matrix = MatPolyOverZ::new(5, 10);
 
         assert!(matrix.get_entry(1, 100).is_err());
     }
@@ -321,7 +321,7 @@ mod test_get_entry {
     /// Ensure that the entry is a deep copy and not just a clone of the reference.
     #[test]
     fn memory_test() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", u64::MAX)).unwrap();
         matrix.set_entry(1, 1, value).unwrap();
         let entry = matrix.get_entry(1, 1).unwrap();
@@ -341,7 +341,7 @@ mod test_get_num {
     /// Ensure that the getter for number of rows works correctly.
     #[test]
     fn num_rows() {
-        let matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let matrix = MatPolyOverZ::new(5, 10);
 
         assert_eq!(matrix.get_num_rows(), 5);
     }
@@ -349,7 +349,7 @@ mod test_get_num {
     /// Ensure that the getter for number of columns works correctly.
     #[test]
     fn num_columns() {
-        let matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let matrix = MatPolyOverZ::new(5, 10);
 
         assert_eq!(matrix.get_num_columns(), 10);
     }

--- a/src/integer/mat_poly_over_z/ownership.rs
+++ b/src/integer/mat_poly_over_z/ownership.rs
@@ -29,7 +29,7 @@ impl Clone for MatPolyOverZ {
     /// ```
     fn clone(&self) -> Self {
         // we can unwrap since we know, that the number of rows and columns is positive and fits into an [`i64`]
-        let mut clone = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut clone = MatPolyOverZ::new(self.get_num_rows(), self.get_num_columns());
 
         unsafe { fmpz_poly_mat_set(&mut clone.matrix, &mut self.matrix.to_owned()) }
 

--- a/src/integer/mat_poly_over_z/set.rs
+++ b/src/integer/mat_poly_over_z/set.rs
@@ -42,7 +42,7 @@ impl SetEntry<&PolyOverZ> for MatPolyOverZ {
     /// use qfall_math::integer::PolyOverZ;
     /// use qfall_math::traits::*;
     ///
-    /// let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+    /// let mut matrix = MatPolyOverZ::new(5, 10);
     /// let value = PolyOverZ::default();
     /// matrix.set_entry(1, 1, &value).unwrap();
     /// ```
@@ -91,7 +91,7 @@ impl MatPolyOverZ {
     /// use qfall_math::integer::MatPolyOverZ;
     /// use std::str::FromStr;
     ///
-    /// let mut mat1 = MatPolyOverZ::new(2, 2).unwrap();
+    /// let mut mat1 = MatPolyOverZ::new(2, 2);
     /// let mat2 = MatPolyOverZ::from_str("[[1  1],[0]]").unwrap();
     /// mat1.set_column(1, &mat2, 0);
     /// ```
@@ -149,7 +149,7 @@ impl MatPolyOverZ {
     /// use qfall_math::integer::MatPolyOverZ;
     /// use std::str::FromStr;
     ///
-    /// let mut mat1 = MatPolyOverZ::new(2, 2).unwrap();
+    /// let mut mat1 = MatPolyOverZ::new(2, 2);
     /// let mat2 = MatPolyOverZ::from_str("[[1  1,0]]").unwrap();
     /// mat1.set_row(0, &mat2, 0);
     /// ```
@@ -205,7 +205,7 @@ impl MatPolyOverZ {
     /// ```
     /// use qfall_math::integer::MatPolyOverZ;
     ///
-    /// let mut matrix = MatPolyOverZ::new(4, 3).unwrap();
+    /// let mut matrix = MatPolyOverZ::new(4, 3);
     /// matrix.swap_entries(0, 0, 2, 1);
     /// ```
     ///
@@ -244,7 +244,7 @@ impl MatPolyOverZ {
     /// ```
     /// use qfall_math::integer::MatPolyOverZ;
     ///
-    /// let mut matrix = MatPolyOverZ::new(4, 3).unwrap();
+    /// let mut matrix = MatPolyOverZ::new(4, 3);
     /// matrix.swap_columns(0, 2);
     /// ```
     ///
@@ -291,7 +291,7 @@ impl MatPolyOverZ {
     /// ```
     /// use qfall_math::integer::MatPolyOverZ;
     ///
-    /// let mut matrix = MatPolyOverZ::new(4, 3).unwrap();
+    /// let mut matrix = MatPolyOverZ::new(4, 3);
     /// matrix.swap_rows(0, 2);
     /// ```
     ///
@@ -332,7 +332,7 @@ impl MatPolyOverZ {
     /// ```
     /// use qfall_math::integer::MatPolyOverZ;
     ///
-    /// let mut matrix = MatPolyOverZ::new(4, 3).unwrap();
+    /// let mut matrix = MatPolyOverZ::new(4, 3);
     /// matrix.reverse_columns();
     /// ```
     pub fn reverse_columns(&mut self) {
@@ -349,7 +349,7 @@ impl MatPolyOverZ {
     /// ```
     /// use qfall_math::integer::MatPolyOverZ;
     ///
-    /// let mut matrix = MatPolyOverZ::new(4, 3).unwrap();
+    /// let mut matrix = MatPolyOverZ::new(4, 3);
     /// matrix.reverse_rows();
     /// ```
     pub fn reverse_rows(&mut self) {
@@ -371,7 +371,7 @@ mod test_setter {
     /// Ensure that setting entries works with standard numbers.
     #[test]
     fn standard_value() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", 889)).unwrap();
         matrix.set_entry(4, 7, &value).unwrap();
 
@@ -383,7 +383,7 @@ mod test_setter {
     /// Ensure that setting entries works with large numbers.
     #[test]
     fn max_int_positive() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", i64::MAX)).unwrap();
         matrix.set_entry(4, 7, &value).unwrap();
 
@@ -395,7 +395,7 @@ mod test_setter {
     /// Ensure that setting entries works with large numbers (larger than i64).
     #[test]
     fn big_positive() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", u64::MAX)).unwrap();
         matrix.set_entry(4, 7, &value).unwrap();
 
@@ -407,7 +407,7 @@ mod test_setter {
     /// Ensure that setting entries works with referenced large numbers (larger than i64).
     #[test]
     fn big_positive_ref() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value1 = PolyOverZ::from_str(&format!("2  {} 1", u64::MAX)).unwrap();
         let value2 = PolyOverZ::from_str(&format!("2  {} 1", 8)).unwrap();
         matrix.set_entry(1, 1, &value1).unwrap();
@@ -423,7 +423,7 @@ mod test_setter {
     /// Ensure that setting entries works with large negative numbers.
     #[test]
     fn max_int_negative() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", i64::MIN)).unwrap();
         matrix.set_entry(4, 7, &value).unwrap();
 
@@ -435,7 +435,7 @@ mod test_setter {
     /// Ensure that setting entries works with large negative numbers (larger than i64).
     #[test]
     fn big_negative() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value_str = &format!("2  -{} 1", u64::MAX);
         let value = PolyOverZ::from_str(value_str).unwrap();
         matrix.set_entry(4, 7, &value).unwrap();
@@ -448,7 +448,7 @@ mod test_setter {
     /// Ensure that setting entries at (0,0) works.
     #[test]
     fn setting_at_zero() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::from_str(&format!("2  {} 1", u64::MAX)).unwrap();
         matrix.set_entry(0, 0, &value).unwrap();
 
@@ -460,7 +460,7 @@ mod test_setter {
     /// Ensure that a wrong number of rows yields an Error.
     #[test]
     fn error_wrong_row() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::default();
 
         assert!(matrix.set_entry(5, 1, value).is_err());
@@ -469,7 +469,7 @@ mod test_setter {
     /// Ensure that a wrong number of columns yields an Error.
     #[test]
     fn error_wrong_column() {
-        let mut matrix = MatPolyOverZ::new(5, 10).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::default();
 
         assert!(matrix.set_entry(1, 100, value).is_err());
@@ -536,7 +536,7 @@ mod test_setter {
     /// Ensures that `set_column` returns an error if one of the specified columns is out of bounds
     #[test]
     fn column_out_of_bounds() {
-        let mut m1 = MatPolyOverZ::new(5, 2).unwrap();
+        let mut m1 = MatPolyOverZ::new(5, 2);
         let m2 = m1.clone();
 
         assert!(m1.set_column(-1, &m2, 0).is_err());
@@ -548,8 +548,8 @@ mod test_setter {
     /// Ensures that mismatching row dimensions result in an error
     #[test]
     fn column_mismatching_columns() {
-        let mut m1 = MatPolyOverZ::new(5, 2).unwrap();
-        let m2 = MatPolyOverZ::new(2, 2).unwrap();
+        let mut m1 = MatPolyOverZ::new(5, 2);
+        let m2 = MatPolyOverZ::new(2, 2);
 
         assert!(m1.set_column(0, &m2, 0).is_err());
         assert!(m1.set_column(1, &m2, 1).is_err());
@@ -618,7 +618,7 @@ mod test_setter {
     /// Ensures that `set_row` returns an error if one of the specified rows is out of bounds
     #[test]
     fn row_out_of_bounds() {
-        let mut m1 = MatPolyOverZ::new(5, 2).unwrap();
+        let mut m1 = MatPolyOverZ::new(5, 2);
         let m2 = m1.clone();
 
         assert!(m1.set_row(-1, &m2, 0).is_err());
@@ -630,8 +630,8 @@ mod test_setter {
     /// Ensures that mismatching column dimensions result in an error
     #[test]
     fn row_mismatching_columns() {
-        let mut m1 = MatPolyOverZ::new(3, 2).unwrap();
-        let m2 = MatPolyOverZ::new(3, 3).unwrap();
+        let mut m1 = MatPolyOverZ::new(3, 2);
+        let m2 = MatPolyOverZ::new(3, 3);
 
         assert!(m1.set_row(0, &m2, 0).is_err());
         assert!(m1.set_row(1, &m2, 1).is_err());
@@ -698,7 +698,7 @@ mod test_swaps {
     /// Ensures that `swap_entries` returns an error if one of the specified entries is out of bounds
     #[test]
     fn entries_out_of_bounds() {
-        let mut matrix = MatPolyOverZ::new(5, 2).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 2);
 
         assert!(matrix.swap_entries(-1, 0, 0, 0).is_err());
         assert!(matrix.swap_entries(0, -1, 0, 0).is_err());
@@ -767,7 +767,7 @@ mod test_swaps {
     /// Ensures that `swap_columns` returns an error if one of the specified columns is out of bounds
     #[test]
     fn column_out_of_bounds() {
-        let mut matrix = MatPolyOverZ::new(5, 2).unwrap();
+        let mut matrix = MatPolyOverZ::new(5, 2);
 
         assert!(matrix.swap_columns(-1, 0).is_err());
         assert!(matrix.swap_columns(0, -1).is_err());
@@ -832,7 +832,7 @@ mod test_swaps {
     /// Ensures that `swap_rows` returns an error if one of the specified rows is out of bounds
     #[test]
     fn row_out_of_bounds() {
-        let mut matrix = MatPolyOverZ::new(2, 4).unwrap();
+        let mut matrix = MatPolyOverZ::new(2, 4);
 
         assert!(matrix.swap_rows(-1, 0).is_err());
         assert!(matrix.swap_rows(0, -1).is_err());

--- a/src/integer/mat_poly_over_z/transpose.rs
+++ b/src/integer/mat_poly_over_z/transpose.rs
@@ -27,7 +27,7 @@ impl MatPolyOverZ {
     /// assert_eq!(mat.transpose(), cmp);
     /// ```
     pub fn transpose(&self) -> Self {
-        let mut out = Self::new(self.get_num_columns(), self.get_num_rows()).unwrap();
+        let mut out = Self::new(self.get_num_columns(), self.get_num_rows());
         unsafe { fmpz_poly_mat_transpose(&mut out.matrix, &self.matrix) };
         out
     }

--- a/src/integer/mat_z/arithmetic/add.rs
+++ b/src/integer/mat_z/arithmetic/add.rs
@@ -84,7 +84,7 @@ impl MatZ {
                 other.get_num_columns()
             )));
         }
-        let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpz_mat_add(&mut out.matrix, &self.matrix, &other.matrix);
         }

--- a/src/integer/mat_z/arithmetic/mul.rs
+++ b/src/integer/mat_z/arithmetic/mul.rs
@@ -84,7 +84,7 @@ impl MatZ {
             )));
         }
 
-        let mut new = MatZ::new(self.get_num_rows(), other.get_num_columns()).unwrap();
+        let mut new = MatZ::new(self.get_num_rows(), other.get_num_columns());
         unsafe { fmpz_mat_mul(&mut new.matrix, &self.matrix, &other.matrix) };
         Ok(new)
     }
@@ -126,7 +126,7 @@ mod test_mul {
     fn large_entries() {
         let mat = MatZ::from_str(&format!("[[{},1],[0,2]]", i64::MAX)).unwrap();
         let vec = MatZ::from_str(&format!("[[{}],[0]]", i64::MAX)).unwrap();
-        let mut cmp = MatZ::new(2, 1).unwrap();
+        let mut cmp = MatZ::new(2, 1);
         let max: Z = i64::MAX.into();
         cmp.set_entry(0, 0, &(&max * &max)).unwrap();
 

--- a/src/integer/mat_z/arithmetic/mul_scalar.rs
+++ b/src/integer/mat_z/arithmetic/mul_scalar.rs
@@ -40,7 +40,7 @@ impl Mul<&Z> for &MatZ {
     /// let mat2 = &mat1 * &integer;
     /// ```
     fn mul(self, scalar: &Z) -> Self::Output {
-        let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpz_mat_scalar_mul_fmpz(&mut out.matrix, &self.matrix, &scalar.value);
         }

--- a/src/integer/mat_z/arithmetic/sub.rs
+++ b/src/integer/mat_z/arithmetic/sub.rs
@@ -84,7 +84,7 @@ impl MatZ {
                 other.get_num_columns()
             )));
         }
-        let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpz_mat_sub(&mut out.matrix, &self.matrix, &other.matrix);
         }

--- a/src/integer/mat_z/cmp.rs
+++ b/src/integer/mat_z/cmp.rs
@@ -57,7 +57,7 @@ mod test_partial_eq {
     #[test]
     fn equality_between_instantiations() {
         let a = MatZ::from_str("[[0,1],[0,0]]").unwrap();
-        let mut b = MatZ::new(2, 2).unwrap();
+        let mut b = MatZ::new(2, 2);
         b.set_entry(0, 1, 1).unwrap();
 
         assert_eq!(a, b);

--- a/src/integer/mat_z/concat.rs
+++ b/src/integer/mat_z/concat.rs
@@ -31,8 +31,8 @@ impl Concatenate for &MatZ {
     /// use qfall_math::traits::*;
     /// use qfall_math::integer::MatZ;
     ///
-    /// let mat_1 = MatZ::new(13, 5).unwrap();
-    /// let mat_2 = MatZ::new(17, 5).unwrap();
+    /// let mat_1 = MatZ::new(13, 5);
+    /// let mat_2 = MatZ::new(17, 5);
     ///
     /// let mat_vert = mat_1.concat_vertical(&mat_2).unwrap();
     /// ```
@@ -54,8 +54,7 @@ impl Concatenate for &MatZ {
         let mut out = MatZ::new(
             self.get_num_rows() + other.get_num_rows(),
             self.get_num_columns(),
-        )
-        .unwrap();
+        );
         unsafe {
             fmpz_mat_concat_vertical(&mut out.matrix, &self.matrix, &other.matrix);
         }
@@ -75,8 +74,8 @@ impl Concatenate for &MatZ {
     /// use qfall_math::traits::*;
     /// use qfall_math::integer::MatZ;
     ///
-    /// let mat_1 = MatZ::new(17, 5).unwrap();
-    /// let mat_2 = MatZ::new(17, 6).unwrap();
+    /// let mat_1 = MatZ::new(17, 5);
+    /// let mat_2 = MatZ::new(17, 6);
     ///
     /// let mat_vert = mat_1.concat_horizontal(&mat_2).unwrap();
     /// ```
@@ -98,8 +97,7 @@ impl Concatenate for &MatZ {
         let mut out = MatZ::new(
             self.get_num_rows(),
             self.get_num_columns() + other.get_num_columns(),
-        )
-        .unwrap();
+        );
         unsafe {
             fmpz_mat_concat_horizontal(&mut out.matrix, &self.matrix, &other.matrix);
         }
@@ -119,9 +117,9 @@ mod test_concatenate {
     /// if the dimensions mismatch
     #[test]
     fn dimensions_vertical() {
-        let mat_1 = MatZ::new(13, 5).unwrap();
-        let mat_2 = MatZ::new(17, 5).unwrap();
-        let mat_3 = MatZ::new(17, 6).unwrap();
+        let mat_1 = MatZ::new(13, 5);
+        let mat_2 = MatZ::new(17, 5);
+        let mat_3 = MatZ::new(17, 6);
 
         let mat_vert = mat_1.concat_vertical(&mat_2).unwrap();
 
@@ -134,9 +132,9 @@ mod test_concatenate {
     /// if the dimensions mismatch
     #[test]
     fn dimensions_horizontal() {
-        let mat_1 = MatZ::new(13, 5).unwrap();
-        let mat_2 = MatZ::new(17, 5).unwrap();
-        let mat_3 = MatZ::new(17, 6).unwrap();
+        let mat_1 = MatZ::new(13, 5);
+        let mat_2 = MatZ::new(17, 5);
+        let mat_3 = MatZ::new(17, 6);
 
         let mat_vert = mat_2.concat_horizontal(&mat_3).unwrap();
 

--- a/src/integer/mat_z/default.rs
+++ b/src/integer/mat_z/default.rs
@@ -9,7 +9,7 @@
 //! Initialize a [`MatZ`] with common defaults, e.g., zero and identity.
 
 use super::MatZ;
-use crate::{error::MathError, utils::index::evaluate_indices};
+use crate::utils::index::evaluate_indices;
 use flint_sys::fmpz_mat::{fmpz_mat_init, fmpz_mat_one};
 use std::{fmt::Display, mem::MaybeUninit};
 
@@ -28,25 +28,20 @@ impl MatZ {
     /// ```
     /// use qfall_math::integer::MatZ;
     ///
-    /// let matrix = MatZ::new(5, 10).unwrap();
+    /// let matrix = MatZ::new(5, 10);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the number of rows or columns is `0`.
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
+    /// # Panics ...
+    /// - if the number of rows or columns is negative or `0`.
+    /// - if the number of rows or columns does not fit into an [`i64`].
     pub fn new(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
-    ) -> Result<Self, MathError> {
-        let (num_rows_i64, num_cols_i64) = evaluate_indices(num_rows, num_cols)?;
+    ) -> Self {
+        let (num_rows_i64, num_cols_i64) = evaluate_indices(num_rows, num_cols).unwrap();
 
         if num_rows_i64 == 0 || num_cols_i64 == 0 {
-            return Err(MathError::InvalidMatrix(
-                "A matrix can not contain 0 rows or 0 columns".to_string(),
-            ));
+            panic!("A matrix can not contain 0 rows or 0 columns");
         }
 
         let mut matrix = MaybeUninit::uninit();
@@ -54,9 +49,9 @@ impl MatZ {
             fmpz_mat_init(matrix.as_mut_ptr(), num_rows_i64, num_cols_i64);
 
             // Construct MatZ from previously initialized fmpz_mat
-            Ok(MatZ {
+            MatZ {
                 matrix: matrix.assume_init(),
-            })
+            }
         }
     }
 
@@ -73,22 +68,21 @@ impl MatZ {
     /// ```
     /// use qfall_math::integer::MatZ;
     ///
-    /// let matrix = MatZ::identity(2, 3).unwrap();
+    /// let matrix = MatZ::identity(2, 3);
     ///
-    /// let identity = MatZ::identity(10, 10).unwrap();
+    /// let identity = MatZ::identity(10, 10);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix) or
-    /// [`OutOfBounds`](MathError::OutOfBounds) if the provided number of rows and columns
-    /// are not suited to create a matrix. For further information see [`MatZ::new`].
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    /// For further information see [`MatZ::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
-    ) -> Result<Self, MathError> {
-        let mut out = MatZ::new(num_rows, num_cols)?;
+    ) -> Self {
+        let mut out = MatZ::new(num_rows, num_cols);
         unsafe { fmpz_mat_one(&mut out.matrix) };
-        Ok(out)
+        out
     }
 }
 
@@ -102,7 +96,7 @@ mod test_new {
     /// Ensure that entries of a new matrix are `0`.
     #[test]
     fn entry_zero() {
-        let matrix = MatZ::new(2, 2).unwrap();
+        let matrix = MatZ::new(2, 2);
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(0, 1).unwrap();
@@ -115,16 +109,18 @@ mod test_new {
         assert_eq!(Z::ZERO, entry4);
     }
 
-    /// Ensure that a new zero matrix fails with `0` as input.
+    /// Ensure that a new zero matrix fails with `0` as `num_cols`.
+    #[should_panic]
     #[test]
-    fn error_zero() {
-        let matrix1 = MatZ::new(1, 0);
-        let matrix2 = MatZ::new(0, 1);
-        let matrix3 = MatZ::new(0, 0);
+    fn error_zero_num_cols() {
+        let _ = MatZ::new(1, 0);
+    }
 
-        assert!(matrix1.is_err());
-        assert!(matrix2.is_err());
-        assert!(matrix3.is_err());
+    /// Ensure that a new zero matrix fails with `0` as `num_rows`.
+    #[should_panic]
+    #[test]
+    fn error_zero_num_rows() {
+        let _ = MatZ::new(0, 1);
     }
 }
 
@@ -138,7 +134,7 @@ mod test_identity {
     /// Tests if an identity matrix is set from a zero matrix.
     #[test]
     fn identity() {
-        let matrix = MatZ::identity(10, 10).unwrap();
+        let matrix = MatZ::identity(10, 10);
 
         for i in 0..10 {
             for j in 0..10 {
@@ -154,7 +150,7 @@ mod test_identity {
     /// Tests if function works for a non-square matrix
     #[test]
     fn non_square_works() {
-        let matrix = MatZ::identity(10, 7).unwrap();
+        let matrix = MatZ::identity(10, 7);
 
         for i in 0..10 {
             for j in 0..7 {
@@ -166,7 +162,7 @@ mod test_identity {
             }
         }
 
-        let matrix = MatZ::identity(7, 10).unwrap();
+        let matrix = MatZ::identity(7, 10);
 
         for i in 0..7 {
             for j in 0..10 {

--- a/src/integer/mat_z/default.rs
+++ b/src/integer/mat_z/default.rs
@@ -21,8 +21,7 @@ impl MatZ {
     /// - `num_rows`: number of rows the new matrix should have
     /// - `num_cols`: number of columns the new matrix should have
     ///
-    /// Returns a [`MatZ`] or an error, if the number of rows or columns is
-    /// less or equal to `0`.
+    /// Returns a new [`MatZ`] instance of the provided dimensions.
     ///
     /// # Examples
     /// ```

--- a/src/integer/mat_z/default.rs
+++ b/src/integer/mat_z/default.rs
@@ -32,8 +32,7 @@ impl MatZ {
     /// ```
     ///
     /// # Panics ...
-    /// - if the number of rows or columns is negative or `0`.
-    /// - if the number of rows or columns does not fit into an [`i64`].
+    /// - if the number of rows or columns is negative, zero, or does not fit into an [`i64`].
     pub fn new(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -43,7 +43,7 @@ impl MatZ {
     /// let a = MatZ::from_mat_zq(&m);
     /// ```
     pub fn from_mat_zq(matrix: &MatZq) -> Self {
-        let mut out = MatZ::new(matrix.get_num_rows(), matrix.get_num_columns()).unwrap();
+        let mut out = MatZ::new(matrix.get_num_rows(), matrix.get_num_columns());
         unsafe { fmpz_mat_set(&mut out.matrix, &matrix.matrix.mat[0]) };
         out
     }
@@ -87,7 +87,7 @@ impl FromStr for MatZ {
     fn from_str(string: &str) -> Result<Self, MathError> {
         let string_matrix = parse_matrix_string(string)?;
         let (num_rows, num_cols) = find_matrix_dimensions(&string_matrix)?;
-        let mut matrix = MatZ::new(num_rows, num_cols)?;
+        let mut matrix = MatZ::new(num_rows, num_cols);
 
         // fill entries of matrix according to entries in string_matrix
         for (row_num, row) in string_matrix.iter().enumerate() {

--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -75,8 +75,7 @@ impl FromStr for MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the matrix is not formatted in a suitable way,
-    /// the number of rows or columns is too big (must fit into [`i64`]) or
+    /// if the matrix is not formatted in a suitable way or
     /// if the number of entries in rows is unequal.
     /// - Returns a [`MathError`] of type
     /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
@@ -84,6 +83,10 @@ impl FromStr for MatZ {
     /// - Returns a [`MathError`] of type
     /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
     /// if an entry is not formatted correctly.
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    /// For further information see [`MatZ::new`].
     fn from_str(string: &str) -> Result<Self, MathError> {
         let string_matrix = parse_matrix_string(string)?;
         let (num_rows, num_cols) = find_matrix_dimensions(&string_matrix)?;
@@ -118,7 +121,7 @@ mod test_from_mat_zq {
     /// Test if the dimensions are taken over correctly
     #[test]
     fn dimensions() {
-        let matzq = MatZq::new(15, 17, 13).unwrap();
+        let matzq = MatZq::new(15, 17, 13);
 
         let matz_1 = MatZ::from(&matzq);
         let matz_2 = MatZ::from_mat_zq(&matzq);
@@ -132,7 +135,7 @@ mod test_from_mat_zq {
     /// Test if entries are taken over correctly
     #[test]
     fn entries_taken_over_correctly() {
-        let mut matzq = MatZq::new(2, 2, u64::MAX).unwrap();
+        let mut matzq = MatZq::new(2, 2, u64::MAX);
         matzq.set_entry(0, 0, u64::MAX - 58).unwrap();
         matzq.set_entry(0, 1, -1).unwrap();
 

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -29,7 +29,7 @@ impl GetNumRows for MatZ {
     /// use qfall_math::integer::MatZ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatZ::new(5,6).unwrap();
+    /// let matrix = MatZ::new(5,6);
     /// let rows = matrix.get_num_rows();
     /// ```
     fn get_num_rows(&self) -> i64 {
@@ -45,7 +45,7 @@ impl GetNumColumns for MatZ {
     /// use qfall_math::integer::MatZ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatZ::new(5,6).unwrap();
+    /// let matrix = MatZ::new(5,6);
     /// let columns = matrix.get_num_columns();
     /// ```
     fn get_num_columns(&self) -> i64 {
@@ -69,7 +69,7 @@ impl GetEntry<Z> for MatZ {
     /// use qfall_math::integer::MatZ;
     /// use qfall_math::traits::GetEntry;
     ///
-    /// let matrix = MatZ::new(5, 10).unwrap();
+    /// let matrix = MatZ::new(5, 10);
     /// let entry = matrix.get_entry(0, 1).unwrap();
     /// ```
     ///
@@ -129,7 +129,7 @@ impl MatZ {
             ));
         }
 
-        let out = MatZ::new(1, self.get_num_columns()).unwrap();
+        let out = MatZ::new(1, self.get_num_columns());
         for column in 0..self.get_num_columns() {
             unsafe {
                 fmpz_set(
@@ -175,7 +175,7 @@ impl MatZ {
             ));
         }
 
-        let out = MatZ::new(self.get_num_rows(), 1).unwrap();
+        let out = MatZ::new(self.get_num_rows(), 1);
         for row in 0..self.get_num_rows() {
             unsafe {
                 fmpz_set(
@@ -229,7 +229,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large numbers.
     #[test]
     fn max_int_positive() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(i64::MAX);
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -241,7 +241,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large numbers (larger than i64).
     #[test]
     fn big_positive() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(u64::MAX);
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -253,7 +253,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large negative numbers.
     #[test]
     fn max_int_negative() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(i64::MIN);
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -265,7 +265,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large negative numbers (larger than i64).
     #[test]
     fn big_negative() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value_str = &format!("-{}", u64::MAX);
         matrix
             .set_entry(1, 1, Z::from_str(value_str).unwrap())
@@ -279,7 +279,7 @@ mod test_get_entry {
     /// Ensure that getting entries at (0,0) works.
     #[test]
     fn getting_at_zero() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(i64::MIN);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -291,7 +291,7 @@ mod test_get_entry {
     /// Ensure that a wrong number of rows yields an Error.
     #[test]
     fn error_wrong_row() {
-        let matrix = MatZ::new(5, 10).unwrap();
+        let matrix = MatZ::new(5, 10);
 
         assert!(matrix.get_entry(5, 1).is_err());
     }
@@ -299,7 +299,7 @@ mod test_get_entry {
     /// Ensure that a wrong number of columns yields an Error.
     #[test]
     fn error_wrong_column() {
-        let matrix = MatZ::new(5, 10).unwrap();
+        let matrix = MatZ::new(5, 10);
 
         assert!(matrix.get_entry(1, 100).is_err());
     }
@@ -307,7 +307,7 @@ mod test_get_entry {
     /// Ensure that the entry is a deep copy and not just a clone of the reference.
     #[test]
     fn memory_test() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(u64::MAX);
         matrix.set_entry(1, 1, value).unwrap();
         let entry = matrix.get_entry(1, 1).unwrap();
@@ -328,7 +328,7 @@ mod test_get_num {
     /// Ensure that the getter for number of rows works correctly.
     #[test]
     fn num_rows() {
-        let matrix = MatZ::new(5, 10).unwrap();
+        let matrix = MatZ::new(5, 10);
 
         assert_eq!(matrix.get_num_rows(), 5);
     }
@@ -336,7 +336,7 @@ mod test_get_num {
     /// Ensure that the getter for number of columns works correctly.
     #[test]
     fn num_columns() {
-        let matrix = MatZ::new(5, 10).unwrap();
+        let matrix = MatZ::new(5, 10);
 
         assert_eq!(matrix.get_num_columns(), 10);
     }

--- a/src/integer/mat_z/inverse.rs
+++ b/src/integer/mat_z/inverse.rs
@@ -36,7 +36,7 @@ impl MatZ {
 
         // check if determinant is not `0`, create new matrix to store inverted result in
         // TODO improve runtime
-        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns());
         match unsafe { fmpq_mat_inv(&mut out.matrix, &MatQ::from(self).matrix) } {
             0 => None,
             _ => Some(out),

--- a/src/integer/mat_z/ownership.rs
+++ b/src/integer/mat_z/ownership.rs
@@ -29,7 +29,7 @@ impl Clone for MatZ {
     /// let b = a.clone();
     /// ```
     fn clone(&self) -> Self {
-        let mut mat = MatZ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut mat = MatZ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpz_mat_set(&mut mat.matrix, &self.matrix);
         }

--- a/src/integer/mat_z/properties.rs
+++ b/src/integer/mat_z/properties.rs
@@ -75,9 +75,9 @@ mod test_is_identity {
 
         assert!(ident.is_identity());
         assert!(nosquare.is_identity());
-        assert!(MatZ::identity(1, 1).unwrap().is_identity());
-        assert!(MatZ::identity(2, 4).unwrap().is_identity());
-        assert!(MatZ::identity(4, 4).unwrap().is_identity());
+        assert!(MatZ::identity(1, 1).is_identity());
+        assert!(MatZ::identity(2, 4).is_identity());
+        assert!(MatZ::identity(4, 4).is_identity());
     }
 
     /// Ensure that is_identity returns `false` for non-identity matrices.

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -60,7 +60,7 @@ impl MatZ {
         T2: Into<Q>,
         T3: Into<Q>,
     {
-        let mut out = Self::new(num_rows, num_cols)?;
+        let mut out = Self::new(num_rows, num_cols);
         let n: Z = n.into();
         let center: Q = center.into();
         let s: Q = s.into();
@@ -92,7 +92,7 @@ impl MatZ {
     /// # Example
     /// ```
     /// use qfall_math::{integer::{MatZ, Z}, rational::{MatQ, Q}};
-    /// let basis = MatZ::identity(5, 5).unwrap();
+    /// let basis = MatZ::identity(5, 5);
     /// let center = MatQ::new(5, 1).unwrap();
     ///
     /// let sample = MatZ::sample_d(&basis, 1024, &center, 1.25f32).unwrap();
@@ -174,7 +174,7 @@ mod test_sample_d {
     /// or Into<Q>, i.e. u8, i16, f32, Z, Q, ...
     #[test]
     fn availability() {
-        let basis = MatZ::identity(5, 5).unwrap();
+        let basis = MatZ::identity(5, 5);
         let n = Z::from(1024);
         let center = MatQ::new(5, 1).unwrap();
         let s = Q::ONE;

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -92,7 +92,7 @@ impl MatZ {
     /// ```
     /// use qfall_math::{integer::{MatZ, Z}, rational::{MatQ, Q}};
     /// let basis = MatZ::identity(5, 5);
-    /// let center = MatQ::new(5, 1).unwrap();
+    /// let center = MatQ::new(5, 1);
     ///
     /// let sample = MatZ::sample_d(&basis, 1024, &center, 1.25f32).unwrap();
     /// ```
@@ -175,7 +175,7 @@ mod test_sample_d {
     fn availability() {
         let basis = MatZ::identity(5, 5);
         let n = Z::from(1024);
-        let center = MatQ::new(5, 1).unwrap();
+        let center = MatQ::new(5, 1);
         let s = Q::ONE;
 
         let _ = MatZ::sample_d(&basis, &16u16, &center, &1u16);

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -41,13 +41,12 @@ impl MatZ {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the number of rows or columns is `0`.
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
     /// if the `n <= 1` or `s <= 0`.
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    /// For further information see [`MatZ::new`].
     pub fn sample_discrete_gauss<T1, T2, T3>(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -64,7 +64,7 @@ impl MatZ {
     {
         let lower_bound: Z = lower_bound.to_owned().into();
         let upper_bound: Z = upper_bound.to_owned().into();
-        let mut matrix = MatZ::new(num_rows, num_cols)?;
+        let mut matrix = MatZ::new(num_rows, num_cols);
 
         let interval_size = &upper_bound - &lower_bound;
         for row in 0..matrix.get_num_rows() {
@@ -168,23 +168,5 @@ mod test_sample_uniform {
         assert_eq!(5, mat_2.get_num_columns());
         assert_eq!(15, mat_3.get_num_rows());
         assert_eq!(20, mat_3.get_num_columns());
-    }
-
-    /// Checks whether matrices with at least one dimension chosen smaller than `1`
-    /// or too big for an [`i64`] results in an error
-    #[test]
-    fn false_sizes() {
-        let lower_bound = Z::from(-15);
-        let upper_bound = Z::from(15);
-
-        let mat_0 = MatZ::sample_uniform(0, 3, &lower_bound, &upper_bound);
-        let mat_1 = MatZ::sample_uniform(3, 0, &lower_bound, &upper_bound);
-        let mat_2 = MatZ::sample_uniform(0, -1, &lower_bound, &upper_bound);
-        let mat_3 = MatZ::sample_uniform(2, u64::MAX, &lower_bound, &upper_bound);
-
-        assert!(mat_0.is_err());
-        assert!(mat_1.is_err());
-        assert!(mat_2.is_err());
-        assert!(mat_3.is_err());
     }
 }

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -44,14 +44,13 @@ impl MatZ {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the number of rows or columns is `0`.
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     /// if the given `upper_bound` isn't at least bigger than `lower_bound + 1`,
     /// i.e. the interval size is at most `1`.
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    /// For further information see [`MatZ::new`].
     pub fn sample_uniform<T1, T2>(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -111,6 +111,17 @@ mod test_sample_uniform {
         }
     }
 
+    /// Checks whether matrices with at least one dimension chosen smaller than `1`
+    /// or too big for an [`i64`] results in an error.
+    #[should_panic]
+    #[test]
+    fn false_size() {
+        let lower_bound = Z::from(-15);
+        let upper_bound = Z::from(15);
+
+        let _ = MatZ::sample_uniform(0, 3, &lower_bound, &upper_bound);
+    }
+
     /// Checks whether providing an invalid interval results in an error.
     #[test]
     fn invalid_interval() {

--- a/src/integer/mat_z/set.rs
+++ b/src/integer/mat_z/set.rs
@@ -48,7 +48,7 @@ impl SetEntry<&Z> for MatZ {
     /// use qfall_math::integer::Z;
     /// use qfall_math::traits::*;
     ///
-    /// let mut matrix = MatZ::new(5, 10).unwrap();
+    /// let mut matrix = MatZ::new(5, 10);
     /// let value = Z::from(5);
     /// matrix.set_entry(1, 1, &value).unwrap();
     /// ```
@@ -99,7 +99,7 @@ impl MatZ {
     /// use qfall_math::integer::MatZ;
     /// use std::str::FromStr;
     ///
-    /// let mut mat1 = MatZ::new(2, 2).unwrap();
+    /// let mut mat1 = MatZ::new(2, 2);
     /// let mat2 = MatZ::from_str("[[1],[2]]").unwrap();
     /// mat1.set_column(1, &mat2, 0);
     /// ```
@@ -157,7 +157,7 @@ impl MatZ {
     /// use qfall_math::integer::MatZ;
     /// use std::str::FromStr;
     ///
-    /// let mut mat1 = MatZ::new(2, 2).unwrap();
+    /// let mut mat1 = MatZ::new(2, 2);
     /// let mat2 = MatZ::from_str("[[1,2]]").unwrap();
     /// mat1.set_row(0, &mat2, 0);
     /// ```
@@ -213,7 +213,7 @@ impl MatZ {
     /// ```
     /// use qfall_math::integer::MatZ;
     ///
-    /// let mut matrix = MatZ::new(4, 3).unwrap();
+    /// let mut matrix = MatZ::new(4, 3);
     /// matrix.swap_entries(0, 0, 2, 1);
     /// ```
     ///
@@ -252,7 +252,7 @@ impl MatZ {
     /// ```
     /// use qfall_math::integer::MatZ;
     ///
-    /// let mut matrix = MatZ::new(4, 3).unwrap();
+    /// let mut matrix = MatZ::new(4, 3);
     /// matrix.swap_columns(0, 2);
     /// ```
     ///
@@ -293,7 +293,7 @@ impl MatZ {
     /// ```
     /// use qfall_math::integer::MatZ;
     ///
-    /// let mut matrix = MatZ::new(4, 3).unwrap();
+    /// let mut matrix = MatZ::new(4, 3);
     /// matrix.swap_rows(0, 2);
     /// ```
     ///
@@ -328,7 +328,7 @@ impl MatZ {
     /// ```
     /// use qfall_math::integer::MatZ;
     ///
-    /// let mut matrix = MatZ::new(4, 3).unwrap();
+    /// let mut matrix = MatZ::new(4, 3);
     /// matrix.reverse_columns();
     /// ```
     pub fn reverse_columns(&mut self) {
@@ -345,7 +345,7 @@ impl MatZ {
     /// ```
     /// use qfall_math::integer::MatZ;
     ///
-    /// let mut matrix = MatZ::new(4, 3).unwrap();
+    /// let mut matrix = MatZ::new(4, 3);
     /// matrix.reverse_rows();
     /// ```
     pub fn reverse_rows(&mut self) {
@@ -366,7 +366,7 @@ mod test_setter {
     /// Ensure that setting entries works with standard numbers.
     #[test]
     fn standard_value() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(869);
         matrix.set_entry(4, 7, &value).unwrap();
 
@@ -378,7 +378,7 @@ mod test_setter {
     /// Ensure that setting entries works with large numbers.
     #[test]
     fn max_int_positive() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(i64::MAX);
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -390,7 +390,7 @@ mod test_setter {
     /// Ensure that setting entries works with large numbers (larger than i64).
     #[test]
     fn big_positive() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(u64::MAX);
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -402,7 +402,7 @@ mod test_setter {
     /// Ensure that setting entries works with referenced large numbers (larger than i64).
     #[test]
     fn big_positive_ref() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value1 = Z::from(u64::MAX);
         let value2 = Z::from(8);
         matrix.set_entry(1, 1, &value1).unwrap();
@@ -418,7 +418,7 @@ mod test_setter {
     /// Ensure that setting entries works with large negative numbers.
     #[test]
     fn max_int_negative() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(i64::MIN);
         matrix.set_entry(1, 1, value).unwrap();
 
@@ -430,7 +430,7 @@ mod test_setter {
     /// Ensure that setting entries works with large negative numbers (larger than i64).
     #[test]
     fn big_negative() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value_str = &format!("-{}", u64::MAX);
         matrix
             .set_entry(1, 1, Z::from_str(value_str).unwrap())
@@ -444,7 +444,7 @@ mod test_setter {
     /// Ensure that setting entries at (0,0) works.
     #[test]
     fn setting_at_zero() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(i64::MIN);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -456,7 +456,7 @@ mod test_setter {
     /// Ensure that a wrong number of rows yields an Error.
     #[test]
     fn error_wrong_row() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(i64::MAX);
 
         assert!(matrix.set_entry(5, 1, value).is_err());
@@ -465,7 +465,7 @@ mod test_setter {
     /// Ensure that a wrong number of columns yields an Error.
     #[test]
     fn error_wrong_column() {
-        let mut matrix = MatZ::new(5, 10).unwrap();
+        let mut matrix = MatZ::new(5, 10);
         let value = Z::from(i64::MAX);
 
         assert!(matrix.set_entry(1, 100, value).is_err());
@@ -527,7 +527,7 @@ mod test_setter {
     /// Ensures that `set_column` returns an error if one of the specified columns is out of bounds
     #[test]
     fn column_out_of_bounds() {
-        let mut m1 = MatZ::new(5, 2).unwrap();
+        let mut m1 = MatZ::new(5, 2);
         let m2 = m1.clone();
 
         assert!(m1.set_column(-1, &m2, 0).is_err());
@@ -539,8 +539,8 @@ mod test_setter {
     /// Ensures that mismatching row dimensions result in an error
     #[test]
     fn column_mismatching_columns() {
-        let mut m1 = MatZ::new(5, 2).unwrap();
-        let m2 = MatZ::new(2, 2).unwrap();
+        let mut m1 = MatZ::new(5, 2);
+        let m2 = MatZ::new(2, 2);
 
         assert!(m1.set_column(0, &m2, 0).is_err());
         assert!(m1.set_column(1, &m2, 1).is_err());
@@ -604,7 +604,7 @@ mod test_setter {
     /// Ensures that `set_row` returns an error if one of the specified rows is out of bounds
     #[test]
     fn row_out_of_bounds() {
-        let mut m1 = MatZ::new(5, 2).unwrap();
+        let mut m1 = MatZ::new(5, 2);
         let m2 = m1.clone();
 
         assert!(m1.set_row(-1, &m2, 0).is_err());
@@ -616,8 +616,8 @@ mod test_setter {
     /// Ensures that mismatching column dimensions result in an error
     #[test]
     fn row_mismatching_columns() {
-        let mut m1 = MatZ::new(3, 2).unwrap();
-        let m2 = MatZ::new(3, 3).unwrap();
+        let mut m1 = MatZ::new(3, 2);
+        let m2 = MatZ::new(3, 3);
 
         assert!(m1.set_row(0, &m2, 0).is_err());
         assert!(m1.set_row(1, &m2, 1).is_err());
@@ -684,7 +684,7 @@ mod test_swaps {
     /// Ensures that `swap_entries` returns an error if one of the specified entries is out of bounds
     #[test]
     fn entries_out_of_bounds() {
-        let mut matrix = MatZ::new(5, 2).unwrap();
+        let mut matrix = MatZ::new(5, 2);
 
         assert!(matrix.swap_entries(-1, 0, 0, 0).is_err());
         assert!(matrix.swap_entries(0, -1, 0, 0).is_err());
@@ -750,7 +750,7 @@ mod test_swaps {
     /// Ensures that `swap_columns` returns an error if one of the specified columns is out of bounds
     #[test]
     fn column_out_of_bounds() {
-        let mut matrix = MatZ::new(5, 2).unwrap();
+        let mut matrix = MatZ::new(5, 2);
 
         assert!(matrix.swap_columns(-1, 0).is_err());
         assert!(matrix.swap_columns(0, -1).is_err());
@@ -812,7 +812,7 @@ mod test_swaps {
     /// Ensures that `swap_rows` returns an error if one of the specified rows is out of bounds
     #[test]
     fn row_out_of_bounds() {
-        let mut matrix = MatZ::new(2, 4).unwrap();
+        let mut matrix = MatZ::new(2, 4);
 
         assert!(matrix.swap_rows(-1, 0).is_err());
         assert!(matrix.swap_rows(0, -1).is_err());

--- a/src/integer/mat_z/sort.rs
+++ b/src/integer/mat_z/sort.rs
@@ -76,7 +76,7 @@ impl MatZ {
         let mut id_vec: Vec<usize> = (0..self.get_num_columns() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);
 
-        let mut out = Self::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = Self::new(self.get_num_rows(), self.get_num_columns());
         for (col, item) in id_vec.iter().enumerate() {
             out.set_column(col, self, *item).unwrap();
         }
@@ -144,7 +144,7 @@ impl MatZ {
         let mut id_vec: Vec<usize> = (0..self.get_num_rows() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);
 
-        let mut out = Self::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = Self::new(self.get_num_rows(), self.get_num_columns());
         for (row, item) in id_vec.iter().enumerate() {
             out.set_row(row, self, *item).unwrap();
         }

--- a/src/integer/mat_z/tensor.rs
+++ b/src/integer/mat_z/tensor.rs
@@ -41,8 +41,7 @@ impl Tensor for MatZ {
         let mut out = MatZ::new(
             self.get_num_rows() * other.get_num_rows(),
             self.get_num_columns() * other.get_num_columns(),
-        )
-        .unwrap();
+        );
 
         unsafe { fmpz_mat_kronecker_product(&mut out.matrix, &self.matrix, &other.matrix) };
 
@@ -60,8 +59,8 @@ mod test_tensor {
     /// Ensure that the dimensions of the tensor product are taken over correctly.
     #[test]
     fn dimensions_fit() {
-        let mat_1 = MatZ::new(17, 13).unwrap();
-        let mat_2 = MatZ::new(3, 4).unwrap();
+        let mat_1 = MatZ::new(17, 13);
+        let mat_2 = MatZ::new(3, 4);
 
         let mat_3 = mat_1.tensor_product(&mat_2);
 

--- a/src/integer/mat_z/transpose.rs
+++ b/src/integer/mat_z/transpose.rs
@@ -28,7 +28,7 @@ impl MatZ {
     /// assert_eq!(mat.transpose(), cmp);
     /// ```
     pub fn transpose(&self) -> Self {
-        let mut out = Self::new(self.get_num_columns(), self.get_num_rows()).unwrap();
+        let mut out = Self::new(self.get_num_columns(), self.get_num_rows());
         unsafe { fmpz_mat_transpose(&mut out.matrix, &self.matrix) };
         out
     }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
@@ -21,8 +21,7 @@ impl MatPolynomialRingZq {
     /// - `num_cols`: number of columns the new matrix should have
     /// - `modulus`: the common modulus of the matrix entries
     ///
-    /// Returns a [`MatPolynomialRingZq`] or an error, if the number of rows or columns is
-    /// less than `1`.
+    /// Returns a new [`MatPolynomialRingZq`] instance of the provided dimensions..
     ///
     /// # Examples
     /// ```

--- a/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
@@ -9,7 +9,7 @@
 //! Initialize a [`MatPolynomialRingZq`] with common defaults, e.g., zero and identity.
 
 use super::MatPolynomialRingZq;
-use crate::{error::MathError, integer::MatPolyOverZ, integer_mod_q::ModulusPolynomialRingZq};
+use crate::{integer::MatPolyOverZ, integer_mod_q::ModulusPolynomialRingZq};
 use std::fmt::Display;
 
 impl MatPolynomialRingZq {
@@ -34,27 +34,23 @@ impl MatPolynomialRingZq {
     /// let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
     /// let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
     ///
-    /// let matrix = MatPolynomialRingZq::new(5, 10, &modulus).unwrap();
+    /// let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the number of rows or columns is `0`.
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
+    /// # Panics ...
+    /// - if the number of rows or columns is negative, zero, or does not fit into an [`i64`].
     #[allow(dead_code)]
     pub fn new(
         num_rows: impl TryInto<i64> + Display + Copy,
         num_cols: impl TryInto<i64> + Display + Copy,
         modulus: &ModulusPolynomialRingZq,
-    ) -> Result<Self, MathError> {
-        let matrix = MatPolyOverZ::new(num_rows, num_cols)?;
+    ) -> Self {
+        let matrix = MatPolyOverZ::new(num_rows, num_cols);
 
-        Ok(MatPolynomialRingZq {
+        MatPolynomialRingZq {
             matrix,
             modulus: modulus.clone(),
-        })
+        }
     }
 }
 
@@ -73,24 +69,29 @@ mod test_new {
         let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
         let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
 
-        assert!(MatPolynomialRingZq::new(2, 2, &modulus).is_ok());
+        let _ = MatPolynomialRingZq::new(2, 2, &modulus);
     }
 
     // TODO: add a test for zero entries
 
-    /// Ensure that a new zero matrix fails with `0` as input.
+    /// Ensure that a new zero matrix fails with `0` as `num_cols`.
+    #[should_panic]
     #[test]
-    fn error_zero() {
+    fn error_zero_num_cols() {
         let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
         let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
 
-        let matrix1 = MatPolynomialRingZq::new(0, 1, &modulus);
-        let matrix2 = MatPolynomialRingZq::new(1, 0, &modulus);
-        let matrix3 = MatPolynomialRingZq::new(0, 0, &modulus);
+        let _ = MatPolynomialRingZq::new(1, 0, &modulus);
+    }
 
-        assert!(matrix1.is_err());
-        assert!(matrix2.is_err());
-        assert!(matrix3.is_err());
+    /// Ensure that a new zero matrix fails with `0` as `num_rows`.
+    #[should_panic]
+    #[test]
+    fn error_zero_num_rows() {
+        let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
+        let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
+
+        let _ = MatPolynomialRingZq::new(0, 1, &modulus);
     }
 
     /// Ensure that the modulus can be large.
@@ -100,6 +101,6 @@ mod test_new {
             PolyOverZq::from_str(&format!("3  1 {} 1 mod {}", i64::MAX, BITPRIME64)).unwrap();
         let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
 
-        assert!(MatPolynomialRingZq::new(2, 2, &modulus).is_ok());
+        let _ = MatPolynomialRingZq::new(2, 2, &modulus);
     }
 }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -205,7 +205,7 @@ mod test_get_entry {
     #[test]
     fn get_edges() {
         let modulus = ModulusPolynomialRingZq::from_str("2  42 17 mod 89").unwrap();
-        let matrix = MatPolynomialRingZq::new(5, 10, &modulus).unwrap();
+        let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(4, 9).unwrap();
@@ -239,7 +239,7 @@ mod test_get_entry {
         let modulus =
             ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", BITPRIME64))
                 .unwrap();
-        let matrix = MatPolynomialRingZq::new(5, 10, &modulus).unwrap();
+        let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
         let entry1: Result<PolyOverZ, MathError> = matrix.get_entry(5, 1);
         let entry2: Result<PolyOverZ, MathError> = matrix.get_entry(5, 10);
 
@@ -253,7 +253,7 @@ mod test_get_entry {
         let modulus =
             ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", BITPRIME64))
                 .unwrap();
-        let matrix = MatPolynomialRingZq::new(5, 10, &modulus).unwrap();
+        let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
         let entry: Result<PolyOverZ, MathError> = matrix.get_entry(1, 100);
 
         assert!(entry.is_err());
@@ -265,7 +265,7 @@ mod test_get_entry {
         let modulus =
             ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", BITPRIME64))
                 .unwrap();
-        let matrix = MatPolynomialRingZq::new(5, 10, &modulus).unwrap();
+        let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
 
         let _: PolyOverZ = matrix.get_entry(0, 0).unwrap();
         let _: PolynomialRingZq = matrix.get_entry(0, 0).unwrap();
@@ -284,7 +284,7 @@ mod test_get_num {
     #[test]
     fn num_rows() {
         let modulus = ModulusPolynomialRingZq::from_str("2  42 17 mod 89").unwrap();
-        let matrix = MatPolynomialRingZq::new(5, 10, &modulus).unwrap();
+        let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
 
         assert_eq!(matrix.get_num_rows(), 5);
     }
@@ -293,7 +293,7 @@ mod test_get_num {
     #[test]
     fn num_columns() {
         let modulus = ModulusPolynomialRingZq::from_str("2  42 17 mod 89").unwrap();
-        let matrix = MatPolynomialRingZq::new(5, 10, &modulus).unwrap();
+        let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
 
         assert_eq!(matrix.get_num_columns(), 10);
     }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/transpose.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/transpose.rs
@@ -29,8 +29,7 @@ impl MatPolynomialRingZq {
     /// let transpose = poly_ring_mat.transpose();
     /// ```
     pub fn transpose(&self) -> Self {
-        let mut out =
-            Self::new(self.get_num_columns(), self.get_num_rows(), &self.modulus).unwrap();
+        let mut out = Self::new(self.get_num_columns(), self.get_num_rows(), &self.modulus);
         unsafe { fmpz_poly_mat_transpose(&mut out.matrix.matrix, &self.matrix.matrix) };
         out
     }

--- a/src/integer_mod_q/mat_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/add.rs
@@ -93,8 +93,7 @@ impl MatZq {
                 other.get_num_columns()
             )));
         }
-        let mut out =
-            MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod()).unwrap();
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod());
         unsafe {
             fmpz_mod_mat_add(&mut out.matrix, &self.matrix, &other.matrix);
         }

--- a/src/integer_mod_q/mat_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/mul.rs
@@ -91,8 +91,7 @@ impl Mul<&MatZ> for &MatZq {
             panic!("Tried to multiply matrices with mismatching matrix dimensions.");
         }
 
-        let mut new =
-            MatZq::new(self.get_num_rows(), other.get_num_columns(), self.get_mod()).unwrap();
+        let mut new = MatZq::new(self.get_num_rows(), other.get_num_columns(), self.get_mod());
         unsafe {
             fmpz_mat_mul(&mut new.matrix.mat[0], &self.matrix.mat[0], &other.matrix);
             _fmpz_mod_mat_reduce(&mut new.matrix)
@@ -151,8 +150,7 @@ impl MatZq {
             )));
         }
 
-        let mut new =
-            MatZq::new(self.get_num_rows(), other.get_num_columns(), self.get_mod()).unwrap();
+        let mut new = MatZq::new(self.get_num_rows(), other.get_num_columns(), self.get_mod());
         unsafe { fmpz_mod_mat_mul(&mut new.matrix, &self.matrix, &other.matrix) };
         Ok(new)
     }
@@ -192,7 +190,7 @@ mod test_mul {
         let mat =
             MatZq::from_str(&format!("[[{},1],[0,2]] mod {}", u64::MAX, u64::MAX - 58)).unwrap();
         let vec = MatZq::from_str(&format!("[[{}],[0]] mod {}", u64::MAX, u64::MAX - 58)).unwrap();
-        let mut cmp = MatZq::new(2, 1, u64::MAX - 58).unwrap();
+        let mut cmp = MatZq::new(2, 1, u64::MAX - 58);
         let max: Z = u64::MAX.into();
         cmp.set_entry(0, 0, &(&max * &max)).unwrap();
 
@@ -247,7 +245,7 @@ mod test_mul_matz {
         let mat =
             MatZq::from_str(&format!("[[{},1],[0,2]] mod {}", u64::MAX, u64::MAX - 58)).unwrap();
         let vec = MatZ::from_str(&format!("[[{}],[0]]", u64::MAX)).unwrap();
-        let mut cmp = MatZq::new(2, 1, u64::MAX - 58).unwrap();
+        let mut cmp = MatZq::new(2, 1, u64::MAX - 58);
         let max: Z = u64::MAX.into();
         cmp.set_entry(0, 0, &(&max * &max)).unwrap();
 

--- a/src/integer_mod_q/mat_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/mul_scalar.rs
@@ -42,8 +42,7 @@ impl Mul<&Z> for &MatZq {
     /// let mat2 = &mat1 * &integer;
     /// ```
     fn mul(self, scalar: &Z) -> Self::Output {
-        let mut out =
-            MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod()).unwrap();
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod());
         unsafe {
             fmpz_mod_mat_scalar_mul_fmpz(&mut out.matrix, &self.matrix, &scalar.value);
         }
@@ -125,8 +124,7 @@ impl MatZq {
             )));
         }
 
-        let mut out =
-            MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod()).unwrap();
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod());
         unsafe {
             fmpz_mod_mat_scalar_mul_fmpz(&mut out.matrix, &self.matrix, &scalar.value.value);
         }

--- a/src/integer_mod_q/mat_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/sub.rs
@@ -93,8 +93,7 @@ impl MatZq {
                 other.get_num_columns()
             )));
         }
-        let mut out =
-            MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod()).unwrap();
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod());
         unsafe {
             fmpz_mod_mat_sub(&mut out.matrix, &self.matrix, &other.matrix);
         }

--- a/src/integer_mod_q/mat_zq/cmp.rs
+++ b/src/integer_mod_q/mat_zq/cmp.rs
@@ -61,7 +61,7 @@ mod test_partial_eq {
     #[test]
     fn equality_between_instantiations() {
         let a = MatZq::from_str("[[0,1],[0,0]] mod 4").unwrap();
-        let mut b = MatZq::new(2, 2, 4).unwrap();
+        let mut b = MatZq::new(2, 2, 4);
         b.set_entry(0, 1, 1).unwrap();
 
         assert_eq!(a, b);

--- a/src/integer_mod_q/mat_zq/concat.rs
+++ b/src/integer_mod_q/mat_zq/concat.rs
@@ -31,8 +31,8 @@ impl Concatenate for &MatZq {
     /// use qfall_math::traits::*;
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let mat_1 = MatZq::new(13, 5, 19).unwrap();
-    /// let mat_2 = MatZq::new(17, 5, 19).unwrap();
+    /// let mat_1 = MatZq::new(13, 5, 19);
+    /// let mat_2 = MatZq::new(17, 5, 19);
     ///
     /// let mat_vert = mat_1.concat_vertical(&mat_2).unwrap();
     /// ```
@@ -67,8 +67,7 @@ impl Concatenate for &MatZq {
             self.get_num_rows() + other.get_num_rows(),
             self.get_num_columns(),
             self.get_mod(),
-        )
-        .unwrap();
+        );
         unsafe {
             fmpz_mod_mat_concat_vertical(&mut out.matrix, &self.matrix, &other.matrix);
         }
@@ -88,8 +87,8 @@ impl Concatenate for &MatZq {
     /// use qfall_math::traits::*;
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let mat_1 = MatZq::new(17, 5, 19).unwrap();
-    /// let mat_2 = MatZq::new(17, 6, 19).unwrap();
+    /// let mat_1 = MatZq::new(17, 5, 19);
+    /// let mat_2 = MatZq::new(17, 6, 19);
     ///
     /// let mat_vert = mat_1.concat_horizontal(&mat_2).unwrap();
     /// ```
@@ -124,8 +123,7 @@ impl Concatenate for &MatZq {
             self.get_num_rows(),
             self.get_num_columns() + other.get_num_columns(),
             self.get_mod(),
-        )
-        .unwrap();
+        );
         unsafe {
             fmpz_mod_mat_concat_horizontal(&mut out.matrix, &self.matrix, &other.matrix);
         }
@@ -146,9 +144,9 @@ mod test_concatenate {
     /// if the dimensions mismatch
     #[test]
     fn dimensions_vertical() {
-        let mat_1 = MatZq::new(13, 5, 17).unwrap();
-        let mat_2 = MatZq::new(17, 5, 17).unwrap();
-        let mat_3 = MatZq::new(17, 6, 17).unwrap();
+        let mat_1 = MatZq::new(13, 5, 17);
+        let mat_2 = MatZq::new(17, 5, 17);
+        let mat_3 = MatZq::new(17, 6, 17);
 
         let mat_vert = mat_1.concat_vertical(&mat_2).unwrap();
 
@@ -161,9 +159,9 @@ mod test_concatenate {
     /// if the dimensions mismatch
     #[test]
     fn dimensions_horizontal() {
-        let mat_1 = MatZq::new(13, 5, 17).unwrap();
-        let mat_2 = MatZq::new(17, 5, 17).unwrap();
-        let mat_3 = MatZq::new(17, 6, 17).unwrap();
+        let mat_1 = MatZq::new(13, 5, 17);
+        let mat_2 = MatZq::new(17, 5, 17);
+        let mat_3 = MatZq::new(17, 6, 17);
 
         let mat_hor = mat_2.concat_horizontal(&mat_3).unwrap();
 
@@ -176,8 +174,8 @@ mod test_concatenate {
     /// in an error
     #[test]
     fn mismatching_moduli() {
-        let mat_1 = MatZq::new(2, 2, 17).unwrap();
-        let mat_2 = MatZq::new(2, 2, 19).unwrap();
+        let mat_1 = MatZq::new(2, 2, 17);
+        let mat_2 = MatZq::new(2, 2, 19);
 
         let mat_hor = mat_1.concat_horizontal(&mat_2);
         let mat_vert = mat_1.concat_vertical(&mat_2);

--- a/src/integer_mod_q/mat_zq/default.rs
+++ b/src/integer_mod_q/mat_zq/default.rs
@@ -9,7 +9,7 @@
 //! Initialize a [`MatZq`] with common defaults, e.g., zero and identity.
 
 use super::MatZq;
-use crate::{error::MathError, integer::Z, integer_mod_q::Modulus, utils::index::evaluate_indices};
+use crate::{integer::Z, integer_mod_q::Modulus, utils::index::evaluate_indices};
 use flint_sys::fmpz_mod_mat::{fmpz_mod_mat_init, fmpz_mod_mat_one};
 use std::{fmt::Display, mem::MaybeUninit};
 
@@ -29,35 +29,27 @@ impl MatZq {
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let matrix = MatZq::new(5, 10, 7).unwrap();
+    /// let matrix = MatZq::new(5, 10, 7);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the number of rows or columns is `0`.
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
-    /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the provided value is not greater than `1`.
+    /// # Panics ...
+    /// - if the number of rows or columns is negative, zero, or does not fit into an [`i64`].
+    /// - if the provided value is not greater than `1`.
     pub fn new(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
         modulus: impl Into<Z>,
-    ) -> Result<Self, MathError> {
-        let (num_rows_i64, num_cols_i64) = evaluate_indices(num_rows, num_cols)?;
+    ) -> Self {
+        let (num_rows_i64, num_cols_i64) = evaluate_indices(num_rows, num_cols).unwrap();
 
         if num_rows_i64 == 0 || num_cols_i64 == 0 {
-            return Err(MathError::InvalidMatrix(format!(
-                "({},{})",
-                num_rows_i64, num_cols_i64,
-            )));
+            panic!("A matrix can not contain 0 rows or 0 columns");
         }
 
-        let modulus = std::convert::Into::<Z>::into(modulus);
+        let modulus: Z = modulus.into();
 
         if modulus <= Z::ONE {
-            return Err(MathError::InvalidIntToModulus(format!("{}", modulus)));
+            panic!("The modulus provided for MatZq initialization must be bigger than 1, but it is {modulus}.");
         }
 
         let mut matrix = MaybeUninit::uninit();
@@ -69,11 +61,11 @@ impl MatZq {
                 &modulus.value,
             );
 
-            Ok(MatZq {
+            MatZq {
                 matrix: matrix.assume_init(),
                 // we can unwrap here since modulus > 1 was checked before
                 modulus: Modulus::try_from(&modulus).unwrap(),
-            })
+            }
         }
     }
 
@@ -92,27 +84,24 @@ impl MatZq {
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let matrix = MatZq::identity(2, 3, 3).unwrap();
+    /// let matrix = MatZq::identity(2, 3, 3);
     ///
-    /// let identity = MatZq::identity(10, 10, 3).unwrap();
+    /// let identity = MatZq::identity(10, 10, 3);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix) or
-    /// [`OutOfBounds`](MathError::OutOfBounds) if the provided number of rows and columns
-    /// are not suited to create a matrix. For further information see [`MatZq::new`].
-    /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the modulus is not greater than `1`. For further information see [`MatZq::new`].
+    /// # Panics ...
+    /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.
+    /// For further information see [`MatZq::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
         modulus: impl Into<Z>,
-    ) -> Result<Self, MathError> {
-        let mut out = MatZq::new(num_rows, num_cols, modulus)?;
+    ) -> Self {
+        let mut out = MatZq::new(num_rows, num_cols, modulus);
         if Z::ONE != Z::from(&out.modulus) {
             unsafe { fmpz_mod_mat_one(&mut out.matrix) };
         }
-        Ok(out)
+        out
     }
 }
 
@@ -123,7 +112,7 @@ mod test_identity {
     /// Tests if an identity matrix is set from a zero matrix.
     #[test]
     fn identity() {
-        let matrix = MatZq::identity(10, 10, 3).unwrap();
+        let matrix = MatZq::identity(10, 10, 3);
 
         for i in 0..10 {
             for j in 0..10 {
@@ -139,7 +128,7 @@ mod test_identity {
     /// Tests if function works for a non-square matrix
     #[test]
     fn non_square_works() {
-        let matrix = MatZq::identity(10, 7, 3).unwrap();
+        let matrix = MatZq::identity(10, 7, 3);
 
         for i in 0..10 {
             for j in 0..7 {
@@ -151,7 +140,7 @@ mod test_identity {
             }
         }
 
-        let matrix = MatZq::identity(7, 10, 3).unwrap();
+        let matrix = MatZq::identity(7, 10, 3);
 
         for i in 0..7 {
             for j in 0..10 {
@@ -167,7 +156,7 @@ mod test_identity {
     /// Tests if an identity matrix can be created using a large modulus.
     #[test]
     fn modulus_large() {
-        let matrix = MatZq::identity(10, 10, i64::MAX).unwrap();
+        let matrix = MatZq::identity(10, 10, i64::MAX);
 
         for i in 0..10 {
             for j in 0..10 {
@@ -181,9 +170,10 @@ mod test_identity {
     }
 
     /// Assert that a modulus of `1` is not allowed.
+    #[should_panic]
     #[test]
     fn modulus_one() {
-        assert!(MatZq::identity(10, 10, 1).is_err());
+        let _ = MatZq::identity(10, 10, 1);
     }
 }
 
@@ -194,13 +184,13 @@ mod test_new {
     /// Ensure that initialization works.
     #[test]
     fn initialization() {
-        assert!(MatZq::new(2, 2, 3).is_ok());
+        let _ = MatZq::new(2, 2, 3);
     }
 
     /// Ensure that entries of a new matrix are `0`.
     #[test]
     fn entry_zero() {
-        let matrix = MatZq::new(2, 2, 3).unwrap();
+        let matrix = MatZq::new(2, 2, 3);
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(0, 1).unwrap();
@@ -213,22 +203,31 @@ mod test_new {
         assert_eq!(Z::ZERO, entry4);
     }
 
-    /// Ensure that a new zero matrix fails with `0` as input.
+    /// Ensure that a new zero matrix fails with `0` as `num_cols`.
+    #[should_panic]
     #[test]
-    fn error_zero() {
-        let matrix1 = MatZq::new(1, 0, 3);
-        let matrix2 = MatZq::new(0, 1, 3);
-        let matrix3 = MatZq::new(0, 0, 3);
+    fn error_zero_num_cols() {
+        let _ = MatZq::new(1, 0, 3);
+    }
 
-        assert!(matrix1.is_err());
-        assert!(matrix2.is_err());
-        assert!(matrix3.is_err());
+    /// Ensure that a new zero matrix fails with `0` as `num_rows`.
+    #[should_panic]
+    #[test]
+    fn error_zero_num_rows() {
+        let _ = MatZq::new(0, 1, 3);
     }
 
     /// Ensure that an invalid modulus yields an error.
+    #[should_panic]
     #[test]
     fn invalid_modulus_error() {
-        assert!(MatZq::new(2, 2, -3).is_err());
-        assert!(MatZq::new(2, 2, 0).is_err());
+        let _ = MatZq::new(2, 2, 1);
+    }
+
+    /// Ensure that a negative modulus yields an error.
+    #[should_panic]
+    #[test]
+    fn negative_modulus_error() {
+        let _ = MatZq::new(2, 2, -3);
     }
 }

--- a/src/integer_mod_q/mat_zq/default.rs
+++ b/src/integer_mod_q/mat_zq/default.rs
@@ -22,8 +22,7 @@ impl MatZq {
     /// - `num_cols`: number of columns the new matrix should have
     /// - `modulus`: the common modulus of the matrix entries
     ///
-    /// Returns a [`MatZq`] or an error, if the number of rows or columns is
-    /// less than `1` or the modulus is less than `1`.
+    /// Returns a new [`MatZq`] instance of the provided dimensions.
     ///
     /// # Examples
     /// ```

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -154,7 +154,7 @@ mod test_from_mat_z_modulus {
     /// Test if the dimensions are taken over correctly
     #[test]
     fn dimensions() {
-        let matz = MatZ::new(15, 17).unwrap();
+        let matz = MatZ::new(15, 17);
         let modulus = Modulus::try_from(&17.into()).unwrap();
 
         let matzq_1 = MatZq::from((&matz, &modulus));
@@ -169,7 +169,7 @@ mod test_from_mat_z_modulus {
     /// Test if entries are taken over correctly
     #[test]
     fn entries_taken_over_correctly() {
-        let mut matz = MatZ::new(2, 2).unwrap();
+        let mut matz = MatZ::new(2, 2);
         let modulus = Modulus::try_from(&u64::MAX.into()).unwrap();
 
         matz.set_entry(0, 0, u64::MAX - 58).unwrap();

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -46,7 +46,7 @@ impl MatZq {
     /// let a = MatZq::from_mat_z_modulus(&m, &modulus);
     /// ```
     pub fn from_mat_z_modulus(matrix: &MatZ, modulus: &Modulus) -> Self {
-        let mut out = MatZq::new(matrix.get_num_rows(), matrix.get_num_columns(), modulus).unwrap();
+        let mut out = MatZq::new(matrix.get_num_rows(), matrix.get_num_columns(), modulus);
         unsafe {
             fmpz_mat_set(&mut out.matrix.mat[0], &matrix.matrix);
             _fmpz_mod_mat_reduce(&mut out.matrix);
@@ -96,8 +96,7 @@ impl FromStr for MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the matrix is not formatted in a suitable way,
-    /// the number of rows or columns is too big (must fit into [`i64`]) or
+    /// if the matrix is not formatted in a suitable way or
     /// if the number of entries in rows is unequal.
     /// - Returns a [`MathError`] of type
     /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
@@ -105,9 +104,10 @@ impl FromStr for MatZq {
     /// - Returns a [`MathError`] of type
     /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
     /// if the modulus or an entry is not formatted correctly.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the modulus is not greater than `1`.
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.
+    /// For further information see [`MatZq::new`].
     fn from_str(string: &str) -> Result<Self, MathError> {
         let (matrix, modulus) = match string.split_once("mod") {
             Some((matrix, modulus)) => (matrix, modulus),
@@ -123,7 +123,7 @@ impl FromStr for MatZq {
 
         let string_matrix = parse_matrix_string(matrix.trim())?;
         let (num_rows, num_cols) = find_matrix_dimensions(&string_matrix)?;
-        let mut matrix = MatZq::new(num_rows, num_cols, modulus)?;
+        let mut matrix = MatZq::new(num_rows, num_cols, modulus);
 
         // fill entries of matrix according to entries in string_matrix
         for (row_num, row) in string_matrix.iter().enumerate() {

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -30,7 +30,7 @@ impl MatZq {
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let matrix = MatZq::new(5, 10, 7).unwrap();
+    /// let matrix = MatZq::new(5, 10, 7);
     /// let entry = matrix.get_mod();
     /// ```
     pub fn get_mod(&self) -> Modulus {
@@ -46,7 +46,7 @@ impl GetNumRows for MatZq {
     /// use qfall_math::integer_mod_q::MatZq;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatZq::new(5, 6, 7).unwrap();
+    /// let matrix = MatZq::new(5, 6, 7);
     /// let rows = matrix.get_num_rows();
     /// ```
     fn get_num_rows(&self) -> i64 {
@@ -62,7 +62,7 @@ impl GetNumColumns for MatZq {
     /// use qfall_math::integer_mod_q::MatZq;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatZq::new(5, 6, 7).unwrap();
+    /// let matrix = MatZq::new(5, 6, 7);
     /// let rows = matrix.get_num_columns();
     /// ```
     fn get_num_columns(&self) -> i64 {
@@ -87,7 +87,7 @@ impl GetEntry<Z> for MatZq {
     /// use qfall_math::traits::GetEntry;
     /// use qfall_math::integer::Z;
     ///
-    /// let matrix = MatZq::new(5, 10, 7).unwrap();
+    /// let matrix = MatZq::new(5, 10, 7);
     /// let entry: Z = matrix.get_entry(0, 1).unwrap();
     /// ```
     ///
@@ -125,7 +125,7 @@ impl GetEntry<Zq> for MatZq {
     /// use qfall_math::traits::GetEntry;
     /// use qfall_math::integer::Z;
     ///
-    /// let matrix = MatZq::new(5, 10, 7).unwrap();
+    /// let matrix = MatZq::new(5, 10, 7);
     /// let entry: Z = matrix.get_entry(0, 1).unwrap();
     /// ```
     ///
@@ -177,7 +177,7 @@ impl MatZq {
             ));
         }
 
-        let out = MatZq::new(1, self.get_num_columns(), self.get_mod()).unwrap();
+        let out = MatZq::new(1, self.get_num_columns(), self.get_mod());
         for column in 0..self.get_num_columns() {
             unsafe {
                 fmpz_set(
@@ -223,7 +223,7 @@ impl MatZq {
             ));
         }
 
-        let out = MatZq::new(self.get_num_rows(), 1, self.get_mod()).unwrap();
+        let out = MatZq::new(self.get_num_rows(), 1, self.get_mod());
         for row in 0..self.get_num_rows() {
             unsafe {
                 fmpz_set(
@@ -303,7 +303,7 @@ mod test_get_entry {
     /// Ensure that getting entries works on the edge.
     #[test]
     fn get_edges() {
-        let matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let matrix = MatZq::new(5, 10, u64::MAX);
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(4, 9).unwrap();
@@ -315,7 +315,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large numbers.
     #[test]
     fn max_int_positive() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         let value = Z::from(i64::MAX);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -327,7 +327,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large numbers (larger than [`i64`]).
     #[test]
     fn big_positive() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         let value = Z::from(u64::MAX - 1);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -339,7 +339,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large numbers.
     #[test]
     fn max_int_negative() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         let value = Z::from(-i64::MAX);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -351,7 +351,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large numbers (larger than [`i64`]).
     #[test]
     fn big_negative() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         let value = Z::from(-i64::MAX - 1);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -366,7 +366,7 @@ mod test_get_entry {
     /// Ensure that a wrong number of rows yields an Error.
     #[test]
     fn error_wrong_row() {
-        let matrix = MatZq::new(5, 10, 7).unwrap();
+        let matrix = MatZq::new(5, 10, 7);
         let entry1: Result<Zq, MathError> = matrix.get_entry(5, 1);
         let entry2: Result<Zq, MathError> = matrix.get_entry(5, 10);
 
@@ -377,7 +377,7 @@ mod test_get_entry {
     /// Ensure that a wrong number of columns yields an Error.
     #[test]
     fn error_wrong_column() {
-        let matrix = MatZq::new(5, 10, 7).unwrap();
+        let matrix = MatZq::new(5, 10, 7);
         let entry: Result<Zq, MathError> = matrix.get_entry(1, 100);
 
         assert!(entry.is_err());
@@ -386,7 +386,7 @@ mod test_get_entry {
     /// Ensure that the entry is a deep copy and not just a clone of the reference.
     #[test]
     fn memory_test() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         let value = Zq::from_str(&format!("{} mod {}", u64::MAX - 1, u64::MAX)).unwrap();
         matrix.set_entry(1, 1, value).unwrap();
         let entry = matrix.get_entry(1, 1).unwrap();
@@ -398,7 +398,7 @@ mod test_get_entry {
     /// Ensure that no memory leak occurs in get_entry with ['Z'](crate::integer::Z).
     #[test]
     fn get_entry_z_memory() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         matrix.set_entry(1, 1, Z::from(u64::MAX - 3)).unwrap();
         let _: Z = matrix.get_entry(1, 1).unwrap();
         matrix.set_entry(2, 2, Z::from(u64::MAX - 10)).unwrap();
@@ -412,7 +412,7 @@ mod test_get_entry {
     /// Ensure that no memory leak occurs in get_entry with ['Zq'](crate::integer_mod_q::Zq).
     #[test]
     fn get_entry_zq_memory() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         matrix.set_entry(1, 1, Z::from(u64::MAX - 3)).unwrap();
         let _: Zq = matrix.get_entry(1, 1).unwrap();
         matrix.set_entry(2, 2, Z::from(u64::MAX - 10)).unwrap();
@@ -426,7 +426,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with different types.
     #[test]
     fn diff_types() {
-        let matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let matrix = MatZq::new(5, 10, u64::MAX);
 
         let _: Z = matrix.get_entry(0, 0).unwrap();
         let _: Zq = matrix.get_entry(0, 0).unwrap();
@@ -443,7 +443,7 @@ mod test_get_num {
     /// Ensure that the getter for number of rows works correctly.
     #[test]
     fn num_rows() {
-        let matrix = MatZq::new(5, 10, 7).unwrap();
+        let matrix = MatZq::new(5, 10, 7);
 
         assert_eq!(matrix.get_num_rows(), 5);
     }
@@ -451,7 +451,7 @@ mod test_get_num {
     /// Ensure that the getter for number of columns works correctly.
     #[test]
     fn num_columns() {
-        let matrix = MatZq::new(5, 10, 7).unwrap();
+        let matrix = MatZq::new(5, 10, 7);
 
         assert_eq!(matrix.get_num_columns(), 10);
     }
@@ -468,7 +468,7 @@ mod test_mod {
     /// Ensure that the getter for modulus works correctly.
     #[test]
     fn get_mod() {
-        let matrix = MatZq::new(5, 10, 7).unwrap();
+        let matrix = MatZq::new(5, 10, 7);
 
         assert_eq!(matrix.get_mod(), Modulus::from_str("7").unwrap());
     }
@@ -476,7 +476,7 @@ mod test_mod {
     /// Ensure that the getter for modulus works with large numbers.
     #[test]
     fn get_mod_large() {
-        let matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let matrix = MatZq::new(5, 10, u64::MAX);
 
         assert_eq!(
             matrix.get_mod(),
@@ -487,7 +487,7 @@ mod test_mod {
     /// Ensure that no memory leak occurs in get_mod.
     #[test]
     fn get_mod_memory() {
-        let matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let matrix = MatZq::new(5, 10, u64::MAX);
         let _ = matrix.get_mod();
         let _ = Modulus::try_from_z(&Z::from(u64::MAX - 1));
 

--- a/src/integer_mod_q/mat_zq/ownership.rs
+++ b/src/integer_mod_q/mat_zq/ownership.rs
@@ -33,8 +33,7 @@ impl Clone for MatZq {
             self.get_num_rows(),
             self.get_num_columns(),
             Z::from(self.get_mod()),
-        )
-        .unwrap();
+        );
         unsafe {
             fmpz_mod_mat_init_set(&mut out.matrix, &self.matrix);
         }

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -95,8 +95,8 @@ impl MatZq {
     /// # Example
     /// ```
     /// use qfall_math::{integer_mod_q::MatZq, rational::MatQ};
-    /// let basis = MatZq::identity(5, 5, 17).unwrap();
-    /// let center = MatQ::new(5, 1).unwrap();
+    /// let basis = MatZq::identity(5, 5, 17);
+    /// let center = MatQ::new(5, 1);
     ///
     /// let sample = MatZq::sample_d(&basis, 1024, &center, 1.25f32).unwrap();
     /// ```
@@ -182,9 +182,9 @@ mod test_sample_d {
     /// or Into<Q>, i.e. u8, i16, f32, Z, Q, ...
     #[test]
     fn availability() {
-        let basis = MatZq::identity(5, 5, 17).unwrap();
+        let basis = MatZq::identity(5, 5, 17);
         let n = Z::from(1024);
-        let center = MatQ::new(5, 1).unwrap();
+        let center = MatQ::new(5, 1);
         let s = Q::ONE;
 
         let _ = MatZq::sample_d(&basis, &16u16, &center, &1u16);

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -42,13 +42,12 @@ impl MatZq {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the number of rows or columns is `0`.
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
     /// if the `n <= 1` or `s <= 0`.
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.
+    /// For further information see [`MatZq::new`].
     pub fn sample_discrete_gauss<T, T1, T2, T3>(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
@@ -67,7 +66,7 @@ impl MatZq {
         let n: Z = n.into();
         let center: Q = center.into();
         let s: Q = s.into();
-        let mut out = Self::new(num_rows, num_cols, modulus)?;
+        let mut out = Self::new(num_rows, num_cols, modulus);
 
         for row in 0..out.get_num_rows() {
             for col in 0..out.get_num_columns() {

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -103,6 +103,16 @@ mod test_sample_uniform {
         }
     }
 
+    /// Checks whether matrices with at least one dimension chosen smaller than `1`
+    /// or too big for an [`i64`] results in an error.
+    #[should_panic]
+    #[test]
+    fn false_size() {
+        let modulus = Z::from(15);
+
+        let _ = MatZq::sample_uniform(0, 3, &modulus);
+    }
+
     /// Checks whether providing an invalid interval/ modulus results in an error.
     #[should_panic]
     #[test]

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -43,15 +43,12 @@ impl MatZq {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the number of rows or columns is `0`.
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     /// if the given `modulus` is smaller than or equal to `1`.
-    /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
-    /// if the provided modulus is not greater than `1`.
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.
+    /// For further information see [`MatZq::new`].
     pub fn sample_uniform<T>(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
@@ -61,7 +58,7 @@ impl MatZq {
         T: Into<Z> + Clone,
     {
         let modulus: Z = modulus.clone().into();
-        let mut matrix = MatZq::new(num_rows, num_cols, modulus.clone())?;
+        let mut matrix = MatZq::new(num_rows, num_cols, modulus.clone());
 
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
@@ -107,19 +104,10 @@ mod test_sample_uniform {
     }
 
     /// Checks whether providing an invalid interval/ modulus results in an error.
+    #[should_panic]
     #[test]
     fn invalid_modulus() {
-        let mat_0 = MatZq::sample_uniform(3, 3, &-1);
-        let mat_1 = MatZq::sample_uniform(4, 1, &1);
-        let mat_2 = MatZq::sample_uniform(1, 5, &0);
-        let mat_3 = MatZq::sample_uniform(1, 5, &i32::MIN);
-        let mat_4 = MatZq::sample_uniform(1, 5, &Z::from(i64::MIN));
-
-        assert!(mat_0.is_err());
-        assert!(mat_1.is_err());
-        assert!(mat_2.is_err());
-        assert!(mat_3.is_err());
-        assert!(mat_4.is_err());
+        let _ = MatZq::sample_uniform(4, 1, &1);
     }
 
     /// Checks whether `sample_uniform` is available for all types
@@ -160,22 +148,5 @@ mod test_sample_uniform {
         assert_eq!(5, mat_2.get_num_columns());
         assert_eq!(15, mat_3.get_num_rows());
         assert_eq!(20, mat_3.get_num_columns());
-    }
-
-    /// Checks whether matrices with at least one dimension chosen smaller than `1`
-    /// or too big for an [`i64`] results in an error
-    #[test]
-    fn false_sizes() {
-        let modulus = Z::from(15);
-
-        let mat_0 = MatZq::sample_uniform(0, 3, &modulus);
-        let mat_1 = MatZq::sample_uniform(3, 0, &modulus);
-        let mat_2 = MatZq::sample_uniform(0, -1, &modulus);
-        let mat_3 = MatZq::sample_uniform(2, u64::MAX, &modulus);
-
-        assert!(mat_0.is_err());
-        assert!(mat_1.is_err());
-        assert!(mat_2.is_err());
-        assert!(mat_3.is_err());
     }
 }

--- a/src/integer_mod_q/mat_zq/set.rs
+++ b/src/integer_mod_q/mat_zq/set.rs
@@ -50,7 +50,7 @@ impl SetEntry<&Z> for MatZq {
     /// use std::str::FromStr;
     /// use qfall_math::traits::*;
     ///
-    /// let mut matrix = MatZq::new(5, 10, 7).unwrap();
+    /// let mut matrix = MatZq::new(5, 10, 7);
     /// let value = Z::from(5);
     /// matrix.set_entry(1, 1, &value).unwrap();
     /// ```
@@ -91,7 +91,7 @@ impl SetEntry<&Zq> for MatZq {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let mut matrix = MatZq::new(5, 10, 7).unwrap();
+    /// let mut matrix = MatZq::new(5, 10, 7);
     /// let value = Zq::from_str("5 mod 7").unwrap();
     /// matrix.set_entry(1, 1, &value).unwrap();
     /// ```
@@ -150,7 +150,7 @@ impl MatZq {
     /// use qfall_math::integer_mod_q::MatZq;
     /// use std::str::FromStr;
     ///
-    /// let mut mat1 = MatZq::new(2, 2, 3).unwrap();
+    /// let mut mat1 = MatZq::new(2, 2, 3);
     /// let mat2 = MatZq::from_str("[[1],[2]] mod 3").unwrap();
     /// mat1.set_column(1, &mat2, 0);
     /// ```
@@ -218,7 +218,7 @@ impl MatZq {
     /// use qfall_math::integer_mod_q::MatZq;
     /// use std::str::FromStr;
     ///
-    /// let mut mat1 = MatZq::new(2, 2, 3).unwrap();
+    /// let mut mat1 = MatZq::new(2, 2, 3);
     /// let mat2 = MatZq::from_str("[[1,2]] mod 3").unwrap();
     /// mat1.set_row(0, &mat2, 0);
     /// ```
@@ -284,7 +284,7 @@ impl MatZq {
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let mut matrix = MatZq::new(4, 3, 5).unwrap();
+    /// let mut matrix = MatZq::new(4, 3, 5);
     /// matrix.swap_entries(0, 0, 2, 1);
     /// ```
     ///
@@ -323,7 +323,7 @@ impl MatZq {
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let mut matrix = MatZq::new(4, 3, 5).unwrap();
+    /// let mut matrix = MatZq::new(4, 3, 5);
     /// matrix.swap_columns(0, 2);
     /// ```
     ///
@@ -364,7 +364,7 @@ impl MatZq {
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let mut matrix = MatZq::new(4, 3, 5).unwrap();
+    /// let mut matrix = MatZq::new(4, 3, 5);
     /// matrix.swap_rows(0, 2);
     /// ```
     ///
@@ -399,7 +399,7 @@ impl MatZq {
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let mut matrix = MatZq::new(4, 3, 5).unwrap();
+    /// let mut matrix = MatZq::new(4, 3, 5);
     /// matrix.reverse_columns();
     /// ```
     pub fn reverse_columns(&mut self) {
@@ -416,7 +416,7 @@ impl MatZq {
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     ///
-    /// let mut matrix = MatZq::new(4, 3, 5).unwrap();
+    /// let mut matrix = MatZq::new(4, 3, 5);
     /// matrix.reverse_rows();
     /// ```
     pub fn reverse_rows(&mut self) {
@@ -439,7 +439,7 @@ mod test_setter {
     /// Ensure that setting entries works with large numbers.
     #[test]
     fn max_int_positive() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         let value = Z::from(i64::MAX);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -451,7 +451,7 @@ mod test_setter {
     /// Ensure that setting entries works with large numbers (larger than [`i64`]).
     #[test]
     fn big_positive() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         let value = Z::from(u64::MAX - 1);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -463,7 +463,7 @@ mod test_setter {
     /// Ensure that setting entries works with large numbers.
     #[test]
     fn max_int_negative() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         let value = Z::from(-i64::MAX);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -475,7 +475,7 @@ mod test_setter {
     /// Ensure that setting entries works with large numbers (larger than [`i64`]).
     #[test]
     fn big_negative() {
-        let mut matrix = MatZq::new(5, 10, u64::MAX).unwrap();
+        let mut matrix = MatZq::new(5, 10, u64::MAX);
         let value = Z::from(-i64::MAX - 1);
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -490,7 +490,7 @@ mod test_setter {
     /// Ensure that a wrong number of rows yields an Error.
     #[test]
     fn error_wrong_row() {
-        let mut matrix = MatZq::new(5, 10, 7).unwrap();
+        let mut matrix = MatZq::new(5, 10, 7);
 
         assert!(matrix.set_entry(5, 1, 3).is_err());
     }
@@ -498,7 +498,7 @@ mod test_setter {
     /// Ensure that a wrong number of columns yields an Error.
     #[test]
     fn error_wrong_column() {
-        let mut matrix = MatZq::new(5, 10, 7).unwrap();
+        let mut matrix = MatZq::new(5, 10, 7);
 
         assert!(matrix.set_entry(1, 100, 3).is_err());
     }
@@ -506,7 +506,7 @@ mod test_setter {
     /// Ensure that setting entries works with different types.
     #[test]
     fn diff_types() {
-        let mut matrix = MatZq::new(5, 10, 56).unwrap();
+        let mut matrix = MatZq::new(5, 10, 56);
 
         matrix.set_entry(0, 0, Z::default()).unwrap();
         matrix
@@ -522,7 +522,7 @@ mod test_setter {
     /// Ensure that value is correctly reduced.
     #[test]
     fn set_entry_reduce() {
-        let mut matrix = MatZq::new(5, 10, 3).unwrap();
+        let mut matrix = MatZq::new(5, 10, 3);
         matrix.set_entry(1, 1, Z::from(u64::MAX)).unwrap();
 
         let entry: Z = matrix.get_entry(1, 1).unwrap();
@@ -533,7 +533,7 @@ mod test_setter {
     /// Ensure that differing moduli result in an error.
     #[test]
     fn modulus_error() {
-        let mut matrix = MatZq::new(5, 10, 3).unwrap();
+        let mut matrix = MatZq::new(5, 10, 3);
         assert!(matrix
             .set_entry(1, 1, Zq::from_str("2 mod 5").unwrap())
             .is_err());
@@ -604,7 +604,7 @@ mod test_setter {
     /// Ensures that `set_column` returns an error if one of the specified columns is out of bounds
     #[test]
     fn column_out_of_bounds() {
-        let mut m1 = MatZq::new(5, 2, 17).unwrap();
+        let mut m1 = MatZq::new(5, 2, 17);
         let m2 = m1.clone();
 
         assert!(m1.set_column(-1, &m2, 0).is_err());
@@ -616,8 +616,8 @@ mod test_setter {
     /// Ensures that mismatching row dimensions result in an error
     #[test]
     fn column_mismatching_columns() {
-        let mut m1 = MatZq::new(5, 2, 17).unwrap();
-        let m2 = MatZq::new(2, 2, 17).unwrap();
+        let mut m1 = MatZq::new(5, 2, 17);
+        let m2 = MatZq::new(2, 2, 17);
 
         assert!(m1.set_column(0, &m2, 0).is_err());
         assert!(m1.set_column(1, &m2, 1).is_err());
@@ -626,8 +626,8 @@ mod test_setter {
     /// Ensures that mismatching moduli result in an error
     #[test]
     fn column_mismatching_moduli() {
-        let mut m1 = MatZq::new(3, 3, 19).unwrap();
-        let m2 = MatZq::new(3, 3, 17).unwrap();
+        let mut m1 = MatZq::new(3, 3, 19);
+        let m2 = MatZq::new(3, 3, 17);
 
         assert!(m1.set_column(0, &m2, 0).is_err());
     }
@@ -699,7 +699,7 @@ mod test_setter {
     /// Ensures that `set_row` returns an error if one of the specified rows is out of bounds
     #[test]
     fn row_out_of_bounds() {
-        let mut m1 = MatZq::new(5, 2, 17).unwrap();
+        let mut m1 = MatZq::new(5, 2, 17);
         let m2 = m1.clone();
 
         assert!(m1.set_row(-1, &m2, 0).is_err());
@@ -711,8 +711,8 @@ mod test_setter {
     /// Ensures that mismatching column dimensions result in an error
     #[test]
     fn row_mismatching_columns() {
-        let mut m1 = MatZq::new(3, 2, 17).unwrap();
-        let m2 = MatZq::new(3, 3, 17).unwrap();
+        let mut m1 = MatZq::new(3, 2, 17);
+        let m2 = MatZq::new(3, 3, 17);
 
         assert!(m1.set_row(0, &m2, 0).is_err());
         assert!(m1.set_row(1, &m2, 1).is_err());
@@ -721,8 +721,8 @@ mod test_setter {
     /// Ensures that mismatching moduli result in an error
     #[test]
     fn row_mismatching_moduli() {
-        let mut m1 = MatZq::new(3, 3, 19).unwrap();
-        let m2 = MatZq::new(3, 3, 17).unwrap();
+        let mut m1 = MatZq::new(3, 3, 19);
+        let m2 = MatZq::new(3, 3, 17);
 
         assert!(m1.set_row(0, &m2, 0).is_err());
     }
@@ -791,7 +791,7 @@ mod test_swaps {
     /// Ensures that `swap_entries` returns an error if one of the specified entries is out of bounds
     #[test]
     fn entries_out_of_bounds() {
-        let mut matrix = MatZq::new(5, 2, 5).unwrap();
+        let mut matrix = MatZq::new(5, 2, 5);
 
         assert!(matrix.swap_entries(-1, 0, 0, 0).is_err());
         assert!(matrix.swap_entries(0, -1, 0, 0).is_err());
@@ -866,7 +866,7 @@ mod test_swaps {
     /// Ensures that `swap_columns` returns an error if one of the specified columns is out of bounds
     #[test]
     fn column_out_of_bounds() {
-        let mut matrix = MatZq::new(5, 2, 5).unwrap();
+        let mut matrix = MatZq::new(5, 2, 5);
 
         assert!(matrix.swap_columns(-1, 0).is_err());
         assert!(matrix.swap_columns(0, -1).is_err());
@@ -937,7 +937,7 @@ mod test_swaps {
     /// Ensures that `swap_rows` returns an error if one of the specified rows is out of bounds
     #[test]
     fn row_out_of_bounds() {
-        let mut matrix = MatZq::new(2, 4, 5).unwrap();
+        let mut matrix = MatZq::new(2, 4, 5);
 
         assert!(matrix.swap_rows(-1, 0).is_err());
         assert!(matrix.swap_rows(0, -1).is_err());

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -83,7 +83,7 @@ impl MatZq {
         }
 
         // set the entries of the output vector using the indices vector
-        let mut out = MatZq::new(self.get_num_columns(), 1, &matrix.get_mod()).ok()?;
+        let mut out = MatZq::new(self.get_num_columns(), 1, &matrix.get_mod());
         for (i, j) in indices.iter() {
             let entry: Z = matrix.get_entry(*i, matrix.get_num_columns() - 1).ok()?;
             out.set_entry(*j, 0, &entry).ok()?;
@@ -177,7 +177,7 @@ mod test_solve {
         let y = MatZq::from_str("[[0],[0]] mod 8").unwrap();
         let x = mat.solve_gaussian_elimination(&y).unwrap();
 
-        assert_eq!(MatZq::new(3, 1, mat.get_mod()).unwrap(), x)
+        assert_eq!(MatZq::new(3, 1, mat.get_mod()), x)
     }
 
     /// Ensure that for different moduli the function panics

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -142,14 +142,12 @@ mod test_solve {
             10,
             10 * 2 * 50,
             &Modulus::try_from(&Z::from(2).pow(50).unwrap()).unwrap(),
-        )
-        .unwrap();
+        );
         let y = MatZq::sample_uniform(
             10,
             1,
             &Modulus::try_from(&Z::from(2).pow(50).unwrap()).unwrap(),
-        )
-        .unwrap();
+        );
 
         let x = mat.solve_gaussian_elimination(&y).unwrap();
 

--- a/src/integer_mod_q/mat_zq/sort.rs
+++ b/src/integer_mod_q/mat_zq/sort.rs
@@ -77,8 +77,7 @@ impl MatZq {
         let mut id_vec: Vec<usize> = (0..self.get_num_columns() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);
 
-        let mut out =
-            Self::new(self.get_num_rows(), self.get_num_columns(), self.get_mod()).unwrap();
+        let mut out = Self::new(self.get_num_rows(), self.get_num_columns(), self.get_mod());
         for (col, item) in id_vec.iter().enumerate() {
             out.set_column(col, self, *item).unwrap();
         }
@@ -147,8 +146,7 @@ impl MatZq {
         let mut id_vec: Vec<usize> = (0..self.get_num_rows() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);
 
-        let mut out =
-            Self::new(self.get_num_rows(), self.get_num_columns(), self.get_mod()).unwrap();
+        let mut out = Self::new(self.get_num_rows(), self.get_num_columns(), self.get_mod());
         for (row, item) in id_vec.iter().enumerate() {
             out.set_row(row, self, *item).unwrap();
         }

--- a/src/integer_mod_q/mat_zq/tensor.rs
+++ b/src/integer_mod_q/mat_zq/tensor.rs
@@ -93,8 +93,7 @@ impl MatZq {
             self.get_num_rows() * other.get_num_rows(),
             self.get_num_columns() * other.get_num_columns(),
             self.get_mod(),
-        )
-        .unwrap();
+        );
 
         unsafe {
             fmpz_mat_kronecker_product(
@@ -121,8 +120,8 @@ mod test_tensor {
     /// Ensure that the dimensions of the tensor product are taken over correctly.
     #[test]
     fn dimensions_fit() {
-        let mat_1 = MatZq::new(17, 13, 13).unwrap();
-        let mat_2 = MatZq::new(3, 4, 13).unwrap();
+        let mat_1 = MatZq::new(17, 13, 13);
+        let mat_2 = MatZq::new(3, 4, 13);
 
         let mat_3 = mat_1.tensor_product(&mat_2);
         let mat_3_safe = mat_1.tensor_product_safe(&mat_2).unwrap();
@@ -286,8 +285,8 @@ mod test_tensor {
     #[test]
     #[should_panic]
     fn mismatching_moduli_tensor_product() {
-        let mat_1 = MatZq::new(1, 2, u64::MAX).unwrap();
-        let mat_2 = MatZq::new(1, 2, u64::MAX - 58).unwrap();
+        let mat_1 = MatZq::new(1, 2, u64::MAX);
+        let mat_2 = MatZq::new(1, 2, u64::MAX - 58);
 
         let _ = mat_1.tensor_product(&mat_2);
     }
@@ -295,8 +294,8 @@ mod test_tensor {
     /// Ensure that tensor_product_safe returns an error if the moduli mismatch
     #[test]
     fn mismatching_moduli_tensor_product_safe() {
-        let mat_1 = MatZq::new(1, 2, u64::MAX).unwrap();
-        let mat_2 = MatZq::new(1, 2, u64::MAX - 58).unwrap();
+        let mat_1 = MatZq::new(1, 2, u64::MAX);
+        let mat_2 = MatZq::new(1, 2, u64::MAX - 58);
 
         assert!(mat_1.tensor_product_safe(&mat_2).is_err());
         assert!(mat_2.tensor_product_safe(&mat_1).is_err());

--- a/src/integer_mod_q/mat_zq/transpose.rs
+++ b/src/integer_mod_q/mat_zq/transpose.rs
@@ -28,8 +28,7 @@ impl MatZq {
     /// assert_eq!(mat.transpose(), cmp);
     /// ```
     pub fn transpose(&self) -> Self {
-        let mut out =
-            Self::new(self.get_num_columns(), self.get_num_rows(), self.get_mod()).unwrap();
+        let mut out = Self::new(self.get_num_columns(), self.get_num_rows(), self.get_mod());
         unsafe { fmpz_mat_transpose(&mut out.matrix.mat[0], &self.matrix.mat[0]) };
         out
     }

--- a/src/rational/mat_q/arithmetic/add.rs
+++ b/src/rational/mat_q/arithmetic/add.rs
@@ -84,7 +84,7 @@ impl MatQ {
                 other.get_num_columns()
             )));
         }
-        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpq_mat_add(&mut out.matrix, &self.matrix, &other.matrix);
         }

--- a/src/rational/mat_q/arithmetic/mul.rs
+++ b/src/rational/mat_q/arithmetic/mul.rs
@@ -89,7 +89,7 @@ impl Mul<&MatZ> for &MatQ {
             panic!("Tried to multiply matrices with mismatching matrix dimensions.");
         }
 
-        let mut new = MatQ::new(self.get_num_rows(), other.get_num_columns()).unwrap();
+        let mut new = MatQ::new(self.get_num_rows(), other.get_num_columns());
         unsafe { fmpq_mat_mul_fmpz_mat(&mut new.matrix, &self.matrix, &other.matrix) };
         new
     }
@@ -136,7 +136,7 @@ impl MatQ {
             )));
         }
 
-        let mut new = MatQ::new(self.get_num_rows(), other.get_num_columns()).unwrap();
+        let mut new = MatQ::new(self.get_num_rows(), other.get_num_columns());
         unsafe { fmpq_mat_mul(&mut new.matrix, &self.matrix, &other.matrix) };
         Ok(new)
     }
@@ -175,7 +175,7 @@ mod test_mul {
     fn large_entries() {
         let mat = MatQ::from_str(&format!("[[{},1],[0,2]]", i64::MAX)).unwrap();
         let vec = MatQ::from_str(&format!("[[1/{}],[0]]", i64::MAX)).unwrap();
-        let mut cmp = MatQ::new(2, 1).unwrap();
+        let mut cmp = MatQ::new(2, 1);
         let max: Q = Q::from_str(format!("{}", i64::MAX).as_str()).unwrap();
         cmp.set_entry(
             0,
@@ -234,7 +234,7 @@ mod test_mul_matz {
     fn large_entries() {
         let mat = MatQ::from_str(&format!("[[{},1],[0,2/{}]]", u64::MAX, u64::MAX)).unwrap();
         let vec = MatZ::from_str(&format!("[[{}],[0]]", u64::MAX)).unwrap();
-        let mut cmp = MatQ::new(2, 1).unwrap();
+        let mut cmp = MatQ::new(2, 1);
         let max: Q = u64::MAX.into();
         cmp.set_entry(0, 0, &(&max * &max)).unwrap();
 

--- a/src/rational/mat_q/arithmetic/mul_scalar.rs
+++ b/src/rational/mat_q/arithmetic/mul_scalar.rs
@@ -41,7 +41,7 @@ impl Mul<&Z> for &MatQ {
     /// let mat2 = &mat1 * &integer;
     /// ```
     fn mul(self, scalar: &Z) -> Self::Output {
-        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpq_mat_scalar_mul_fmpz(&mut out.matrix, &self.matrix, &scalar.value);
         }
@@ -79,7 +79,7 @@ impl Mul<&Q> for &MatQ {
     /// let mat2 = &mat1 * &rational;
     /// ```
     fn mul(self, scalar: &Q) -> Self::Output {
-        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpq_mat_scalar_mul_fmpq(&mut out.matrix, &self.matrix, &scalar.value);
         }

--- a/src/rational/mat_q/arithmetic/sub.rs
+++ b/src/rational/mat_q/arithmetic/sub.rs
@@ -84,7 +84,7 @@ impl MatQ {
                 other.get_num_columns()
             )));
         }
-        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpq_mat_sub(&mut out.matrix, &self.matrix, &other.matrix);
         }

--- a/src/rational/mat_q/cmp.rs
+++ b/src/rational/mat_q/cmp.rs
@@ -60,7 +60,7 @@ mod test_partial_eq {
     #[test]
     fn equality_between_instantiations() {
         let a = MatQ::from_str("[[0,1/2],[0/2,0]]").unwrap();
-        let mut b = MatQ::new(2, 2).unwrap();
+        let mut b = MatQ::new(2, 2);
         b.set_entry(0, 1, Q::from_str("2/4").unwrap()).unwrap();
 
         assert_eq!(a, b);

--- a/src/rational/mat_q/concat.rs
+++ b/src/rational/mat_q/concat.rs
@@ -31,8 +31,8 @@ impl Concatenate for &MatQ {
     /// use qfall_math::traits::*;
     /// use qfall_math::rational::MatQ;
     ///
-    /// let mat_1 = MatQ::new(13, 5).unwrap();
-    /// let mat_2 = MatQ::new(17, 5).unwrap();
+    /// let mat_1 = MatQ::new(13, 5);
+    /// let mat_2 = MatQ::new(17, 5);
     ///
     /// let mat_vert = mat_1.concat_vertical(&mat_2).unwrap();
     /// ```
@@ -54,8 +54,7 @@ impl Concatenate for &MatQ {
         let mut out = MatQ::new(
             self.get_num_rows() + other.get_num_rows(),
             self.get_num_columns(),
-        )
-        .unwrap();
+        );
         unsafe {
             fmpq_mat_concat_vertical(&mut out.matrix, &self.matrix, &other.matrix);
         }
@@ -75,8 +74,8 @@ impl Concatenate for &MatQ {
     /// use qfall_math::traits::*;
     /// use qfall_math::rational::MatQ;
     ///
-    /// let mat_1 = MatQ::new(17, 5).unwrap();
-    /// let mat_2 = MatQ::new(17, 6).unwrap();
+    /// let mat_1 = MatQ::new(17, 5);
+    /// let mat_2 = MatQ::new(17, 6);
     ///
     /// let mat_vert = mat_1.concat_horizontal(&mat_2).unwrap();
     /// ```
@@ -98,8 +97,7 @@ impl Concatenate for &MatQ {
         let mut out = MatQ::new(
             self.get_num_rows(),
             self.get_num_columns() + other.get_num_columns(),
-        )
-        .unwrap();
+        );
         unsafe {
             fmpq_mat_concat_horizontal(&mut out.matrix, &self.matrix, &other.matrix);
         }
@@ -119,9 +117,9 @@ mod test_concatenate {
     /// if the dimensions mismatch
     #[test]
     fn dimensions_vertical() {
-        let mat_1 = MatQ::new(13, 5).unwrap();
-        let mat_2 = MatQ::new(17, 5).unwrap();
-        let mat_3 = MatQ::new(17, 6).unwrap();
+        let mat_1 = MatQ::new(13, 5);
+        let mat_2 = MatQ::new(17, 5);
+        let mat_3 = MatQ::new(17, 6);
 
         let mat_vert = mat_1.concat_vertical(&mat_2).unwrap();
 
@@ -134,9 +132,9 @@ mod test_concatenate {
     /// if the dimensions mismatch
     #[test]
     fn dimensions_horizontal() {
-        let mat_1 = MatQ::new(13, 5).unwrap();
-        let mat_2 = MatQ::new(17, 5).unwrap();
-        let mat_3 = MatQ::new(17, 6).unwrap();
+        let mat_1 = MatQ::new(13, 5);
+        let mat_2 = MatQ::new(17, 5);
+        let mat_3 = MatQ::new(17, 6);
 
         let mat_hor = mat_2.concat_horizontal(&mat_3).unwrap();
 

--- a/src/rational/mat_q/default.rs
+++ b/src/rational/mat_q/default.rs
@@ -9,7 +9,7 @@
 //! Initialize a [`MatQ`] with common defaults, e.g., zero and identity.
 
 use super::MatQ;
-use crate::{error::MathError, utils::index::evaluate_indices};
+use crate::utils::index::evaluate_indices;
 use flint_sys::fmpq_mat::{fmpq_mat_init, fmpq_mat_one};
 use std::{fmt::Display, mem::MaybeUninit};
 
@@ -28,26 +28,19 @@ impl MatQ {
     /// ```
     /// use qfall_math::rational::MatQ;
     ///
-    /// let matrix = MatQ::new(5, 10).unwrap();
+    /// let matrix = MatQ::new(5, 10);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the number of rows or columns is `0`.
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is negative or it does not fit into an [`i64`].
+    /// # Panics ...
+    /// - if the number of rows or columns is negative, zero, or does not fit into an [`i64`].
     pub fn new(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
-    ) -> Result<Self, MathError> {
-        let (num_rows_i64, num_cols_i64) = evaluate_indices(num_rows, num_cols)?;
+    ) -> Self {
+        let (num_rows_i64, num_cols_i64) = evaluate_indices(num_rows, num_cols).unwrap();
 
         if num_rows_i64 == 0 || num_cols_i64 == 0 {
-            return Err(MathError::InvalidMatrix(format!(
-                "({},{})",
-                num_rows_i64, num_cols_i64,
-            )));
+            panic!("A matrix can not contain 0 rows or 0 columns");
         }
 
         let mut matrix = MaybeUninit::uninit();
@@ -55,9 +48,9 @@ impl MatQ {
             fmpq_mat_init(matrix.as_mut_ptr(), num_rows_i64, num_cols_i64);
 
             // Construct MatQ from previously initialized fmpq_mat
-            Ok(MatQ {
+            MatQ {
                 matrix: matrix.assume_init(),
-            })
+            }
         }
     }
 
@@ -74,22 +67,21 @@ impl MatQ {
     /// ```
     /// use qfall_math::rational::MatQ;
     ///
-    /// let matrix = MatQ::identity(2, 3).unwrap();
+    /// let matrix = MatQ::identity(2, 3);
     ///
-    /// let identity = MatQ::identity(10, 10).unwrap();
+    /// let identity = MatQ::identity(10, 10);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix) or
-    /// [`OutOfBounds`](MathError::OutOfBounds) if the provided number of rows and columns
-    /// are not suited to create a matrix. For further information see [`MatQ::new`].
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    /// For further information see [`MatQ::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
-    ) -> Result<Self, MathError> {
-        let mut out = MatQ::new(num_rows, num_cols)?;
+    ) -> Self {
+        let mut out = MatQ::new(num_rows, num_cols);
         unsafe { fmpq_mat_one(&mut out.matrix) };
-        Ok(out)
+        out
     }
 }
 
@@ -100,21 +92,22 @@ mod test_new {
     /// Ensure that initialization works.
     #[test]
     fn initialization() {
-        assert!(MatQ::new(2, 2).is_ok());
+        let _ = MatQ::new(2, 2);
     }
 
-    /// Ensure that a new zero matrix fails with `0` as input.
+    /// Ensure that a new zero matrix fails with `0` as `num_cols`.
+    #[should_panic]
     #[test]
-    fn error_zero() {
-        let matrix1 = MatQ::new(1, 0);
-        let matrix2 = MatQ::new(0, 1);
-        let matrix3 = MatQ::new(0, 0);
-
-        assert!(matrix1.is_err());
-        assert!(matrix2.is_err());
-        assert!(matrix3.is_err());
+    fn error_zero_num_cols() {
+        let _ = MatQ::new(1, 0);
     }
-    // TODO add test for `0` entries
+
+    /// Ensure that a new zero matrix fails with `0` as `num_rows`.
+    #[should_panic]
+    #[test]
+    fn error_zero_num_rows() {
+        let _ = MatQ::new(0, 1);
+    }
 }
 
 #[cfg(test)]
@@ -127,7 +120,7 @@ mod test_set_one {
     /// Tests if an identity matrix is set from a zero matrix.
     #[test]
     fn identity() {
-        let matrix = MatQ::identity(10, 10).unwrap();
+        let matrix = MatQ::identity(10, 10);
 
         for i in 0..10 {
             for j in 0..10 {
@@ -143,7 +136,7 @@ mod test_set_one {
     /// Tests if function works for a non-square matrix
     #[test]
     fn non_square_works() {
-        let matrix = MatQ::identity(10, 7).unwrap();
+        let matrix = MatQ::identity(10, 7);
 
         for i in 0..10 {
             for j in 0..7 {
@@ -155,7 +148,7 @@ mod test_set_one {
             }
         }
 
-        let matrix = MatQ::identity(7, 10).unwrap();
+        let matrix = MatQ::identity(7, 10);
 
         for i in 0..7 {
             for j in 0..10 {

--- a/src/rational/mat_q/default.rs
+++ b/src/rational/mat_q/default.rs
@@ -21,8 +21,7 @@ impl MatQ {
     /// - `num_rows`: number of rows the new matrix should have
     /// - `num_cols`: number of columns the new matrix should have
     ///
-    /// Returns a [`MatQ`] or an error, if the number of rows or columns is
-    /// less or equal to `0`.
+    /// Returns a new [`MatQ`] instance of the provided dimensions.
     ///
     /// # Examples
     /// ```

--- a/src/rational/mat_q/from.rs
+++ b/src/rational/mat_q/from.rs
@@ -133,7 +133,7 @@ mod test_from_mat_zq {
     /// Test if the dimensions are taken over correctly
     #[test]
     fn dimensions() {
-        let matz = MatZ::new(15, 17).unwrap();
+        let matz = MatZ::new(15, 17);
 
         let matq_1 = MatQ::from(&matz);
         let matq_2 = MatQ::from_mat_z(&matz);
@@ -147,7 +147,7 @@ mod test_from_mat_zq {
     /// Test if entries are taken over correctly
     #[test]
     fn entries_taken_over_correctly() {
-        let mut matz = MatZ::new(2, 2).unwrap();
+        let mut matz = MatZ::new(2, 2);
         matz.set_entry(0, 0, u64::MAX - 58).unwrap();
         matz.set_entry(0, 1, i64::MIN).unwrap();
 

--- a/src/rational/mat_q/from.rs
+++ b/src/rational/mat_q/from.rs
@@ -43,7 +43,7 @@ impl MatQ {
     /// let a = MatQ::from_mat_z(&m);
     /// ```
     pub fn from_mat_z(matrix: &MatZ) -> Self {
-        let mut out = MatQ::new(matrix.get_num_rows(), matrix.get_num_columns()).unwrap();
+        let mut out = MatQ::new(matrix.get_num_rows(), matrix.get_num_columns());
         unsafe { fmpq_mat_set_fmpz_mat(&mut out.matrix, &matrix.matrix) };
         out
     }
@@ -90,8 +90,7 @@ impl FromStr for MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the matrix is not formatted in a suitable way,
-    /// the number of rows or columns is too big (must fit into [`i64`]) or
+    /// if the matrix is not formatted in a suitable way, or
     /// if the number of entries in rows is unequal.
     /// - Returns a [`MathError`] of type
     /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
@@ -99,10 +98,14 @@ impl FromStr for MatQ {
     /// - Returns a [`MathError`] of type
     /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
     /// if an entry is not formatted correctly.
+    /// 
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    /// For further information see [`MatQ::new`].
     fn from_str(string: &str) -> Result<Self, MathError> {
         let string_matrix = parse_matrix_string(string)?;
         let (num_rows, num_cols) = find_matrix_dimensions(&string_matrix)?;
-        let mut matrix = MatQ::new(num_rows, num_cols)?;
+        let mut matrix = MatQ::new(num_rows, num_cols);
 
         // fill entries of matrix according to entries in string_matrix
         for (row_num, row) in string_matrix.iter().enumerate() {

--- a/src/rational/mat_q/from.rs
+++ b/src/rational/mat_q/from.rs
@@ -98,7 +98,7 @@ impl FromStr for MatQ {
     /// - Returns a [`MathError`] of type
     /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
     /// if an entry is not formatted correctly.
-    /// 
+    ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
     /// For further information see [`MatQ::new`].

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -26,7 +26,7 @@ impl GetNumRows for MatQ {
     /// use qfall_math::rational::MatQ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatQ::new(5,6).unwrap();
+    /// let matrix = MatQ::new(5,6);
     /// let rows = matrix.get_num_rows();
     /// ```
     fn get_num_rows(&self) -> i64 {
@@ -42,7 +42,7 @@ impl GetNumColumns for MatQ {
     /// use qfall_math::rational::MatQ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatQ::new(5,6).unwrap();
+    /// let matrix = MatQ::new(5,6);
     /// let columns = matrix.get_num_columns();
     /// ```
     fn get_num_columns(&self) -> i64 {
@@ -66,7 +66,7 @@ impl GetEntry<Q> for MatQ {
     /// use qfall_math::rational::MatQ;
     /// use qfall_math::traits::GetEntry;
     ///
-    /// let matrix = MatQ::new(5, 10).unwrap();
+    /// let matrix = MatQ::new(5, 10);
     /// let entry = matrix.get_entry(0, 1).unwrap();
     /// ```
     ///
@@ -126,7 +126,7 @@ impl MatQ {
             ));
         }
 
-        let out = MatQ::new(1, self.get_num_columns()).unwrap();
+        let out = MatQ::new(1, self.get_num_columns());
         for column in 0..self.get_num_columns() {
             unsafe {
                 fmpq_set(
@@ -172,7 +172,7 @@ impl MatQ {
             ));
         }
 
-        let out = MatQ::new(self.get_num_rows(), 1).unwrap();
+        let out = MatQ::new(self.get_num_rows(), 1);
         for row in 0..self.get_num_rows() {
             unsafe {
                 fmpq_set(
@@ -226,7 +226,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large large numerators and denominators.
     #[test]
     fn max_int_positive() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value1 = Q::from_str(&format!("{}/1", i64::MAX)).unwrap();
         let value2 = Q::from_str(&format!("1/{}", i64::MAX)).unwrap();
         matrix.set_entry(0, 0, value1).unwrap();
@@ -242,7 +242,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large numerators and denominators (larger than [`i64`]).
     #[test]
     fn big_positive() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value1 = Q::from_str(&format!("{}", u64::MAX)).unwrap();
         let value2 = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
         matrix.set_entry(0, 0, value1).unwrap();
@@ -258,7 +258,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large negative numerators and denominators.
     #[test]
     fn max_int_negative() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value1 = Q::from_str(&format!("{}", i64::MIN)).unwrap();
         let value2 = Q::from_str(&format!("1/{}", i64::MIN)).unwrap();
         matrix.set_entry(0, 0, value1).unwrap();
@@ -274,7 +274,7 @@ mod test_get_entry {
     /// Ensure that getting entries works with large negative numerators and denominators (larger than [`i64`]).
     #[test]
     fn big_negative() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value1 = format!("-{}", u64::MAX);
         let value2 = format!("1/-{}", u64::MAX);
         matrix
@@ -294,7 +294,7 @@ mod test_get_entry {
     /// Ensure that getting entries at (0,0) works.
     #[test]
     fn getting_at_zero() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value = Q::from_str(&format!("{}", i64::MIN)).unwrap();
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -306,7 +306,7 @@ mod test_get_entry {
     /// Ensure that a wrong number of rows yields an Error.
     #[test]
     fn error_wrong_row() {
-        let matrix = MatQ::new(5, 10).unwrap();
+        let matrix = MatQ::new(5, 10);
 
         assert!(matrix.get_entry(5, 1).is_err());
     }
@@ -314,7 +314,7 @@ mod test_get_entry {
     /// Ensure that a wrong number of columns yields an Error.
     #[test]
     fn error_wrong_column() {
-        let matrix = MatQ::new(5, 10).unwrap();
+        let matrix = MatQ::new(5, 10);
 
         assert!(matrix.get_entry(1, 100).is_err());
     }
@@ -322,7 +322,7 @@ mod test_get_entry {
     /// Ensure that the entry is a deep copy and not just a clone of the reference.
     #[test]
     fn memory_test() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value = Q::from_str(&format!("{}", u64::MAX)).unwrap();
         matrix.set_entry(1, 1, value).unwrap();
         let entry = matrix.get_entry(1, 1).unwrap();
@@ -342,7 +342,7 @@ mod test_get_num {
     /// Ensure that the getter for number of rows works correctly.
     #[test]
     fn num_rows() {
-        let matrix = MatQ::new(5, 10).unwrap();
+        let matrix = MatQ::new(5, 10);
 
         assert_eq!(matrix.get_num_rows(), 5);
     }
@@ -350,7 +350,7 @@ mod test_get_num {
     /// Ensure that the getter for number of columns works correctly.
     #[test]
     fn num_columns() {
-        let matrix = MatQ::new(5, 10).unwrap();
+        let matrix = MatQ::new(5, 10);
 
         assert_eq!(matrix.get_num_columns(), 10);
     }

--- a/src/rational/mat_q/gso.rs
+++ b/src/rational/mat_q/gso.rs
@@ -24,7 +24,7 @@ impl MatQ {
     /// let mat_gso = mat.gso();
     /// ```
     pub fn gso(&self) -> Self {
-        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpq_mat_gso(&mut out.matrix, &self.matrix);
         }

--- a/src/rational/mat_q/inverse.rs
+++ b/src/rational/mat_q/inverse.rs
@@ -32,7 +32,7 @@ impl MatQ {
         }
 
         // check if determinant is not `0`, create new matrix to store inverted result in
-        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns());
         match unsafe { fmpq_mat_inv(&mut out.matrix, &self.matrix) } {
             0 => None,
             _ => Some(out),
@@ -69,7 +69,7 @@ mod test_inverse {
     #[test]
     fn inverse_correct() {
         let mat = MatQ::from_str("[[5/6,2],[2/9,1/3]]").unwrap();
-        let cmp = MatQ::identity(2, 2).unwrap();
+        let cmp = MatQ::identity(2, 2);
 
         let inv = mat.inverse().unwrap();
         let diag = &mat * &inv;

--- a/src/rational/mat_q/ownership.rs
+++ b/src/rational/mat_q/ownership.rs
@@ -29,7 +29,7 @@ impl Clone for MatQ {
     /// let b = a.clone();
     /// ```
     fn clone(&self) -> Self {
-        let mut mat = MatQ::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut mat = MatQ::new(self.get_num_rows(), self.get_num_columns());
         unsafe {
             fmpq_mat_set(&mut mat.matrix, &self.matrix);
         }

--- a/src/rational/mat_q/set.rs
+++ b/src/rational/mat_q/set.rs
@@ -48,7 +48,7 @@ impl SetEntry<&Q> for MatQ {
     /// use std::str::FromStr;
     /// use qfall_math::traits::*;
     ///
-    /// let mut matrix = MatQ::new(5, 10).unwrap();
+    /// let mut matrix = MatQ::new(5, 10);
     /// let value = Q::from_str("5/2").unwrap();
     /// matrix.set_entry(1, 1, &value).unwrap();
     /// ```
@@ -99,7 +99,7 @@ impl MatQ {
     /// use qfall_math::rational::MatQ;
     /// use std::str::FromStr;
     ///
-    /// let mut mat1 = MatQ::new(2, 2).unwrap();
+    /// let mut mat1 = MatQ::new(2, 2);
     /// let mat2 = MatQ::from_str("[[1],[2]]").unwrap();
     /// mat1.set_column(1, &mat2, 0);
     /// ```
@@ -157,7 +157,7 @@ impl MatQ {
     /// use qfall_math::rational::MatQ;
     /// use std::str::FromStr;
     ///
-    /// let mut mat1 = MatQ::new(2, 2).unwrap();
+    /// let mut mat1 = MatQ::new(2, 2);
     /// let mat2 = MatQ::from_str("[[1,2]]").unwrap();
     /// mat1.set_row(0, &mat2, 0);
     /// ```
@@ -213,7 +213,7 @@ impl MatQ {
     /// ```
     /// use qfall_math::rational::MatQ;
     ///
-    /// let mut matrix = MatQ::new(4, 3).unwrap();
+    /// let mut matrix = MatQ::new(4, 3);
     /// matrix.swap_entries(0, 0, 2, 1);
     /// ```
     ///
@@ -252,7 +252,7 @@ impl MatQ {
     /// ```
     /// use qfall_math::rational::MatQ;
     ///
-    /// let mut matrix = MatQ::new(4, 3).unwrap();
+    /// let mut matrix = MatQ::new(4, 3);
     /// matrix.swap_columns(0, 2);
     /// ```
     ///
@@ -293,7 +293,7 @@ impl MatQ {
     /// ```
     /// use qfall_math::rational::MatQ;
     ///
-    /// let mut matrix = MatQ::new(4, 3).unwrap();
+    /// let mut matrix = MatQ::new(4, 3);
     /// matrix.swap_rows(0, 2);
     /// ```
     ///
@@ -328,7 +328,7 @@ impl MatQ {
     /// ```
     /// use qfall_math::rational::MatQ;
     ///
-    /// let mut matrix = MatQ::new(4, 3).unwrap();
+    /// let mut matrix = MatQ::new(4, 3);
     /// matrix.reverse_columns();
     /// ```
     pub fn reverse_columns(&mut self) {
@@ -345,7 +345,7 @@ impl MatQ {
     /// ```
     /// use qfall_math::rational::MatQ;
     ///
-    /// let mut matrix = MatQ::new(4, 3).unwrap();
+    /// let mut matrix = MatQ::new(4, 3);
     /// matrix.reverse_rows();
     /// ```
     pub fn reverse_rows(&mut self) {
@@ -368,7 +368,7 @@ mod test_setter {
     /// Ensure that setting entries works with standard numbers.
     #[test]
     fn standard_value() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value = Q::from(869);
         matrix.set_entry(4, 7, &value).unwrap();
 
@@ -380,7 +380,7 @@ mod test_setter {
     /// Ensure that setting entries works with large large numerators and denominators.
     #[test]
     fn max_int_positive() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value1 = Q::from_str(&format!("{}/1", i64::MAX)).unwrap();
         let value2 = Q::from_str(&format!("1/{}", i64::MAX)).unwrap();
         matrix.set_entry(0, 0, value1).unwrap();
@@ -396,7 +396,7 @@ mod test_setter {
     /// Ensure that setting entries works with large numerators and denominators (larger than [`i64`]).
     #[test]
     fn big_positive() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value1 = Q::from_str(&format!("{}", u64::MAX)).unwrap();
         let value2 = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
         matrix.set_entry(0, 0, value1).unwrap();
@@ -412,7 +412,7 @@ mod test_setter {
     /// Ensure that setting entries works with large negative numerators and denominators.
     #[test]
     fn max_int_negative() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value1 = Q::from_str(&format!("{}", i64::MIN)).unwrap();
         let value2 = Q::from_str(&format!("1/{}", i64::MIN)).unwrap();
         matrix.set_entry(0, 0, value1).unwrap();
@@ -428,7 +428,7 @@ mod test_setter {
     /// Ensure that setting entries works with large negative numerators and denominators (larger than [`i64`]).
     #[test]
     fn big_negative() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value1 = format!("-{}", u64::MAX);
         let value2 = format!("1/-{}", u64::MAX);
         matrix
@@ -448,7 +448,7 @@ mod test_setter {
     /// Ensure that setting entries at (0,0) works.
     #[test]
     fn getting_at_zero() {
-        let mut matrix = MatQ::new(5, 10).unwrap();
+        let mut matrix = MatQ::new(5, 10);
         let value = Q::from_str(&format!("{}", i64::MIN)).unwrap();
         matrix.set_entry(0, 0, value).unwrap();
 
@@ -460,7 +460,7 @@ mod test_setter {
     /// Ensure that a wrong number of rows yields an Error.
     #[test]
     fn error_wrong_row() {
-        let matrix = MatQ::new(5, 10).unwrap();
+        let matrix = MatQ::new(5, 10);
 
         assert!(matrix.get_entry(5, 1).is_err());
     }
@@ -468,7 +468,7 @@ mod test_setter {
     /// Ensure that a wrong number of columns yields an Error.
     #[test]
     fn error_wrong_column() {
-        let matrix = MatQ::new(5, 10).unwrap();
+        let matrix = MatQ::new(5, 10);
 
         assert!(matrix.get_entry(1, 100).is_err());
     }
@@ -529,7 +529,7 @@ mod test_setter {
     /// Ensures that `set_column` returns an error if one of the specified columns is out of bounds
     #[test]
     fn column_out_of_bounds() {
-        let mut m1 = MatQ::new(5, 2).unwrap();
+        let mut m1 = MatQ::new(5, 2);
         let m2 = m1.clone();
 
         assert!(m1.set_column(-1, &m2, 0).is_err());
@@ -541,8 +541,8 @@ mod test_setter {
     /// Ensures that mismatching row dimensions result in an error
     #[test]
     fn column_mismatching_columns() {
-        let mut m1 = MatQ::new(5, 2).unwrap();
-        let m2 = MatQ::new(2, 2).unwrap();
+        let mut m1 = MatQ::new(5, 2);
+        let m2 = MatQ::new(2, 2);
 
         assert!(m1.set_column(0, &m2, 0).is_err());
         assert!(m1.set_column(1, &m2, 1).is_err());
@@ -607,7 +607,7 @@ mod test_setter {
     /// Ensures that `set_row` returns an error if one of the specified rows is out of bounds
     #[test]
     fn row_out_of_bounds() {
-        let mut m1 = MatQ::new(5, 2).unwrap();
+        let mut m1 = MatQ::new(5, 2);
         let m2 = m1.clone();
 
         assert!(m1.set_row(-1, &m2, 0).is_err());
@@ -619,8 +619,8 @@ mod test_setter {
     /// Ensures that mismatching column dimensions result in an error
     #[test]
     fn row_mismatching_columns() {
-        let mut m1 = MatQ::new(3, 2).unwrap();
-        let m2 = MatQ::new(3, 3).unwrap();
+        let mut m1 = MatQ::new(3, 2);
+        let m2 = MatQ::new(3, 3);
 
         assert!(m1.set_row(0, &m2, 0).is_err());
         assert!(m1.set_row(1, &m2, 1).is_err());
@@ -687,7 +687,7 @@ mod test_swaps {
     /// Ensures that `swap_entries` returns an error if one of the specified entries is out of bounds
     #[test]
     fn entries_out_of_bounds() {
-        let mut matrix = MatQ::new(5, 2).unwrap();
+        let mut matrix = MatQ::new(5, 2);
 
         assert!(matrix.swap_entries(-1, 0, 0, 0).is_err());
         assert!(matrix.swap_entries(0, -1, 0, 0).is_err());
@@ -753,7 +753,7 @@ mod test_swaps {
     /// Ensures that `swap_columns` returns an error if one of the specified columns is out of bounds
     #[test]
     fn column_out_of_bounds() {
-        let mut matrix = MatQ::new(5, 2).unwrap();
+        let mut matrix = MatQ::new(5, 2);
 
         assert!(matrix.swap_columns(-1, 0).is_err());
         assert!(matrix.swap_columns(0, -1).is_err());
@@ -816,7 +816,7 @@ mod test_swaps {
     /// Ensures that `swap_rows` returns an error if one of the specified rows is out of bounds
     #[test]
     fn row_out_of_bounds() {
-        let mut matrix = MatQ::new(2, 4).unwrap();
+        let mut matrix = MatQ::new(2, 4);
 
         assert!(matrix.swap_rows(-1, 0).is_err());
         assert!(matrix.swap_rows(0, -1).is_err());

--- a/src/rational/mat_q/sort.rs
+++ b/src/rational/mat_q/sort.rs
@@ -76,7 +76,7 @@ impl MatQ {
         let mut id_vec: Vec<usize> = (0..self.get_num_columns() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);
 
-        let mut out = Self::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = Self::new(self.get_num_rows(), self.get_num_columns());
         for (col, item) in id_vec.iter().enumerate() {
             out.set_column(col, self, *item).unwrap();
         }
@@ -144,7 +144,7 @@ impl MatQ {
         let mut id_vec: Vec<usize> = (0..self.get_num_rows() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);
 
-        let mut out = Self::new(self.get_num_rows(), self.get_num_columns()).unwrap();
+        let mut out = Self::new(self.get_num_rows(), self.get_num_columns());
         for (row, item) in id_vec.iter().enumerate() {
             out.set_row(row, self, *item).unwrap();
         }

--- a/src/rational/mat_q/transpose.rs
+++ b/src/rational/mat_q/transpose.rs
@@ -28,7 +28,7 @@ impl MatQ {
     /// assert_eq!(mat.transpose(), cmp);
     /// ```
     pub fn transpose(&self) -> Self {
-        let mut out = Self::new(self.get_num_columns(), self.get_num_rows()).unwrap();
+        let mut out = Self::new(self.get_num_columns(), self.get_num_rows());
         unsafe { fmpq_mat_transpose(&mut out.matrix, &self.matrix) };
         out
     }

--- a/src/utils/index.rs
+++ b/src/utils/index.rs
@@ -174,14 +174,14 @@ mod test_eval_indices {
     /// Tests that negative indices are not accepted
     #[test]
     fn is_err_negative() {
-        let matrix = MatZ::new(3, 3).unwrap();
+        let matrix = MatZ::new(3, 3);
         assert!(evaluate_indices_for_matrix(&matrix, i32::MIN, 3).is_err())
     }
 
     /// Tests that the function can be called with several types
     #[test]
     fn is_ok_several_types() {
-        let matrix = MatZ::new(i16::MAX, u8::MAX).unwrap();
+        let matrix = MatZ::new(i16::MAX, u8::MAX);
 
         assert!(evaluate_indices_for_matrix(&matrix, 3i8, 0).is_ok());
         assert!(evaluate_indices_for_matrix(&matrix, 3i16, 0).is_ok());
@@ -206,7 +206,7 @@ mod test_eval_indices {
     /// are not accepted
     #[test]
     fn does_not_fit() {
-        let matrix = MatZ::new(3, 3).unwrap();
+        let matrix = MatZ::new(3, 3);
 
         assert!(evaluate_indices_for_matrix(&matrix, u64::MAX, 0).is_err());
         assert!(evaluate_indices_for_matrix(&matrix, 0, u64::MAX).is_err());

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -148,7 +148,7 @@ fn gaussian_function(x: &Z, c: &Q, s: &Q) -> Q {
 /// use qfall_math::utils::sample::discrete_gauss::sample_d;
 /// let basis = MatZ::identity(5, 5);
 /// let n = Z::from(1024);
-/// let center = MatQ::new(5, 1).unwrap();
+/// let center = MatQ::new(5, 1);
 /// let gaussian_parameter = Q::ONE;
 ///
 /// let sample = sample_d(basis, &n, &center, &gaussian_parameter).unwrap();
@@ -378,7 +378,7 @@ mod test_sample_d {
     fn doc_test() {
         let basis = MatZ::identity(5, 5);
         let n = Z::from(1024);
-        let center = MatQ::new(5, 1).unwrap();
+        let center = MatQ::new(5, 1);
         let gaussian_parameter = Q::ONE;
 
         let _ = sample_d(&basis, &n, &center, &gaussian_parameter).unwrap();
@@ -389,7 +389,7 @@ mod test_sample_d {
     fn non_zero_center() {
         let basis = MatZ::identity(5, 5);
         let n = Z::from(1024);
-        let center = MatQ::identity(5, 1).unwrap();
+        let center = MatQ::identity(5, 1);
         let gaussian_parameter = Q::ONE;
 
         let _ = sample_d(&basis, &n, &center, &gaussian_parameter).unwrap();
@@ -400,7 +400,7 @@ mod test_sample_d {
     fn non_identity_basis() {
         let basis = MatZ::from_str("[[2,1],[1,2]]").unwrap();
         let n = Z::from(1024);
-        let center = MatQ::new(2, 1).unwrap();
+        let center = MatQ::new(2, 1);
         let gaussian_parameter = Q::ONE;
 
         let _ = sample_d(&basis, &n, &center, &gaussian_parameter).unwrap();
@@ -415,7 +415,7 @@ mod test_sample_d {
     fn point_of_lattice() {
         let basis = MatZ::from_str("[[7,0],[7,3]]").unwrap();
         let n = Z::from(1024);
-        let center = MatQ::new(2, 1).unwrap();
+        let center = MatQ::new(2, 1);
         let gaussian_parameter = Q::ONE;
 
         let sample = sample_d(&basis, &n, &center, &gaussian_parameter).unwrap();
@@ -451,7 +451,7 @@ mod test_sample_d {
     fn invalid_gaussian_parameter() {
         let basis = MatZ::identity(5, 5);
         let n = Z::from(1024);
-        let center = MatQ::new(5, 1).unwrap();
+        let center = MatQ::new(5, 1);
 
         assert!(sample_d(&basis, &n, &center, &Q::ZERO).is_err());
         assert!(sample_d(&basis, &n, &center, &Q::MINUS_ONE).is_err());
@@ -462,7 +462,7 @@ mod test_sample_d {
     #[test]
     fn invalid_n() {
         let basis = MatZ::identity(5, 5);
-        let center = MatQ::new(5, 1).unwrap();
+        let center = MatQ::new(5, 1);
         let gaussian_parameter = Q::ONE;
 
         assert!(sample_d(&basis, &Z::ONE, &center, &gaussian_parameter).is_err());
@@ -476,7 +476,7 @@ mod test_sample_d {
     fn mismatching_matrix_dimensions() {
         let basis = MatZ::identity(3, 5);
         let n = Z::from(1024);
-        let center = MatQ::new(4, 1).unwrap();
+        let center = MatQ::new(4, 1);
         let gaussian_parameter = Q::ONE;
 
         let res = sample_d(&basis, &n, &center, &gaussian_parameter);
@@ -489,7 +489,7 @@ mod test_sample_d {
     fn center_not_column_vector() {
         let basis = MatZ::identity(2, 2);
         let n = Z::from(1024);
-        let center = MatQ::new(2, 2).unwrap();
+        let center = MatQ::new(2, 2);
         let gaussian_parameter = Q::ONE;
 
         let res = sample_d(&basis, &n, &center, &gaussian_parameter);

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -146,7 +146,7 @@ fn gaussian_function(x: &Z, c: &Q, s: &Q) -> Q {
 /// ```compile_fail
 /// use qfall_math::{integer::{MatZ, Z}, rational::{MatQ, Q}};
 /// use qfall_math::utils::sample::discrete_gauss::sample_d;
-/// let basis = MatZ::identity(5, 5).unwrap();
+/// let basis = MatZ::identity(5, 5);
 /// let n = Z::from(1024);
 /// let center = MatQ::new(5, 1).unwrap();
 /// let gaussian_parameter = Q::ONE;
@@ -193,7 +193,7 @@ pub(crate) fn sample_d(basis: &MatZ, n: &Z, center: &MatQ, s: &Q) -> Result<MatZ
     // to the euclidean norm.
     let basis_gso = MatQ::from_mat_z(&basis).gso();
 
-    let mut out = MatZ::new(basis_gso.get_num_columns(), 1).unwrap();
+    let mut out = MatZ::new(basis_gso.get_num_columns(), 1);
 
     for i in (0..basis_gso.get_num_columns()).rev() {
         // basisvector_i = b_tilde[i]
@@ -376,7 +376,7 @@ mod test_sample_d {
     /// Ensures that the doc-test compiles and runs properly
     #[test]
     fn doc_test() {
-        let basis = MatZ::identity(5, 5).unwrap();
+        let basis = MatZ::identity(5, 5);
         let n = Z::from(1024);
         let center = MatQ::new(5, 1).unwrap();
         let gaussian_parameter = Q::ONE;
@@ -387,7 +387,7 @@ mod test_sample_d {
     /// Ensures that `sample_d` works properly for a non-zero center
     #[test]
     fn non_zero_center() {
-        let basis = MatZ::identity(5, 5).unwrap();
+        let basis = MatZ::identity(5, 5);
         let n = Z::from(1024);
         let center = MatQ::identity(5, 1).unwrap();
         let gaussian_parameter = Q::ONE;
@@ -422,9 +422,9 @@ mod test_sample_d {
 
         // check whether hermite normal form of HNF(b) = HNF([b|sample_vector])
         let basis_concat_sample = basis.concat_horizontal(&sample).unwrap();
-        let mut hnf_basis = MatZ::new(2, 2).unwrap();
+        let mut hnf_basis = MatZ::new(2, 2);
         unsafe { fmpz_mat_hnf(&mut hnf_basis.matrix, &basis.matrix) };
-        let mut hnf_basis_concat_sample = MatZ::new(2, 3).unwrap();
+        let mut hnf_basis_concat_sample = MatZ::new(2, 3);
         unsafe {
             fmpz_mat_hnf(
                 &mut hnf_basis_concat_sample.matrix,
@@ -441,7 +441,7 @@ mod test_sample_d {
         );
         // check whether last vector is zero, i.e. was linearly dependend and part of lattice
         assert_eq!(
-            MatZ::new(2, 1).unwrap(),
+            MatZ::new(2, 1),
             hnf_basis_concat_sample.get_column(2).unwrap()
         );
     }
@@ -449,7 +449,7 @@ mod test_sample_d {
     /// Checks whether `sample_d` returns an error if the gaussian parameter `s <= 0`
     #[test]
     fn invalid_gaussian_parameter() {
-        let basis = MatZ::identity(5, 5).unwrap();
+        let basis = MatZ::identity(5, 5);
         let n = Z::from(1024);
         let center = MatQ::new(5, 1).unwrap();
 
@@ -461,7 +461,7 @@ mod test_sample_d {
     /// Checks whether `sample_d` returns an error if `n <= 1`
     #[test]
     fn invalid_n() {
-        let basis = MatZ::identity(5, 5).unwrap();
+        let basis = MatZ::identity(5, 5);
         let center = MatQ::new(5, 1).unwrap();
         let gaussian_parameter = Q::ONE;
 
@@ -474,7 +474,7 @@ mod test_sample_d {
     /// Checks whether `sample_d` returns an error if the basis and center number of rows differs
     #[test]
     fn mismatching_matrix_dimensions() {
-        let basis = MatZ::identity(3, 5).unwrap();
+        let basis = MatZ::identity(3, 5);
         let n = Z::from(1024);
         let center = MatQ::new(4, 1).unwrap();
         let gaussian_parameter = Q::ONE;
@@ -487,7 +487,7 @@ mod test_sample_d {
     /// Checks whether `sample_d` returns an error if center isn't a column vector
     #[test]
     fn center_not_column_vector() {
-        let basis = MatZ::identity(2, 2).unwrap();
+        let basis = MatZ::identity(2, 2);
         let n = Z::from(1024);
         let center = MatQ::new(2, 2).unwrap();
         let gaussian_parameter = Q::ONE;


### PR DESCRIPTION
**Description**
This PR removes the `Result`s from Matrix `new` and `identity` functions. Errors are replaced by suitable `panic` texts.

**Checklist:**
- [x] I have performed a self-review of my own code