### PR TITLE
Rework from for zq

### DIFF
--- a/src/integer_mod_q/mat_zq/trace.rs
+++ b/src/integer_mod_q/mat_zq/trace.rs
@@ -40,7 +40,7 @@ impl MatZq {
             return Err(MathError::NoSquareMatrix(self.to_string()));
         }
 
-        let mut out = Zq::try_from_int_int(0, self.get_mod()).unwrap();
+        let mut out = Zq::from((0, self.get_mod()));
         unsafe {
             fmpz_mod_mat_trace(&mut out.value.value, &self.matrix);
         }
@@ -62,8 +62,8 @@ mod test_trace {
         let trace1 = mat1.trace().unwrap();
         let trace2 = mat2.trace().unwrap();
 
-        assert_eq!(Zq::try_from_int_int(7, 10).unwrap(), trace1);
-        assert_eq!(Zq::try_from_int_int(0, 2).unwrap(), trace2);
+        assert_eq!(Zq::from((7, 10)), trace1);
+        assert_eq!(Zq::from((0, 2)), trace2);
     }
 
     /// Test whether `trace` works for big values
@@ -89,12 +89,9 @@ mod test_trace {
         let trace2 = mat2.trace().unwrap();
         let trace3 = mat3.trace().unwrap();
 
-        assert_eq!(
-            Zq::try_from_int_int(2 * i64::MAX as u64, u64::MAX).unwrap(),
-            trace1
-        );
-        assert_eq!(Zq::try_from_int_int(i64::MIN, u64::MAX).unwrap(), trace2);
-        assert_eq!(Zq::try_from_int_int(-1, u64::MAX).unwrap(), trace3);
+        assert_eq!(Zq::from((2 * i64::MAX as u64, u64::MAX)), trace1);
+        assert_eq!(Zq::from((i64::MIN, u64::MAX)), trace2);
+        assert_eq!(Zq::from((-1, u64::MAX)), trace3);
     }
 
     /// Ensure that a matrix that is not square yields an error.

--- a/src/integer_mod_q/mat_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_zq/vector/dot_product.rs
@@ -153,7 +153,7 @@ mod test_dot_product {
         let vec_1 = MatZq::from_str(&format!("[[1,1,{}]] mod {}", i64::MAX, u128::MAX)).unwrap();
         let vec_2 = MatZq::from_str(&format!("[[1,{},1]] mod {}", i64::MIN, u128::MAX)).unwrap();
         let cmp = Z::from(i64::MIN) + Z::from(i64::MAX) + Z::ONE;
-        let cmp = Zq::try_from_z_z(&cmp, &Z::from_str(&format!("{}", u128::MAX)).unwrap()).unwrap();
+        let cmp = Zq::from((&cmp, &Z::from_str(&format!("{}", u128::MAX)).unwrap()));
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 

--- a/src/integer_mod_q/z_q.rs
+++ b/src/integer_mod_q/z_q.rs
@@ -45,7 +45,7 @@ mod to_string;
 /// use std::str::FromStr;
 ///
 /// // instantiation
-/// let a = Zq::try_from((5, 10))?;
+/// let a = Zq::from((5, 10));
 /// let b = Zq::from_str("93 mod 10")?;
 /// let _ = a.clone();
 ///

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -145,12 +145,10 @@ impl Zq {
     }
 }
 
-impl<IntegerValue: Into<Z>, IntegerModulus: Into<Z>> TryFrom<(IntegerValue, IntegerModulus)>
+impl<IntegerValue: Into<Z>, IntegerModulus: Into<Modulus>> From<(IntegerValue, IntegerModulus)>
     for Zq
 {
-    type Error = MathError;
-    /// Implements the [`TryFrom`] trait. It is used to create [`Zq`] from a tuple
-    /// with two values that can be converted into [`Z`].
+    /// Create [`Zq`] from a tuple with the values and the modulus.
     ///
     /// Parameters:
     /// - `value_modulus_tuple` is a tuple of integers `(value, modulus)`
@@ -160,29 +158,24 @@ impl<IntegerValue: Into<Z>, IntegerModulus: Into<Z>> TryFrom<(IntegerValue, Inte
     ///
     /// # Examples
     /// ```
-    /// # use qfall_math::error::MathError;
-    /// use qfall_math::integer::Z;
     /// use qfall_math::integer_mod_q::Zq;
+    /// use qfall_math::integer::Z;
     ///
-    /// let value_a: Z = Z::from(42);
-    /// let value_b: u64 = 1337+42;
-    /// let modulus: i32 = 1337;
+    /// let answer_a = Zq::from((1337 + 42, 1337));
+    /// let answer_b = Zq::from((Z::from(42), 1337));
     ///
-    /// let answer_a = Zq::try_from((value_a, modulus))?;
-    /// let answer_b = Zq::try_from((value_b, modulus))?;
-    ///
-    /// // TODO: assert_eq!(answer_a, answer_b);
-    /// # Ok::<(), MathError>(())
+    /// assert_eq!(answer_a, answer_b);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    ///   [`InvalidIntToModulus`](MathError::InvalidIntToModulus) if the
-    ///   provided value is not greater than `1`.
-    fn try_from(value_modulus_tuple: (IntegerValue, IntegerModulus)) -> Result<Self, Self::Error> {
-        let modulus = value_modulus_tuple.1;
-        let value = value_modulus_tuple.0;
-        Zq::try_from_int_int(value, modulus)
+    /// # Panics ...
+    /// - if the modulus is not greater than `1`.
+    fn from(value_modulus_tuple: (IntegerValue, IntegerModulus)) -> Self {
+        let value = value_modulus_tuple.0.into();
+        let modulus = value_modulus_tuple.1.into();
+
+        let mut out = Zq { value, modulus };
+        out.reduce();
+        out
     }
 }
 
@@ -321,63 +314,126 @@ mod test_try_from_z_z {
 }
 
 #[cfg(test)]
-mod test_try_from_trait {
-    use crate::{integer::Z, integer_mod_q::Zq};
+mod test_from_trait {
+    use crate::{
+        integer::Z,
+        integer_mod_q::{Modulus, Zq},
+    };
 
-    /// Showcase some of the different types supported by the trait.
+    /// Test that the different combinations of rust integers, [`Z`], and [`Modulus`]
+    /// in their owned and borrowed form can be used to create a [`Zq`].
     #[test]
-    fn types_example() {
-        // rust integers supported
-        assert!(Zq::try_from((1u8, 2u16)).is_ok());
-        assert!(Zq::try_from((1u32, 2u64)).is_ok());
-        assert!(Zq::try_from((1i8, 2i16)).is_ok());
-        assert!(Zq::try_from((1i32, 2i64)).is_ok());
+    fn different_types() {
+        let int_8: i8 = 10;
+        let int_16: i16 = 10;
+        let int_32: i32 = 10;
+        let int_64: i64 = 10;
+        let uint_8: u8 = 10;
+        let uint_16: u16 = 10;
+        let uint_32: u32 = 10;
+        let uint_64: u64 = 10;
+        let z = Z::from(10);
+        let modulus = Modulus::from(10);
 
-        // [`Z`] supported
-        assert!(Zq::try_from((Z::from(1), Z::from(2))).is_ok());
+        // owned, owned the same type in numerator and denominator
+        let _ = Zq::from((int_8, int_8));
+        let _ = Zq::from((int_16, int_16));
+        let _ = Zq::from((int_32, int_32));
+        let _ = Zq::from((int_64, int_64));
+        let _ = Zq::from((uint_8, uint_8));
+        let _ = Zq::from((uint_16, uint_16));
+        let _ = Zq::from((uint_32, uint_32));
+        let _ = Zq::from((uint_64, uint_64));
+        let _ = Zq::from((z.clone(), z.clone()));
+        let _ = Zq::from((modulus.clone(), modulus.clone()));
+
+        // borrowed, borrowed the same type in numerator and denominator
+        let _ = Zq::from((&int_8, &int_8));
+        let _ = Zq::from((&int_16, &int_16));
+        let _ = Zq::from((&int_32, &int_32));
+        let _ = Zq::from((&int_64, &int_64));
+        let _ = Zq::from((&uint_8, &uint_8));
+        let _ = Zq::from((&uint_16, &uint_16));
+        let _ = Zq::from((&uint_32, &uint_32));
+        let _ = Zq::from((&uint_64, &uint_64));
+        let _ = Zq::from((&z, &z));
+        let _ = Zq::from((&modulus, &modulus));
+
+        // From now on assume that i/u8, i/u16, i/u32 and i/u64 behave the same.
+        // This assumption is reasonable, since their implementation is the same.
+
+        // owned, owned mixed types
+        let _ = Zq::from((int_8, z.clone()));
+        let _ = Zq::from((z.clone(), int_8));
+        let _ = Zq::from((int_8, modulus.clone()));
+        let _ = Zq::from((z.clone(), modulus.clone()));
+        let _ = Zq::from((modulus.clone(), int_8));
+        let _ = Zq::from((modulus.clone(), z.clone()));
+
+        // owned, borrowed mixed types
+        let _ = Zq::from((int_8, &z));
+        let _ = Zq::from((modulus.clone(), &z));
+        let _ = Zq::from((z.clone(), &int_8));
+        let _ = Zq::from((z.clone(), &modulus));
+        let _ = Zq::from((int_8, &modulus));
+        let _ = Zq::from((modulus.clone(), &int_8));
+
+        // borrowed, owned mixed types
+        let _ = Zq::from((&int_8, z.clone()));
+        let _ = Zq::from((&modulus, z.clone()));
+        let _ = Zq::from((&z, int_8));
+        let _ = Zq::from((&z, modulus.clone()));
+        let _ = Zq::from((&int_8, modulus.clone()));
+        let _ = Zq::from((&modulus, int_8));
+
+        // borrowed, borrowed mixed types
+        let _ = Zq::from((&int_8, &z));
+        let _ = Zq::from((&modulus, &z));
+        let _ = Zq::from((&z, &int_8));
+        let _ = Zq::from((&z, &modulus));
+        let _ = Zq::from((&int_8, &modulus));
+        let _ = Zq::from((&modulus, &int_8));
     }
 
     /// Ensure that the modulus calculation is performed at initialization.
     #[test]
     fn modulus_at_initialization() {
-        let a = Zq::try_from((0, 10)).unwrap();
-        let b = Zq::try_from((10, 10)).unwrap();
+        let a = Zq::from((0, 10));
+        let b = Zq::from((10, 10));
 
-        // TODO: use Zq equal once implemented.
-        assert_eq!(&a.value, &b.value);
-        assert_eq!(&a.modulus, &b.modulus);
+        assert_eq!(a, b);
     }
 
     /// Test with small valid value and modulus.
     #[test]
     fn working_small() {
-        let new_zq = Zq::try_from((10, 15));
+        let zq_1 = Zq::from((10, 15));
+        let zq_2 = Zq::from((Z::from(10), Modulus::from(15)));
 
-        assert!(new_zq.is_ok());
+        assert_eq!(zq_1, zq_2)
     }
 
     /// Test with large value and modulus (FLINT uses pointer representation).
     #[test]
     fn working_large() {
-        let new_zq = Zq::try_from((u64::MAX - 1, u64::MAX));
+        let zq_1 = Zq::from((u64::MAX - 1, u64::MAX));
+        let zq_2 = Zq::from((&Z::from(u64::MAX - 1), Modulus::from(u64::MAX)));
 
-        assert!(new_zq.is_ok());
+        assert_eq!(zq_1, zq_2)
     }
 
     /// Test with zero modulus (not valid)
     #[test]
+    #[should_panic]
     fn modulus_zero() {
-        let new_zq = Zq::try_from((10, 0));
-
-        assert!(new_zq.is_err());
+        let _1 = Zq::from((10, 0));
     }
 
     /// Test with negative modulus (not valid)
     #[test]
+    #[should_panic]
     fn modulus_negative() {
-        let new_zq = Zq::try_from((10, -1));
-
-        assert!(new_zq.is_err());
+        let _1 = Zq::from((10, -1));
     }
 }
 

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -14,52 +14,6 @@ use flint_sys::fmpz_mod::fmpz_mod_set_fmpz;
 use std::str::FromStr;
 
 impl Zq {
-    /// Create [`Zq`] from two [`Z`] values.
-    ///
-    /// This function creates a copy of the value and creates a new [`Modulus`].
-    /// Therefore, it should be avoided to create multiple values with the
-    /// same [`Modulus`] with this function to improve performance.
-    /// It is better to use [`Zq::from_z_modulus()`] instead.
-    ///
-    /// Parameters:
-    /// - `value` defines the value of the new [`Zq`].
-    /// - `modulus` is used to create a new [`Modulus`] context that will be
-    ///   used by [`Zq`].
-    ///
-    /// Returns the new `value` mod `modulus` as a [`Zq`].
-    ///
-    /// # Examples
-    /// ```
-    /// # use qfall_math::error::MathError;
-    /// use qfall_math::integer::Z;
-    /// use qfall_math::integer_mod_q::Zq;
-    ///
-    /// let value_a = Z::from(42);
-    /// let value_b = Z::from(1337+42);
-    /// let modulus = Z::from(1337);
-    ///
-    /// let answer_a = Zq::try_from_z_z(&value_a, &modulus)?;
-    /// let answer_b = Zq::try_from_z_z(&value_b, &modulus)?;
-    ///
-    /// // TODO: assert_eq!(answer_a, answer_b); once equal for Zq is implemented
-    /// # Ok::<(), MathError>(())
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    ///   [`InvalidIntToModulus`](MathError::InvalidIntToModulus) if the
-    ///   provided value is not greater than `1`.
-    pub fn try_from_z_z(value: &Z, modulus: &Z) -> Result<Self, MathError> {
-        // TODO: This is not super nice but this function will be removed in the
-        // Zq::from rework anyway.
-        if modulus <= &Z::ONE {
-            return Err(MathError::InvalidIntToModulus(modulus.to_string()));
-        }
-        let modulus = Modulus::from(modulus);
-
-        Ok(Self::from_z_modulus(value, &modulus))
-    }
-
     /// Create [`Zq`] from a [`Z`] values and a [`Modulus`].
     ///
     /// As the [`Modulus`] object counts its references and
@@ -99,49 +53,6 @@ impl Zq {
             value: out,
             modulus: modulus.clone(),
         }
-    }
-
-    /// Create [`Zq`] from two values that can be converted to [`Z`].
-    /// For example, [`i64`] and [`u32`].
-    ///
-    /// The parameters have to implement the [`Into<Z>`] trait, which is
-    /// automatically the case if [`Z`] implements the [`From`] trait for this type.
-    /// The first and second element of the tuple may have different types.
-    ///
-    /// Parameters:
-    /// - `value` is the value of the new [`Zq`].
-    /// - `modulus` defines the new [`Modulus`], which is part of [`Zq`].
-    ///
-    /// Returns the `value` mod `modulus` as a [`Zq`].
-    ///
-    /// # Examples
-    /// ```
-    /// # use qfall_math::error::MathError;
-    /// use qfall_math::integer::Z;
-    /// use qfall_math::integer_mod_q::Zq;
-    ///
-    /// let value_a: Z = Z::from(42);
-    /// let value_b: u64 = 1337+42;
-    /// let modulus: i32 = 1337;
-    ///
-    /// let answer_a = Zq::try_from_int_int(value_a, modulus)?;
-    /// let answer_b = Zq::try_from_int_int(value_b, modulus)?;
-    ///
-    /// // TODO: assert_eq!(answer_a, answer_b);
-    /// # Ok::<(), MathError>(())
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type
-    ///   [`InvalidIntToModulus`](MathError::InvalidIntToModulus) if the
-    ///   provided value is not greater than `1`.
-    pub fn try_from_int_int<T1: Into<Z>, T2: Into<Z>>(
-        value: T1,
-        modulus: T2,
-    ) -> Result<Self, MathError> {
-        let modulus: Z = modulus.into();
-        let value: Z = value.into();
-        Zq::try_from_z_z(&value, &modulus)
     }
 }
 
@@ -261,55 +172,6 @@ mod test_from_z_modulus {
         let modulus = Modulus::try_from(&Z::from(u64::MAX)).unwrap();
 
         let _ = Zq::from_z_modulus(&value, &modulus);
-    }
-}
-
-#[cfg(test)]
-mod test_try_from_z_z {
-    use super::Zq;
-    use crate::integer::Z;
-
-    /// Test with small valid value and modulus.
-    #[test]
-    fn working_small() {
-        let value = Z::from(10);
-        let modulus = Z::from(15);
-
-        let answer = Zq::try_from_z_z(&value, &modulus);
-        assert!(answer.is_ok());
-    }
-
-    /// Test with large value and modulus (FLINT uses pointer representation).
-    #[test]
-    fn working_large() {
-        let value = Z::from(u64::MAX - 1);
-        let modulus = Z::from(u64::MAX);
-
-        let answer = Zq::try_from_z_z(&value, &modulus);
-
-        assert!(answer.is_ok());
-    }
-
-    /// Test with zero modulus (not valid)
-    #[test]
-    fn modulus_zero() {
-        let value = Z::from(10);
-        let modulus = Z::ZERO;
-
-        let new_zq = Zq::try_from_z_z(&value, &modulus);
-
-        assert!(new_zq.is_err());
-    }
-
-    /// Test with negative modulus (not valid)
-    #[test]
-    fn modulus_negative() {
-        let value = Z::from(10);
-        let modulus = Z::from(-1);
-
-        let new_zq = Zq::try_from_z_z(&value, &modulus);
-
-        assert!(new_zq.is_err());
     }
 }
 

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -59,7 +59,7 @@ impl Zq {
 impl<IntegerValue: Into<Z>, IntegerModulus: Into<Modulus>> From<(IntegerValue, IntegerModulus)>
     for Zq
 {
-    /// Create [`Zq`] from a tuple with the values and the modulus.
+    /// Create [`Zq`] from a tuple with the integer and the modulus.
     ///
     /// Parameters:
     /// - `value_modulus_tuple` is a tuple of integers `(value, modulus)`
@@ -288,14 +288,14 @@ mod test_from_trait {
     #[test]
     #[should_panic]
     fn modulus_zero() {
-        let _1 = Zq::from((10, 0));
+        let _ = Zq::from((10, 0));
     }
 
     /// Test with negative modulus (not valid)
     #[test]
     #[should_panic]
     fn modulus_negative() {
-        let _1 = Zq::from((10, -1));
+        let _ = Zq::from((10, -1));
     }
 }
 

--- a/src/integer_mod_q/z_q/properties.rs
+++ b/src/integer_mod_q/z_q/properties.rs
@@ -125,7 +125,7 @@ mod test_is_zero {
     /// Ensure that is_zero returns `false` for non-zero values.
     #[test]
     fn zero_rejection() {
-        let small = Zq::try_from_int_int(4, 9).unwrap();
+        let small = Zq::from((4, 9));
         let large =
             Zq::from_str(&format!("{} mod {}", (u128::MAX - 1) / 2 + 1, u128::MAX)).unwrap();
 

--- a/src/integer_mod_q/z_q/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/z_q/sample/discrete_gauss.rs
@@ -41,9 +41,9 @@ impl Zq {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
     /// if `n <= 1` or `s <= 0`.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus) if the
-    /// provided value is not greater than `0`.
+    ///
+    /// # Panics ...
+    /// - if the modulus is not greater than `1`.
     ///
     /// This function implements SampleZ according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
@@ -68,7 +68,7 @@ impl Zq {
         let s: Q = s.to_owned().into();
 
         let sample = sample_z(&n, &center, &s)?;
-        Zq::try_from_z_z(&sample, &modulus)
+        Ok(Zq::from((&sample, &modulus)))
     }
 }
 

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -45,7 +45,7 @@ impl Zq {
         let modulus: Z = modulus.clone().into();
 
         let random = sample_uniform_rejection(&modulus)?;
-        Zq::try_from((random, modulus))
+        Ok(Zq::from((random, modulus)))
     }
 }
 


### PR DESCRIPTION
**Description**


This PR implements...
- [x] From Trait for Zq
- [x] Remove TryFrom trait for Zq
- [x] Remove `Zq::try_from_int_int` and `Zq::try_from_z_z`
Reasoning:
1. We can use the from trait now that does not return a Result.
2. If we would like to have a function that returns a Result, the naming would have to be changed anyway (maybe to something like `try_from_int_modulus`) and it should use generics.

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
