### PR TITLE
Refactor sprint 9

### DIFF
--- a/benches/classic_crypto.rs
+++ b/benches/classic_crypto.rs
@@ -126,7 +126,7 @@ mod rsa_textbook {
     ///
     /// `rsa_textbook.enc(N, pk, msg) = msg^pk mod N`
     pub fn enc(modulus: &Modulus, pk: &Z, msg: &Z) -> Zq {
-        let msg = Zq::from_z_modulus(msg, modulus);
+        let msg = Zq::from((msg, modulus));
         msg.pow(pk).unwrap()
     }
 
@@ -267,7 +267,7 @@ mod el_gamal_enc {
 
         let (pk, sk) = gen_key_pair(&modulus, &generator);
 
-        let msg = Zq::from_z_modulus(&Z::sample_uniform(&0, &modulus).unwrap(), &modulus);
+        let msg = Zq::from((&Z::sample_uniform(&0, &modulus).unwrap(), &modulus));
 
         let (c_0, c_1) = enc(&generator, &pk, &msg);
         let cmp = dec(&sk, &c_0, &c_1);

--- a/benches/classic_crypto.rs
+++ b/benches/classic_crypto.rs
@@ -100,7 +100,7 @@ mod rsa_textbook {
             "Primes used for modulus N calculation shouldn't be equal."
         );
 
-        let modulus = Modulus::try_from(&(&p * &q)).unwrap();
+        let modulus = Modulus::from(&p * &q);
         let phi_mod = (&p - Z::ONE) * (&q - Z::ONE);
 
         // standard prime value chosen as public key

--- a/src/integer/mat_poly_over_z/arithmetic/add.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/add.rs
@@ -42,7 +42,7 @@ impl Add for &MatPolyOverZ {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the dimensions of both matrices mismatch
+    /// - if the dimensions of both matrices mismatch.
     fn add(self, other: Self) -> Self::Output {
         self.add_safe(other).unwrap()
     }

--- a/src/integer/mat_poly_over_z/arithmetic/mul.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/mul.rs
@@ -44,8 +44,8 @@ impl Mul for &MatPolyOverZ {
     /// let f = c * &e;
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Panics if the dimensions of `self` and `other` do not match for multiplication.
+    /// # Panics ...
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
     fn mul(self, other: Self) -> Self::Output {
         self.mul_safe(other).unwrap()
     }

--- a/src/integer/mat_poly_over_z/arithmetic/sub.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/sub.rs
@@ -42,7 +42,7 @@ impl Sub for &MatPolyOverZ {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the dimensions of both matrices mismatch
+    /// - if the dimensions of both matrices mismatch.
     fn sub(self, other: Self) -> Self::Output {
         self.sub_safe(other).unwrap()
     }

--- a/src/integer/mat_z/arithmetic/add.rs
+++ b/src/integer/mat_z/arithmetic/add.rs
@@ -41,8 +41,8 @@ impl Add for &MatZ {
     /// let f: MatZ = c + &e;
     /// ```
     ///
-    /// # Panics
-    /// - Panics if the dimensions of both matrices mismatch
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
     fn add(self, other: Self) -> Self::Output {
         self.add_safe(other).unwrap()
     }

--- a/src/integer/mat_z/arithmetic/mul.rs
+++ b/src/integer/mat_z/arithmetic/mul.rs
@@ -44,7 +44,7 @@ impl Mul for &MatZ {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the dimensions of `self` and `other` do not match for multiplication.
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
     fn mul(self, other: Self) -> Self::Output {
         self.mul_safe(other).unwrap()
     }

--- a/src/integer/mat_z/arithmetic/sub.rs
+++ b/src/integer/mat_z/arithmetic/sub.rs
@@ -41,8 +41,8 @@ impl Sub for &MatZ {
     /// let f: MatZ = c - &e;
     /// ```
     ///
-    /// # Panics
-    /// - Panics if the dimensions of both matrices mismatch
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
     fn sub(self, other: Self) -> Self::Output {
         self.sub_safe(other).unwrap()
     }

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -160,7 +160,7 @@ mod test_sample_discrete_gauss {
     #[test]
     fn availability() {
         let n = Z::from(1024);
-        let center = Q::from(0);
+        let center = Q::ZERO;
         let s = Q::ONE;
 
         let _ = MatZ::sample_discrete_gauss(2u64, 3i8, &16u16, &center, &1u16);

--- a/src/integer/poly_over_z/evaluate.rs
+++ b/src/integer/poly_over_z/evaluate.rs
@@ -219,7 +219,7 @@ mod test_evaluate_q {
         let res_ref = poly.evaluate(&value);
         let res = poly.evaluate(value);
 
-        assert_eq!(Q::from(1), res);
+        assert_eq!(Q::ONE, res);
         assert_eq!(res_ref, res);
     }
 }

--- a/src/integer/poly_over_z/evaluate.rs
+++ b/src/integer/poly_over_z/evaluate.rs
@@ -65,7 +65,7 @@ impl Evaluate<&Q, Q> for PolyOverZ {
     /// use std::str::FromStr;
     ///
     /// let poly = PolyOverZ::from_str("5  0 1 2 -3 1").unwrap();
-    /// let value = Q::from_str("3/2").unwrap();
+    /// let value = Q::from((3,2));
     /// let res = poly.evaluate(&value);
     /// ```
     fn evaluate(&self, value: &Q) -> Q {
@@ -175,12 +175,12 @@ mod test_evaluate_q {
     #[test]
     fn evaluate_positive() {
         let poly = PolyOverZ::from_str("2  1 3").unwrap();
-        let value = Q::from_str("3/2").unwrap();
+        let value = Q::from((3, 2));
 
         let res_ref = poly.evaluate(&value);
         let res = poly.evaluate(value);
 
-        assert_eq!(Q::from_str("11/2").unwrap(), res);
+        assert_eq!(Q::from((11, 2)), res);
         assert_eq!(res_ref, res);
     }
 
@@ -188,12 +188,12 @@ mod test_evaluate_q {
     #[test]
     fn evaluate_negative() {
         let poly = PolyOverZ::from_str("2  1 3").unwrap();
-        let value = Q::from_str("-3/2").unwrap();
+        let value = Q::from((-3, 2));
 
         let res_ref = poly.evaluate(&value);
         let res = poly.evaluate(value);
 
-        assert_eq!(Q::from_str("-7/2").unwrap(), res);
+        assert_eq!(Q::from((-7, 2)), res);
         assert_eq!(res_ref, res);
     }
 
@@ -201,12 +201,12 @@ mod test_evaluate_q {
     #[test]
     fn evaluate_large_positive() {
         let poly = PolyOverZ::from_str(&format!("2  {} 1", (u64::MAX - 1) / 2)).unwrap();
-        let value = Q::from_str(&((u64::MAX - 1) / 2).to_string()).unwrap();
+        let value = Q::from((u64::MAX - 1) / 2);
 
         let res_ref = poly.evaluate(&value);
         let res = poly.evaluate(value);
 
-        assert_eq!(Q::from_str(&(u64::MAX - 1).to_string()).unwrap(), res);
+        assert_eq!(Q::from(u64::MAX - 1), res);
         assert_eq!(res_ref, res);
     }
 

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -283,8 +283,8 @@ mod test_add_between_z_and_q {
         let d: Q = &a + b;
         let e: Q = a + c;
 
-        assert_eq!(d, Q::from((1, u64::MAX)) + Q::from((u64::MAX, 1)));
-        assert_eq!(e, Q::from((u64::MAX, 1)) + Q::from((u64::MAX, 2)));
+        assert_eq!(d, Q::from((1, u64::MAX)) + Q::from(u64::MAX));
+        assert_eq!(e, Q::from(u64::MAX) + Q::from((u64::MAX, 2)));
     }
 }
 

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -361,52 +361,49 @@ mod test_add_between_z_and_zq {
     #[test]
     fn add() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = a + b;
-        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+        assert_eq!(c, Zq::from((2, 11)));
     }
 
     /// Testing addition for both borrowed [`Z`] and [`Zq`]
     #[test]
     fn add_borrow() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = &a + &b;
-        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+        assert_eq!(c, Zq::from((2, 11)));
     }
 
     /// Testing addition for borrowed [`Z`] and [`Zq`]
     #[test]
     fn add_first_borrowed() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = &a + b;
-        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+        assert_eq!(c, Zq::from((2, 11)));
     }
 
     /// Testing addition for [`Z`] and borrowed [`Zq`]
     #[test]
     fn add_second_borrowed() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = a + &b;
-        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+        assert_eq!(c, Zq::from((2, 11)));
     }
 
     /// Testing addition for big numbers
     #[test]
     fn add_large_numbers() {
         let a: Z = Z::from(u64::MAX);
-        let b: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
-        let c: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let b: Zq = Zq::from((i64::MAX, u64::MAX - 58));
+        let c: Zq = Zq::from((i64::MAX - 1, i64::MAX));
 
         let d: Zq = &a + b;
         let e: Zq = a + c;
 
-        assert_eq!(
-            d,
-            Zq::try_from(((u64::MAX - 1) / 2 + 58, u64::MAX - 58)).unwrap()
-        );
-        assert_eq!(e, Zq::try_from((0, i64::MAX)).unwrap());
+        assert_eq!(d, Zq::from(((u64::MAX - 1) / 2 + 58, u64::MAX - 58)));
+        assert_eq!(e, Zq::from((0, i64::MAX)));
     }
 }

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -113,7 +113,7 @@ impl Add<&Zq> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(42);
-    /// let b: Zq = Zq::from_str("42 mod 19").unwrap();
+    /// let b: Zq = Zq::from((42,19);
     ///
     /// let c: Zq = &a + &b;
     /// let d: Zq = a + b;

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -113,7 +113,7 @@ impl Add<&Zq> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(42);
-    /// let b: Zq = Zq::from((42,19);
+    /// let b: Zq = Zq::from((42,19));
     ///
     /// let c: Zq = &a + &b;
     /// let d: Zq = a + b;

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -76,8 +76,8 @@ impl Add<&Q> for &Z {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Z = Z::from_str("-42").unwrap();
-    /// let b: Q = Q::from_str("42/19").unwrap();
+    /// let a: Z = Z::from(-42);
+    /// let b: Q = Q::from((42,19));
     ///
     /// let c: Q = &a + &b;
     /// let d: Q = a + b;
@@ -236,64 +236,56 @@ mod test_add_between_types {
 mod test_add_between_z_and_q {
     use super::Z;
     use crate::rational::Q;
-    use std::str::FromStr;
+    
 
     /// Testing addition for [`Z`] and [`Q`]
     #[test]
     fn add() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = a + b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        assert_eq!(c, Q::from((33, 7)));
     }
 
     /// Testing addition for both borrowed [`Z`] and [`Q`]
     #[test]
     fn add_borrow() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = &a + &b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        assert_eq!(c, Q::from((33, 7)));
     }
 
     /// Testing addition for borrowed [`Z`] and [`Q`]
     #[test]
     fn add_first_borrowed() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = &a + b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        assert_eq!(c, Q::from((33, 7)));
     }
 
     /// Testing addition for [`Z`] and borrowed [`Q`]
     #[test]
     fn add_second_borrowed() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = a + &b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        assert_eq!(c, Q::from((33, 7)));
     }
 
     /// Testing addition for big numbers
     #[test]
     fn add_large_numbers() {
         let a: Z = Z::from(u64::MAX);
-        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
-        let c: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
+        let b: Q = Q::from((1, u64::MAX));
+        let c: Q = Q::from((u64::MAX, 2));
 
         let d: Q = &a + b;
         let e: Q = a + c;
 
-        assert_eq!(
-            d,
-            Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
-                + Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-        );
-        assert_eq!(
-            e,
-            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-                + Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
-        );
+        assert_eq!(d, Q::from((1, u64::MAX)) + Q::from((u64::MAX, 1)));
+        assert_eq!(e, Q::from((u64::MAX, 1)) + Q::from((u64::MAX, 2)));
     }
 }
 

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -236,7 +236,6 @@ mod test_add_between_types {
 mod test_add_between_z_and_q {
     use super::Z;
     use crate::rational::Q;
-    
 
     /// Testing addition for [`Z`] and [`Q`]
     #[test]

--- a/src/integer/z/arithmetic/div.rs
+++ b/src/integer/z/arithmetic/div.rs
@@ -229,7 +229,7 @@ impl Div<&Q> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(-42);
-    /// let b: Q = Q::from_str("42/19").unwrap();
+    /// let b: Q = Q::from((42,19));
     ///
     /// let c: Q = &a / &b;
     /// let d: Q = a / b;
@@ -496,63 +496,55 @@ mod test_div {
 mod test_div_between_z_and_q {
     use super::Z;
     use crate::rational::Q;
-    use std::str::FromStr;
+    
 
     /// Testing division for [`Z`] and [`Q`]
     #[test]
     fn div() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = a / b;
-        assert_eq!(c, Q::from_str("28/5").unwrap());
+        assert_eq!(c, Q::from((28, 5)));
     }
 
     /// Testing division for both borrowed [`Z`] and [`Q`]
     #[test]
     fn div_borrow() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = &a / &b;
-        assert_eq!(c, Q::from_str("28/5").unwrap());
+        assert_eq!(c, Q::from((28, 5)));
     }
 
     /// Testing division for borrowed [`Z`] and [`Q`]
     #[test]
     fn div_first_borrowed() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = &a / b;
-        assert_eq!(c, Q::from_str("28/5").unwrap());
+        assert_eq!(c, Q::from((28, 5)));
     }
 
     /// Testing division for [`Z`] and borrowed [`Q`]
     #[test]
     fn div_second_borrowed() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = a / &b;
-        assert_eq!(c, Q::from_str("28/5").unwrap());
+        assert_eq!(c, Q::from((28, 5)));
     }
 
     /// Testing division for big numbers
     #[test]
     fn div_large_numbers() {
         let a: Z = Z::from(u64::MAX);
-        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
-        let c: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
+        let b: Q = Q::from((1, u64::MAX));
+        let c: Q = Q::from((u64::MAX, 2));
 
         let d: Q = &a / b;
         let e: Q = a / c;
 
-        assert_eq!(
-            d,
-            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-                / Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
-        );
-        assert_eq!(
-            e,
-            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-                / Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
-        );
+        assert_eq!(d, Q::from((u64::MAX, 1)) / Q::from((1, u64::MAX)));
+        assert_eq!(e, Q::from((u64::MAX, 1)) / Q::from((u64::MAX, 2)));
     }
 }

--- a/src/integer/z/arithmetic/div.rs
+++ b/src/integer/z/arithmetic/div.rs
@@ -152,14 +152,14 @@ impl Div for &Z {
     /// let c: Q = &a / &b;
     /// let d: Q = a / b;
     ///
-    /// assert_eq!(Q::try_from((&21, &10)).unwrap(), c);
-    /// assert_eq!(Q::try_from((&21, &10)).unwrap(), d);
+    /// assert_eq!(Q::from((21, 10)), c);
+    /// assert_eq!(Q::from((21, 10)), d);
     /// ```
     ///
     /// # Panics ...
     /// - if the divisor is `0`.
     fn div(self, other: Self) -> Self::Output {
-        Q::try_from((self, other)).unwrap()
+        Q::from((self, other))
     }
 }
 
@@ -446,7 +446,7 @@ mod test_div {
         let a: Z = Z::from(42);
         let b: Z = Z::from(4);
         let c: Q = a / b;
-        assert_eq!(c, Q::try_from((&21, &2)).unwrap());
+        assert_eq!(c, Q::from((21, 2)));
     }
 
     /// Testing division for two borrowed [`Z`]
@@ -455,7 +455,7 @@ mod test_div {
         let a: Z = Z::from(42);
         let b: Z = Z::from(4);
         let c: Q = &a / &b;
-        assert_eq!(c, Q::try_from((&21, &2)).unwrap());
+        assert_eq!(c, Q::from((21, 2)));
     }
 
     /// Testing division for borrowed [`Z`] and [`Z`]
@@ -464,7 +464,7 @@ mod test_div {
         let a: Z = Z::from(42);
         let b: Z = Z::from(4);
         let c: Q = &a / b;
-        assert_eq!(c, Q::try_from((&21, &2)).unwrap());
+        assert_eq!(c, Q::from((21, 2)));
     }
 
     /// Testing division for [`Z`] and borrowed [`Z`]
@@ -473,7 +473,7 @@ mod test_div {
         let a: Z = Z::from(42);
         let b: Z = Z::from(4);
         let c: Q = a / &b;
-        assert_eq!(c, Q::try_from((&21, &2)).unwrap());
+        assert_eq!(c, Q::from((21, 2)));
     }
 
     /// Testing division for big [`Z`]
@@ -487,7 +487,7 @@ mod test_div {
         let e: Q = a / b;
         let f: Q = c / d;
 
-        assert_eq!(e, Q::from(Z::from(2).pow(62).unwrap()));
+        assert_eq!(e, Q::from(2).pow(62).unwrap());
         assert_eq!(f, Q::MINUS_ONE);
     }
 }
@@ -543,7 +543,7 @@ mod test_div_between_z_and_q {
         let d: Q = &a / b;
         let e: Q = a / c;
 
-        assert_eq!(d, Q::from((u64::MAX, 1)) / Q::from((1, u64::MAX)));
-        assert_eq!(e, Q::from((u64::MAX, 1)) / Q::from((u64::MAX, 2)));
+        assert_eq!(d, Q::from(u64::MAX) / Q::from((1, u64::MAX)));
+        assert_eq!(e, Q::from(u64::MAX) / Q::from((u64::MAX, 2)));
     }
 }

--- a/src/integer/z/arithmetic/div.rs
+++ b/src/integer/z/arithmetic/div.rs
@@ -157,7 +157,7 @@ impl Div for &Z {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the divisor is `0`.
+    /// - if the divisor is `0`.
     fn div(self, other: Self) -> Self::Output {
         Q::try_from((self, other)).unwrap()
     }
@@ -238,7 +238,7 @@ impl Div<&Q> for &Z {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the divisor is `0`
+    /// - if the divisor is `0`.
     fn div(self, other: &Q) -> Self::Output {
         if other == &Q::ZERO {
             panic!(
@@ -487,7 +487,7 @@ mod test_div {
         let e: Q = a / b;
         let f: Q = c / d;
 
-        assert_eq!(e, Q::from_int(Z::from(2).pow(62).unwrap()));
+        assert_eq!(e, Q::from(Z::from(2).pow(62).unwrap()));
         assert_eq!(f, Q::MINUS_ONE);
     }
 }
@@ -496,7 +496,6 @@ mod test_div {
 mod test_div_between_z_and_q {
     use super::Z;
     use crate::rational::Q;
-    
 
     /// Testing division for [`Z`] and [`Q`]
     #[test]

--- a/src/integer/z/arithmetic/div.rs
+++ b/src/integer/z/arithmetic/div.rs
@@ -228,7 +228,7 @@ impl Div<&Q> for &Z {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Z = Z::from_str("-42").unwrap();
+    /// let a: Z = Z::from(-42);
     /// let b: Q = Q::from_str("42/19").unwrap();
     ///
     /// let c: Q = &a / &b;

--- a/src/integer/z/arithmetic/exp.rs
+++ b/src/integer/z/arithmetic/exp.rs
@@ -39,7 +39,6 @@ impl Z {
 #[cfg(test)]
 mod test_exp {
     use crate::{integer::Z, rational::Q};
-    use std::str::FromStr;
 
     /// Ensure that `0` is returned if the length `0` is provided
     #[test]
@@ -52,17 +51,8 @@ mod test_exp {
     /// Test correct evaluation for some explicit values
     #[test]
     fn ten_length_value() {
-        assert_eq!(
-            Q::from_str("98641/36288").unwrap(),
-            Z::ONE.exp_taylor(10_u32)
-        );
-        assert_eq!(
-            Q::from_str("22471/1120").unwrap(),
-            Z::from(3).exp_taylor(10_u32)
-        );
-        assert_eq!(
-            Q::from_str("83/2240").unwrap(),
-            Z::from(-3).exp_taylor(10_u32)
-        );
+        assert_eq!(Q::from((98641, 36288)), Z::ONE.exp_taylor(10_u32));
+        assert_eq!(Q::from((22471, 1120)), Z::from(3).exp_taylor(10_u32));
+        assert_eq!(Q::from((83, 2240)), Z::from(-3).exp_taylor(10_u32));
     }
 }

--- a/src/integer/z/arithmetic/logarithm.rs
+++ b/src/integer/z/arithmetic/logarithm.rs
@@ -354,8 +354,8 @@ mod test_log {
         let z_2 = Z::from(6);
         let z_3 = Z::from(9);
         let cmp_0 = Q::from(6_f64.log2());
-        let cmp_1 = Q::try_from((&2, &1)).unwrap();
-        let max_distance = Q::try_from((&1, &1_000_000_000)).unwrap();
+        let cmp_1 = Q::from(2);
+        let max_distance = Q::from((1, 1_000_000_000));
 
         let res_0 = z_0.log(&2).unwrap();
         let res_1 = z_1.log(&2).unwrap();
@@ -374,9 +374,9 @@ mod test_log {
         let z_0 = Z::from(i64::MAX as u64 + 1);
         let z_1 = Z::from(i64::MAX);
         let z_2 = Z::from(i32::MAX);
-        let cmp_0 = Q::try_from((&63, &1)).unwrap();
+        let cmp_0 = Q::from(63);
         let cmp_1 = Q::from((i64::MAX as f64).log2());
-        let max_distance = Q::try_from((&1, &1_000_000_000)).unwrap();
+        let max_distance = Q::from((1, 1_000_000_000));
 
         let res_0 = z_0.log(&2).unwrap();
         let res_1 = z_1.log(&2).unwrap();

--- a/src/integer/z/arithmetic/mul.rs
+++ b/src/integer/z/arithmetic/mul.rs
@@ -77,7 +77,7 @@ impl Mul<&Q> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(-42);
-    /// let b: Q = Q::from_str("42/19").unwrap();
+    /// let b: Q = Q::from((42, 19));
     ///
     /// let c: Q = &a * &b;
     /// let d: Q = a * b;
@@ -351,63 +351,55 @@ mod test_mul_between_z_and_zq {
 mod test_mul_between_z_and_q {
     use super::Z;
     use crate::rational::Q;
-    use std::str::FromStr;
+    
 
     /// Testing multiplication for [`Z`] and [`Q`]
     #[test]
     fn mul() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = a * b;
-        assert_eq!(c, Q::from_str("20/7").unwrap());
+        assert_eq!(c, Q::from((20, 7)));
     }
 
     /// Testing multiplication for both borrowed [`Z`] and [`Q`]
     #[test]
     fn mul_borrow() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = &a * &b;
-        assert_eq!(c, Q::from_str("20/7").unwrap());
+        assert_eq!(c, Q::from((20, 7)));
     }
 
     /// Testing multiplication for borrowed [`Z`] and [`Q`]
     #[test]
     fn mul_first_borrowed() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = &a * b;
-        assert_eq!(c, Q::from_str("20/7").unwrap());
+        assert_eq!(c, Q::from((20, 7)));
     }
 
     /// Testing multiplication for [`Z`] and borrowed [`Q`]
     #[test]
     fn mul_second_borrowed() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = a * &b;
-        assert_eq!(c, Q::from_str("20/7").unwrap());
+        assert_eq!(c, Q::from((20, 7)));
     }
 
     /// Testing multiplication for big numbers
     #[test]
     fn mul_large_numbers() {
         let a: Z = Z::from(u64::MAX);
-        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
-        let c: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
+        let b: Q = Q::from((1, u64::MAX));
+        let c: Q = Q::from((u64::MAX, 2));
 
         let d: Q = &a * b;
         let e: Q = a * c;
 
-        assert_eq!(
-            d,
-            Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
-                * Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-        );
-        assert_eq!(
-            e,
-            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-                * Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
-        );
+        assert_eq!(d, Q::from((1, u64::MAX)) * Q::from((u64::MAX, 1)));
+        assert_eq!(e, Q::from((u64::MAX, 1)) * Q::from((u64::MAX, 2)));
     }
 }

--- a/src/integer/z/arithmetic/mul.rs
+++ b/src/integer/z/arithmetic/mul.rs
@@ -76,7 +76,7 @@ impl Mul<&Q> for &Z {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Z = Z::from_str("-42").unwrap();
+    /// let a: Z = Z::from(-42);
     /// let b: Q = Q::from_str("42/19").unwrap();
     ///
     /// let c: Q = &a * &b;

--- a/src/integer/z/arithmetic/mul.rs
+++ b/src/integer/z/arithmetic/mul.rs
@@ -398,7 +398,7 @@ mod test_mul_between_z_and_q {
         let d: Q = &a * b;
         let e: Q = a * c;
 
-        assert_eq!(d, Q::from((1, u64::MAX)) * Q::from((u64::MAX, 1)));
-        assert_eq!(e, Q::from((u64::MAX, 1)) * Q::from((u64::MAX, 2)));
+        assert_eq!(d, Q::from((1, u64::MAX)) * Q::from(u64::MAX));
+        assert_eq!(e, Q::from(u64::MAX) * Q::from((u64::MAX, 2)));
     }
 }

--- a/src/integer/z/arithmetic/mul.rs
+++ b/src/integer/z/arithmetic/mul.rs
@@ -113,7 +113,7 @@ impl Mul<&Zq> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(42);
-    /// let b: Zq = Zq::from_str("42 mod 19").unwrap();
+    /// let b: Zq = Zq::from(42, 9);
     ///
     /// let c: Zq = &a * &b;
     /// let d: Zq = a * b;

--- a/src/integer/z/arithmetic/mul.rs
+++ b/src/integer/z/arithmetic/mul.rs
@@ -113,7 +113,7 @@ impl Mul<&Zq> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(42);
-    /// let b: Zq = Zq::from(42, 9);
+    /// let b: Zq = Zq::from((42, 9));
     ///
     /// let c: Zq = &a * &b;
     /// let d: Zq = a * b;

--- a/src/integer/z/arithmetic/mul.rs
+++ b/src/integer/z/arithmetic/mul.rs
@@ -351,7 +351,6 @@ mod test_mul_between_z_and_zq {
 mod test_mul_between_z_and_q {
     use super::Z;
     use crate::rational::Q;
-    
 
     /// Testing multiplication for [`Z`] and [`Q`]
     #[test]

--- a/src/integer/z/arithmetic/mul.rs
+++ b/src/integer/z/arithmetic/mul.rs
@@ -297,57 +297,53 @@ mod test_mul_between_z_and_zq {
     #[test]
     fn mul() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = a * b;
-        assert_eq!(c, Zq::try_from((3, 11)).unwrap());
+        assert_eq!(c, Zq::from((3, 11)));
     }
 
     /// Testing multiplication for both borrowed [`Z`] and [`Zq`]
     #[test]
     fn mul_borrow() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = &a * &b;
-        assert_eq!(c, Zq::try_from((3, 11)).unwrap());
+        assert_eq!(c, Zq::from((3, 11)));
     }
 
     /// Testing multiplication for borrowed [`Z`] and [`Zq`]
     #[test]
     fn mul_first_borrowed() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = &a * b;
-        assert_eq!(c, Zq::try_from((3, 11)).unwrap());
+        assert_eq!(c, Zq::from((3, 11)));
     }
 
     /// Testing multiplication for [`Z`] and borrowed [`Zq`]
     #[test]
     fn mul_second_borrowed() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = a * &b;
-        assert_eq!(c, Zq::try_from((3, 11)).unwrap());
+        assert_eq!(c, Zq::from((3, 11)));
     }
 
     /// Testing multiplication for big numbers
     #[test]
     fn mul_large_numbers() {
         let a: Z = Z::from(u64::MAX);
-        let b: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
-        let c: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let b: Zq = Zq::from((i64::MAX, u64::MAX - 58));
+        let c: Zq = Zq::from((i64::MAX - 1, i64::MAX));
 
         let d: Zq = &a * b;
         let e: Zq = a * c;
 
         assert_eq!(
             d,
-            Zq::try_from(((u64::MAX - 1) / 2, u64::MAX - 58)).unwrap()
-                * Zq::try_from((u64::MAX, u64::MAX - 58)).unwrap()
+            Zq::from(((u64::MAX - 1) / 2, u64::MAX - 58)) * Zq::from((u64::MAX, u64::MAX - 58))
         );
-        assert_eq!(
-            e,
-            Zq::try_from((u64::MAX, i64::MAX)).unwrap() * Zq::try_from((-1, i64::MAX)).unwrap()
-        );
+        assert_eq!(e, Zq::from((u64::MAX, i64::MAX)) * Zq::from((-1, i64::MAX)));
     }
 }
 

--- a/src/integer/z/arithmetic/root.rs
+++ b/src/integer/z/arithmetic/root.rs
@@ -146,7 +146,7 @@ mod test_sqrt_precision {
                 // sqrt_precision(v,precision) = r = sqrt(x) + e
                 // => r^2 = x + 2*sqrt(x)*e + e^2
                 // => r^2-x = 2*sqrt(x)*e + e^2 = difference <= 2*sqrt(x)*p + p^2
-                let p = Q::try_from((&1, precision)).unwrap() / Q::from(2);
+                let p = Q::from((1, precision)) / Q::from(2);
 
                 let root_squared = &root * &root;
                 let difference = root_squared - Q::from(value.clone());

--- a/src/integer/z/arithmetic/root.rs
+++ b/src/integer/z/arithmetic/root.rs
@@ -201,8 +201,8 @@ mod test_sqrt_precision {
     /// # Errors and Failures
     /// - Returns a [`MathError`] if a type conversion failed.
     ///
-    /// # Panics
-    /// - Panics if at any point the calculated solution is not matching
+    /// # Panics ...
+    /// - if at any point the calculated solution is not matching
     ///   the given solution.
     fn compare_solutions(value: Z, solutions: Vec<&str>) -> Result<(), MathError> {
         let max_precision = Q::from_str(solutions.last().unwrap())?.get_denominator();

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -342,8 +342,8 @@ mod test_sub_between_z_and_q {
         let d: Q = &a - b;
         let e: Q = a - c;
 
-        assert_eq!(d, Q::from((u64::MAX, 1)) - Q::from((1, u64::MAX)));
-        assert_eq!(e, Q::from((u64::MAX, 1)) - Q::from((u64::MAX, 2)));
+        assert_eq!(d, Q::from(u64::MAX) - Q::from((1, u64::MAX)));
+        assert_eq!(e, Q::from(u64::MAX) - Q::from((u64::MAX, 2)));
     }
 }
 

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -365,52 +365,49 @@ mod test_sub_between_z_and_zq {
     #[test]
     fn sub() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((10, 11)).unwrap();
+        let b: Zq = Zq::from((10, 11));
         let c: Zq = a - b;
-        assert_eq!(c, Zq::try_from((10, 11)).unwrap());
+        assert_eq!(c, Zq::from((10, 11)));
     }
 
     /// Testing subtraction for both borrowed [`Z`] and [`Zq`]
     #[test]
     fn sub_borrow() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = &a - &b;
-        assert_eq!(c, Zq::try_from((5, 11)).unwrap());
+        assert_eq!(c, Zq::from((5, 11)));
     }
 
     /// Testing subtraction for borrowed [`Z`] and [`Zq`]
     #[test]
     fn sub_first_borrowed() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = &a - b;
-        assert_eq!(c, Zq::try_from((5, 11)).unwrap());
+        assert_eq!(c, Zq::from((5, 11)));
     }
 
     /// Testing subtraction for [`Z`] and borrowed [`Zq`]
     #[test]
     fn sub_second_borrowed() {
         let a: Z = Z::from(9);
-        let b: Zq = Zq::try_from((4, 11)).unwrap();
+        let b: Zq = Zq::from((4, 11));
         let c: Zq = a - &b;
-        assert_eq!(c, Zq::try_from((5, 11)).unwrap());
+        assert_eq!(c, Zq::from((5, 11)));
     }
 
     /// Testing subtraction for big numbers
     #[test]
     fn sub_large_numbers() {
         let a: Z = Z::from(u64::MAX);
-        let b: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
-        let c: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let b: Zq = Zq::from((i64::MAX, u64::MAX - 58));
+        let c: Zq = Zq::from((i64::MAX - 1, i64::MAX));
 
         let d: Zq = &a - b;
         let e: Zq = a - c;
 
-        assert_eq!(
-            d,
-            Zq::try_from(((u64::MAX - 1) / 2 + 1, u64::MAX - 58)).unwrap()
-        );
-        assert_eq!(e, Zq::try_from((2, i64::MAX)).unwrap());
+        assert_eq!(d, Zq::from(((u64::MAX - 1) / 2 + 1, u64::MAX - 58)));
+        assert_eq!(e, Zq::from((2, i64::MAX)));
     }
 }

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -76,7 +76,7 @@ impl Sub<&Q> for &Z {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Z = Z::from_str("-42").unwrap();
+    /// let a: Z = Z::from(-42);
     /// let b: Q = Q::from_str("42/19").unwrap();
     ///
     /// let c: Q = &a - &b;

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -115,7 +115,7 @@ impl Sub<&Zq> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(42);
-    /// let b: Zq = Zq::from(42, 19);
+    /// let b: Zq = Zq::from((42, 19));
     ///
     /// let c: Zq = &a - &b;
     /// let d: Zq = a - b;

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -115,7 +115,7 @@ impl Sub<&Zq> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(42);
-    /// let b: Zq = Zq::from_str("42 mod 19").unwrap();
+    /// let b: Zq = Zq::from(42, 19);
     ///
     /// let c: Zq = &a - &b;
     /// let d: Zq = a - b;

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -295,7 +295,6 @@ mod test_sub {
 mod test_sub_between_z_and_q {
     use super::Z;
     use crate::rational::Q;
-    
 
     /// Testing subtraction for [`Z`] and [`Q`]
     #[test]

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -77,7 +77,7 @@ impl Sub<&Q> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(-42);
-    /// let b: Q = Q::from_str("42/19").unwrap();
+    /// let b: Q = Q::from((42, 19));
     ///
     /// let c: Q = &a - &b;
     /// let d: Q = a - b;
@@ -295,64 +295,56 @@ mod test_sub {
 mod test_sub_between_z_and_q {
     use super::Z;
     use crate::rational::Q;
-    use std::str::FromStr;
+    
 
     /// Testing subtraction for [`Z`] and [`Q`]
     #[test]
     fn sub() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = a - b;
-        assert_eq!(c, Q::from_str("23/7").unwrap());
+        assert_eq!(c, Q::from((23, 7)));
     }
 
     /// Testing subtraction for both borrowed [`Z`] and [`Q`]
     #[test]
     fn sub_borrow() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = &a - &b;
-        assert_eq!(c, Q::from_str("23/7").unwrap());
+        assert_eq!(c, Q::from((23, 7)));
     }
 
     /// Testing subtraction for borrowed [`Z`] and [`Q`]
     #[test]
     fn sub_first_borrowed() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = &a - b;
-        assert_eq!(c, Q::from_str("23/7").unwrap());
+        assert_eq!(c, Q::from((23, 7)));
     }
 
     /// Testing subtraction for [`Z`] and borrowed [`Q`]
     #[test]
     fn sub_second_borrowed() {
         let a: Z = Z::from(4);
-        let b: Q = Q::from_str("5/7").unwrap();
+        let b: Q = Q::from((5, 7));
         let c: Q = a - &b;
-        assert_eq!(c, Q::from_str("23/7").unwrap());
+        assert_eq!(c, Q::from((23, 7)));
     }
 
     /// Testing subtraction for big numbers
     #[test]
     fn sub_large_numbers() {
         let a: Z = Z::from(u64::MAX);
-        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
-        let c: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
+        let b: Q = Q::from((1, u64::MAX));
+        let c: Q = Q::from((u64::MAX, 2));
 
         let d: Q = &a - b;
         let e: Q = a - c;
 
-        assert_eq!(
-            d,
-            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-                - Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
-        );
-        assert_eq!(
-            e,
-            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-                - Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
-        );
+        assert_eq!(d, Q::from((u64::MAX, 1)) - Q::from((1, u64::MAX)));
+        assert_eq!(e, Q::from((u64::MAX, 1)) - Q::from((u64::MAX, 2)));
     }
 }
 

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -225,7 +225,7 @@ impl FromStr for Z {
     /// use qfall_math::integer::Z;
     ///  
     /// let a: Z = "100".parse().unwrap();
-    /// let b: Z = Z::from_str("100").unwrap();
+    /// let b: Z = Z::from(100);
     /// ```
     ///
     /// # Errors and Failures

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -412,9 +412,9 @@ mod tests_from_int {
     #[test]
     fn modulus() {
         let val_1 = Z::from(u64::MAX);
-        let mod_1 = Modulus::try_from(&val_1).unwrap();
+        let mod_1 = Modulus::from(&val_1);
         let val_2 = Z::from(10);
-        let mod_2 = Modulus::try_from(&val_2).unwrap();
+        let mod_2 = Modulus::from(&val_2);
 
         assert_eq!(val_1, Z::from(&mod_1));
         assert_eq!(val_2, Z::from(&mod_2));

--- a/src/integer/z/properties.rs
+++ b/src/integer/z/properties.rs
@@ -90,7 +90,7 @@ impl Z {
     ///
     /// let inverse = value.inverse().unwrap();
     ///
-    /// assert_eq!(Q::try_from((&1, &4)).unwrap(), inverse);
+    /// assert_eq!(Q::from((1, 4)), inverse);
     /// ```
     pub fn inverse(&self) -> Option<Q> {
         if self == &Z::ZERO {
@@ -223,8 +223,8 @@ mod test_inv {
         let inv_0 = val_0.inverse().unwrap();
         let inv_1 = val_1.inverse().unwrap();
 
-        assert_eq!(Q::try_from((&1, &4)).unwrap(), inv_0);
-        assert_eq!(Q::try_from((&-1, &7)).unwrap(), inv_1);
+        assert_eq!(Q::from((1, 4)), inv_0);
+        assert_eq!(Q::from((-1, 7)), inv_1);
     }
 
     /// Checks whether the inverse is correctly computed for large values.
@@ -236,8 +236,8 @@ mod test_inv {
         let inv_0 = val_0.inverse().unwrap();
         let inv_1 = val_1.inverse().unwrap();
 
-        assert_eq!(Q::try_from((&1, &i64::MAX)).unwrap(), inv_0);
-        assert_eq!(Q::try_from((&1, &i64::MIN)).unwrap(), inv_1);
+        assert_eq!(Q::from((1, i64::MAX)), inv_0);
+        assert_eq!(Q::from((1, i64::MIN)), inv_1);
     }
 
     /// Checks whether the inverse of `0` returns `None`.

--- a/src/integer/z/sample/uniform.rs
+++ b/src/integer/z/sample/uniform.rs
@@ -209,7 +209,7 @@ mod test_sample_uniform {
 #[cfg(test)]
 mod test_sample_prime_uniform {
     use crate::{integer::Z, integer_mod_q::Modulus};
-    use std::str::FromStr;
+    
 
     /// Checks whether `sample_prime_uniform` outputs a prime sample every time.
     #[test]
@@ -287,7 +287,7 @@ mod test_sample_prime_uniform {
     /// implementing Into<Z>, i.e. u8, u16, u32, u64, i8, ...
     #[test]
     fn availability() {
-        let modulus = Modulus::from_str("7").unwrap();
+        let modulus = Modulus::from(7);
         let z = Z::from(7);
 
         let _ = Z::sample_prime_uniform(&0u16, &7u8);

--- a/src/integer/z/sample/uniform.rs
+++ b/src/integer/z/sample/uniform.rs
@@ -209,7 +209,6 @@ mod test_sample_uniform {
 #[cfg(test)]
 mod test_sample_prime_uniform {
     use crate::{integer::Z, integer_mod_q::Modulus};
-    
 
     /// Checks whether `sample_prime_uniform` outputs a prime sample every time.
     #[test]

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
@@ -47,8 +47,8 @@ impl Add for &MatPolynomialRingZq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the moduli of both [`MatPolynomialRingZq`] mismatch.
-    /// - ... if the dimensions of both [`MatPolynomialRingZq`] mismatch.
+    /// - if the moduli of both [`MatPolynomialRingZq`] mismatch.
+    /// - if the dimensions of both [`MatPolynomialRingZq`] mismatch.
     fn add(self, other: Self) -> Self::Output {
         self.add_safe(other).unwrap()
     }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
@@ -118,7 +118,7 @@ mod test_add {
     use crate::integer_mod_q::ModulusPolynomialRingZq;
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = 18446744073709551557;
+    const LARGE_PRIME: u64 = 18446744073709551557;
 
     /// Testing addition for two [`MatPolynomialRingZq`]
     #[test]
@@ -205,7 +205,7 @@ mod test_add {
         let modulus = ModulusPolynomialRingZq::from_str(&format!(
             "5  1 1 0 0 {} mod {}",
             i64::MAX,
-            BITPRIME64
+            LARGE_PRIME
         ))
         .unwrap();
         let poly_mat1 = MatPolyOverZ::from_str(&format!(

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
@@ -123,7 +123,7 @@ mod test_mul {
     use crate::{integer::MatPolyOverZ, integer_mod_q::ModulusPolynomialRingZq};
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Checks if matrix multiplication works fine for squared matrices.
     #[test]
@@ -163,7 +163,7 @@ mod test_mul {
     #[test]
     fn large_entries() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat1 =
             MatPolyOverZ::from_str(&format!("[[2  3 {},1  15],[1  1,0]]", u64::MAX)).unwrap();
         let poly_ring_mat1 = MatPolynomialRingZq::from((&poly_mat1, &modulus));

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
@@ -46,9 +46,9 @@ impl Mul for &MatPolynomialRingZq {
     /// let poly_ring_mat6: MatPolynomialRingZq = poly_ring_mat3 * &poly_ring_mat5;
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Panics if the dimensions of `self` and `other` do not match for multiplication.
-    /// - Panics if the moduli mismatch.
+    /// # Panics ...
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
+    /// - if the moduli mismatch.
     fn mul(self, other: Self) -> Self::Output {
         self.mul_safe(other).unwrap()
     }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/concat.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/concat.rs
@@ -137,13 +137,13 @@ mod test_concatenate {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that the dimensions are taken over correctly and an error occurs
     /// if the dimensions mismatch.
     #[test]
     fn dimensions_vertical() {
-        let modulus_str = format!("3  1 {} 1 mod {}", i64::MAX, BITPRIME64);
+        let modulus_str = format!("3  1 {} 1 mod {}", i64::MAX, LARGE_PRIME);
         let modulus = ModulusPolynomialRingZq::from_str(&modulus_str).unwrap();
         let mat_1 = MatPolynomialRingZq::new(13, 5, &modulus);
         let mat_2 = MatPolynomialRingZq::new(17, 5, &modulus);
@@ -161,7 +161,7 @@ mod test_concatenate {
     /// if the dimensions mismatch.
     #[test]
     fn dimensions_horizontal() {
-        let modulus_str = format!("3  1 {} 1 mod {}", i64::MAX, BITPRIME64);
+        let modulus_str = format!("3  1 {} 1 mod {}", i64::MAX, LARGE_PRIME);
         let modulus = ModulusPolynomialRingZq::from_str(&modulus_str).unwrap();
         let mat_1 = MatPolynomialRingZq::new(13, 5, &modulus);
         let mat_2 = MatPolynomialRingZq::new(17, 5, &modulus);
@@ -178,7 +178,7 @@ mod test_concatenate {
     /// Ensure that vertical concatenation works correctly.
     #[test]
     fn vertically_correct() {
-        let modulus_str = format!("3  1 {} 1 mod {}", i64::MAX, BITPRIME64);
+        let modulus_str = format!("3  1 {} 1 mod {}", i64::MAX, LARGE_PRIME);
         let modulus = ModulusPolynomialRingZq::from_str(&modulus_str).unwrap();
         let poly_mat_1 =
             MatPolyOverZ::from_str(&format!("[[4  2 {} 1 1, 1  42],[0, 2  1 2]]", u64::MAX))
@@ -199,11 +199,11 @@ mod test_concatenate {
     /// Ensure that horizontal concatenation works correctly.
     #[test]
     fn horizontally_correct() {
-        let modulus_str = format!("3  1 {} 1 mod {}", i64::MAX, BITPRIME64);
+        let modulus_str = format!("3  1 {} 1 mod {}", i64::MAX, LARGE_PRIME);
         let modulus = ModulusPolynomialRingZq::from_str(&modulus_str).unwrap();
         let poly_mat_1 = MatPolyOverZ::from_str(&format!(
             "[[4  {} {} 1 1, 1  42],[0, 2  1 2]]",
-            BITPRIME64 + 2,
+            LARGE_PRIME + 2,
             u64::MAX
         ))
         .unwrap();

--- a/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
@@ -60,7 +60,7 @@ mod test_new {
     use crate::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq, PolyOverZq};
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that initialization works.
     #[test]
@@ -97,7 +97,7 @@ mod test_new {
     #[test]
     fn large_modulus() {
         let poly_mod =
-            PolyOverZq::from_str(&format!("3  1 {} 1 mod {}", i64::MAX, BITPRIME64)).unwrap();
+            PolyOverZq::from_str(&format!("3  1 {} 1 mod {}", i64::MAX, LARGE_PRIME)).unwrap();
         let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
 
         let _ = MatPolynomialRingZq::new(2, 2, &modulus);

--- a/src/integer_mod_q/mat_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/from.rs
@@ -80,17 +80,17 @@ mod test_from_poly_over_z_modulus_polynomial_ring_zq {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that the modulus is applied with a large prime and large coefficients
     #[test]
     fn is_reduced_large() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
 
         let poly_mat = MatPolyOverZ::from_str(&format!(
             "[[4  {} {} 1 1, 1  42],[0, 2  1 2]]",
-            BITPRIME64 + 2,
+            LARGE_PRIME + 2,
             u64::MAX
         ))
         .unwrap();
@@ -110,10 +110,10 @@ mod test_from_poly_over_z_modulus_polynomial_ring_zq {
     #[test]
     fn same_instantiation() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat = MatPolyOverZ::from_str(&format!(
             "[[4  {} {} 1 1, 1  42],[0, 2  1 2]]",
-            BITPRIME64 + 2,
+            LARGE_PRIME + 2,
             u64::MAX
         ))
         .unwrap();
@@ -130,7 +130,7 @@ mod test_from_poly_over_z_modulus_polynomial_ring_zq {
     #[test]
     fn different_dimensions() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("3  1 9 12 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("3  1 9 12 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat1 = MatPolyOverZ::from_str("[[2  1 8],[2  1 2]]").unwrap();
         let poly_mat2 = MatPolyOverZ::from_str("[[2  1 8, 1  42, 0],[0, 2  1 2, 1  17]]").unwrap();
         let poly_mat3 = MatPolyOverZ::from_str("[[2  1 8]]").unwrap();

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -199,7 +199,7 @@ mod test_get_entry {
     use crate::{error::MathError, traits::GetEntry};
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that getting entries works on the edge.
     #[test]
@@ -218,7 +218,7 @@ mod test_get_entry {
     #[test]
     fn big_positive() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", BITPRIME64))
+            ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", LARGE_PRIME))
                 .unwrap();
         let poly_mat =
             MatPolyOverZ::from_str(&format!("[[4  1 0 {} 1, 1  42],[0, 2  1 2]]", i64::MAX))
@@ -237,7 +237,7 @@ mod test_get_entry {
     #[test]
     fn error_wrong_row() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", BITPRIME64))
+            ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", LARGE_PRIME))
                 .unwrap();
         let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
         let entry1: Result<PolyOverZ, MathError> = matrix.get_entry(5, 1);
@@ -251,7 +251,7 @@ mod test_get_entry {
     #[test]
     fn error_wrong_column() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", BITPRIME64))
+            ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", LARGE_PRIME))
                 .unwrap();
         let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
         let entry: Result<PolyOverZ, MathError> = matrix.get_entry(1, 100);
@@ -263,7 +263,7 @@ mod test_get_entry {
     #[test]
     fn diff_types() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", BITPRIME64))
+            ModulusPolynomialRingZq::from_str(&format!("5  42 17 1 2 3 mod {}", LARGE_PRIME))
                 .unwrap();
         let matrix = MatPolynomialRingZq::new(5, 10, &modulus);
 
@@ -307,7 +307,7 @@ mod test_mod {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that the getter for modulus works correctly.
     #[test]
@@ -326,13 +326,13 @@ mod test_mod {
     #[test]
     fn get_mod_large() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
         let matrix = MatPolynomialRingZq::from((&poly_mat, &modulus));
 
         assert_eq!(
             matrix.get_mod(),
-            ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", BITPRIME64)).unwrap()
+            ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", LARGE_PRIME)).unwrap()
         );
     }
 
@@ -340,17 +340,18 @@ mod test_mod {
     #[test]
     fn get_mod_memory() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
         let matrix = MatPolynomialRingZq::from((&poly_mat, &modulus));
         let _ = matrix.get_mod();
-        let _ = ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", BITPRIME64)).unwrap();
+        let _ =
+            ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", LARGE_PRIME)).unwrap();
 
         let modulus = matrix.get_mod();
 
         assert_eq!(
             modulus,
-            ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", BITPRIME64)).unwrap()
+            ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {}", LARGE_PRIME)).unwrap()
         );
     }
 }
@@ -362,12 +363,12 @@ mod test_collect_entries {
     use flint_sys::fmpz_poly::fmpz_poly_set;
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     #[test]
     fn all_entries_collected() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat1 = MatPolyOverZ::from_str(&format!(
             "[[4  -1 0 3 1, 1  {}],[2  1 2, 3  {} 1 1]]",
             i64::MAX,

--- a/src/integer_mod_q/mat_polynomial_ring_zq/reduce.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/reduce.rs
@@ -58,7 +58,7 @@ mod test_reduced {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that the entries are reduced
     #[test]
@@ -90,9 +90,12 @@ mod test_reduced {
     /// Ensure that reduce works with large entries and moduli
     #[test]
     fn large_values() {
-        let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  {} 0 0 1 mod {}", i64::MAX, BITPRIME64))
-                .unwrap();
+        let modulus = ModulusPolynomialRingZq::from_str(&format!(
+            "4  {} 0 0 1 mod {}",
+            i64::MAX,
+            LARGE_PRIME
+        ))
+        .unwrap();
         let poly_mat =
             MatPolyOverZ::from_str(&format!("[[4  -1 0 {} 1, 1  42],[0, 2  1 2]]", i64::MAX))
                 .unwrap();
@@ -101,12 +104,15 @@ mod test_reduced {
             modulus,
         };
 
-        let cmp_modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  {} 0 0 1 mod {}", i64::MAX, BITPRIME64))
-                .unwrap();
+        let cmp_modulus = ModulusPolynomialRingZq::from_str(&format!(
+            "4  {} 0 0 1 mod {}",
+            i64::MAX,
+            LARGE_PRIME
+        ))
+        .unwrap();
         let cmp_poly_mat = MatPolyOverZ::from_str(&format!(
             "[[3  {} 0 {}, 1  42],[0, 2  1 2]]",
-            BITPRIME64 - i64::MAX as u64 - 1,
+            LARGE_PRIME - i64::MAX as u64 - 1,
             i64::MAX
         ))
         .unwrap();

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -132,7 +132,7 @@ mod test_setter {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that setting entries works with standard numbers.
     #[test]
@@ -156,7 +156,7 @@ mod test_setter {
     #[test]
     fn big_positive() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat =
             MatPolyOverZ::from_str(&format!("[[2  1 1, 1  42],[0, 2  {} 2]]", i64::MAX)).unwrap();
         let mut poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
@@ -170,7 +170,7 @@ mod test_setter {
         assert_eq!(format!("3  1 {} 1", i64::MAX), entry_z.to_string());
         assert_eq!(format!("3  1 {} 1", i64::MAX), entry_zq.poly.to_string());
         assert_eq!(
-            format!("4  1 0 0 1 mod {}", BITPRIME64),
+            format!("4  1 0 0 1 mod {}", LARGE_PRIME),
             entry_zq.modulus.to_string()
         );
     }
@@ -179,7 +179,7 @@ mod test_setter {
     #[test]
     fn big_positive_ref() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat = MatPolyOverZ::from_str(&format!(
             "[[2  1 1, 1  42, 0],[0, 2  {} 2, 1  1]]",
             i64::MAX
@@ -196,7 +196,7 @@ mod test_setter {
         assert_eq!(format!("3  1 {} 1", i64::MAX), entry_z.to_string());
         assert_eq!(format!("3  1 {} 1", i64::MAX), entry_zq.poly.to_string());
         assert_eq!(
-            format!("4  1 0 0 1 mod {}", BITPRIME64),
+            format!("4  1 0 0 1 mod {}", LARGE_PRIME),
             entry_zq.modulus.to_string()
         );
     }
@@ -205,7 +205,7 @@ mod test_setter {
     #[test]
     fn big_negative() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat = MatPolyOverZ::from_str(&format!(
             "[[2  1 1, 1  42],[0, 2  {} 2],[1  2, 0]]",
             i64::MAX
@@ -222,7 +222,7 @@ mod test_setter {
         assert_eq!(format!("3  1 {} 1", i64::MIN), entry_z.to_string());
         assert_eq!(format!("3  1 {} 1", i64::MIN), entry_zq.poly.to_string());
         assert_eq!(
-            format!("4  1 0 0 1 mod {}", BITPRIME64),
+            format!("4  1 0 0 1 mod {}", LARGE_PRIME),
             entry_zq.modulus.to_string()
         );
     }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/transpose.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/transpose.rs
@@ -43,7 +43,7 @@ mod test_transpose {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Checks if a row is correctly converted to a column
     #[test]
@@ -71,13 +71,13 @@ mod test_transpose {
     #[test]
     fn different_entry_values() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
         let poly_mat = MatPolyOverZ::from_str(&format!("[[1  {},1  -42,1  0]]", i64::MAX)).unwrap();
         let poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
         let cmp = MatPolyOverZ::from_str(&format!(
             "[[1  {}],[1  {}],[1  0]]",
             i64::MAX,
-            BITPRIME64 - 42
+            LARGE_PRIME - 42
         ))
         .unwrap();
 

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector/is_vector.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector/is_vector.rs
@@ -116,7 +116,7 @@ mod test_is_vector {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Check whether matrices with one row or one column
     /// get recognized as (row or column) vectors
@@ -125,7 +125,7 @@ mod test_is_vector {
         let modulus = ModulusPolynomialRingZq::from_str(&format!(
             "5  1 1 0 0 {} mod {}",
             i64::MAX,
-            BITPRIME64
+            LARGE_PRIME
         ))
         .unwrap();
         let poly_mat1 =
@@ -156,7 +156,7 @@ mod test_is_vector {
         let modulus = ModulusPolynomialRingZq::from_str(&format!(
             "5  1 1 0 0 {} mod {}",
             i64::MAX,
-            BITPRIME64
+            LARGE_PRIME
         ))
         .unwrap();
         let poly_mat1 = MatPolyOverZ::from_str(&format!(
@@ -188,7 +188,7 @@ mod test_is_vector {
         let modulus = ModulusPolynomialRingZq::from_str(&format!(
             "5  1 1 0 0 {} mod {}",
             i64::MAX,
-            BITPRIME64
+            LARGE_PRIME
         ))
         .unwrap();
         let poly_mat1 = MatPolyOverZ::from_str("[[1  42]]").unwrap();
@@ -218,7 +218,7 @@ mod test_is_vector {
         let modulus = ModulusPolynomialRingZq::from_str(&format!(
             "5  1 1 0 0 {} mod {}",
             i64::MAX,
-            BITPRIME64
+            LARGE_PRIME
         ))
         .unwrap();
         let poly_mat1 =

--- a/src/integer_mod_q/mat_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/add.rs
@@ -42,8 +42,8 @@ impl Add for &MatZq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the dimensions of both matrices mismatch
-    /// - ... if the moduli mismatch
+    /// - if the dimensions of both matrices mismatch.
+    /// - if the moduli mismatch.
     fn add(self, other: Self) -> Self::Output {
         self.add_safe(other).unwrap()
     }

--- a/src/integer_mod_q/mat_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/mul.rs
@@ -46,9 +46,9 @@ impl Mul for &MatZq {
     /// let f = c * &e;
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Panics if the dimensions of `self` and `other` do not match for multiplication.
-    /// - Panics if the moduli mismatch
+    /// # Panics ...
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
+    /// - if the moduli mismatch.
     fn mul(self, other: Self) -> Self::Output {
         self.mul_safe(other).unwrap()
     }
@@ -84,8 +84,8 @@ impl Mul<&MatZ> for &MatZq {
     /// let f = c * &e;
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Panics if the dimensions of `self` and `other` do not match for multiplication.
+    /// # Panics ...
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
     fn mul(self, other: &MatZ) -> Self::Output {
         if self.get_num_columns() != other.get_num_rows() {
             panic!("Tried to multiply matrices with mismatching matrix dimensions.");

--- a/src/integer_mod_q/mat_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/mul_scalar.rs
@@ -74,7 +74,7 @@ impl Mul<&Zq> for &MatZq {
     /// use std::str::FromStr;
     ///
     /// let mat1 = MatZq::from_str("[[42, 17],[8, 6]] mod 61").unwrap();
-    /// let integer = Zq::try_from((2, 61)).unwrap();
+    /// let integer = Zq::from((2, 61));
     ///
     /// let mat2 = &mat1 * &integer;
     /// ```
@@ -107,7 +107,7 @@ impl MatZq {
     /// use std::str::FromStr;
     ///
     /// let mat1 = MatZq::from_str("[[42, 17],[8, 6]] mod 61").unwrap();
-    /// let integer = Zq::try_from((2, 61)).unwrap();
+    /// let integer = Zq::from((2, 61));
     ///
     /// let mat2 = &mat1.mul_scalar_safe(&integer).unwrap();
     /// ```
@@ -255,7 +255,7 @@ mod test_mul_zq {
         let mat1 = MatZq::from_str("[[42, 17],[8, 6]] mod 61").unwrap();
         let mat2 = mat1.clone();
         let mat3 = MatZq::from_str("[[84, 34],[16, 12]] mod 61").unwrap();
-        let integer = Zq::try_from((2, 61)).unwrap();
+        let integer = Zq::from((2, 61));
 
         let mat1 = &mat1 * &integer;
         let mat2 = &integer * &mat2;
@@ -270,8 +270,8 @@ mod test_mul_zq {
         let mat1 = MatZq::from_str("[[42, 17],[8, 6]] mod 61").unwrap();
         let mat2 = mat1.clone();
         let mat3 = MatZq::from_str("[[84, 34],[16, 12]] mod 61").unwrap();
-        let integer1 = Zq::try_from((2, 61)).unwrap();
-        let integer2 = Zq::try_from((2, 61)).unwrap();
+        let integer1 = Zq::from((2, 61));
+        let integer2 = Zq::from((2, 61));
 
         let mat1 = mat1 * integer1;
         let mat2 = integer2 * mat2;
@@ -288,8 +288,8 @@ mod test_mul_zq {
         let mat3 = mat1.clone();
         let mat4 = mat1.clone();
         let mat5 = MatZq::from_str("[[84, 34],[16, 12]] mod 61").unwrap();
-        let integer1 = Zq::try_from((2, 61)).unwrap();
-        let integer2 = Zq::try_from((2, 61)).unwrap();
+        let integer1 = Zq::from((2, 61));
+        let integer2 = Zq::from((2, 61));
 
         let mat1 = mat1 * &integer1;
         let mat2 = &integer2 * mat2;
@@ -309,7 +309,7 @@ mod test_mul_zq {
         let mat2 = MatZq::from_str("[[2, 6, 5],[4, 42, 3]] mod 61").unwrap();
         let mat3 = MatZq::from_str("[[84],[0],[4]] mod 61").unwrap();
         let mat4 = MatZq::from_str("[[4, 12, 10],[8, 84, 6]] mod 61").unwrap();
-        let integer = Zq::try_from((2, 61)).unwrap();
+        let integer = Zq::from((2, 61));
 
         assert_eq!(mat3, &integer * mat1);
         assert_eq!(mat4, integer * mat2);
@@ -323,8 +323,8 @@ mod test_mul_zq {
         let mat3 =
             MatZq::from_str(&format!("[[3],[{}],[12]] mod {}", i64::MAX - 1, u64::MAX)).unwrap();
         let mat4 = MatZq::from_str(&format!("[[{}]] mod {}", i64::MAX - 1, u64::MAX)).unwrap();
-        let integer1 = Zq::try_from((3, u64::MAX)).unwrap();
-        let integer2 = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
+        let integer1 = Zq::from((3, u64::MAX));
+        let integer2 = Zq::from((i64::MAX, u64::MAX));
 
         assert_eq!(mat3, integer1 * mat1);
         assert_eq!(mat4, integer2 * mat2);
@@ -335,7 +335,7 @@ mod test_mul_zq {
     #[should_panic]
     fn different_moduli_error() {
         let mat1 = MatZq::from_str("[[42],[0],[2]] mod 61").unwrap();
-        let integer = Zq::try_from((2, 3)).unwrap();
+        let integer = Zq::from((2, 3));
 
         _ = &integer * mat1;
     }
@@ -344,7 +344,7 @@ mod test_mul_zq {
     #[test]
     fn different_moduli_error_safe() {
         let mat1 = MatZq::from_str("[[42],[0],[2]] mod 61").unwrap();
-        let integer = Zq::try_from((2, 3)).unwrap();
+        let integer = Zq::from((2, 3));
 
         let mat2 = &mat1.mul_scalar_safe(&integer);
 

--- a/src/integer_mod_q/mat_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/sub.rs
@@ -41,9 +41,9 @@ impl Sub for &MatZq {
     /// let f: MatZq = c - &e;
     /// ```
     ///
-    /// # Panics
-    /// - ... if the dimensions of both matrices mismatch
-    /// - ... if the moduli mismatch
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
+    /// - if the moduli mismatch.
     fn sub(self, other: Self) -> Self::Output {
         self.sub_safe(other).unwrap()
     }

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -298,7 +298,6 @@ mod test_get_entry {
         integer_mod_q::MatZq,
         traits::{GetEntry, SetEntry},
     };
-    
 
     /// Ensure that getting entries works on the edge.
     #[test]
@@ -460,14 +459,14 @@ mod test_get_num {
 #[cfg(test)]
 mod test_mod {
     use crate::integer_mod_q::{MatZq, Modulus};
-    use std::str::FromStr;
+    
 
     /// Ensure that the getter for modulus works correctly.
     #[test]
     fn get_mod() {
         let matrix = MatZq::new(5, 10, 7);
 
-        assert_eq!(matrix.get_mod(), Modulus::from_str("7").unwrap());
+        assert_eq!(matrix.get_mod(), Modulus::from(7));
     }
 
     /// Ensure that the getter for modulus works with large numbers.

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -137,9 +137,9 @@ impl GetEntry<Zq> for MatZq {
         row: impl TryInto<i64> + Display,
         column: impl TryInto<i64> + Display,
     ) -> Result<Zq, MathError> {
-        let value = self.get_entry(row, column)?;
+        let value: Z = self.get_entry(row, column)?;
 
-        Ok(Zq::from_z_modulus(&value, &self.modulus))
+        Ok(Zq::from((value, &self.modulus)))
     }
 }
 

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -298,7 +298,7 @@ mod test_get_entry {
         integer_mod_q::MatZq,
         traits::{GetEntry, SetEntry},
     };
-    use std::str::FromStr;
+    
 
     /// Ensure that getting entries works on the edge.
     #[test]
@@ -387,7 +387,7 @@ mod test_get_entry {
     #[test]
     fn memory_test() {
         let mut matrix = MatZq::new(5, 10, u64::MAX);
-        let value = Zq::from_str(&format!("{} mod {}", u64::MAX - 1, u64::MAX)).unwrap();
+        let value = Zq::from((u64::MAX - 1, u64::MAX));
         matrix.set_entry(1, 1, value).unwrap();
         let entry = matrix.get_entry(1, 1).unwrap();
         matrix.set_entry(1, 1, Z::ONE).unwrap();

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -459,7 +459,6 @@ mod test_get_num {
 #[cfg(test)]
 mod test_mod {
     use crate::integer_mod_q::{MatZq, Modulus};
-    
 
     /// Ensure that the getter for modulus works correctly.
     #[test]

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -165,7 +165,7 @@ mod test_sample_discrete_gauss {
     #[test]
     fn availability() {
         let n = Z::from(1024);
-        let center = Q::from(0);
+        let center = Q::ZERO;
         let s = Q::ONE;
         let modulus = Modulus::from(83);
 

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -167,7 +167,7 @@ mod test_sample_discrete_gauss {
         let n = Z::from(1024);
         let center = Q::from(0);
         let s = Q::ONE;
-        let modulus = Modulus::try_from(&Z::from(83)).unwrap();
+        let modulus = Modulus::from(83);
 
         let _ = MatZq::sample_discrete_gauss(2u64, 3i8, &modulus, 16u16, 0f32, 1u16);
         let _ = MatZq::sample_discrete_gauss(3u8, 2i16, 83u8, 2u32, &center, 1u8);

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -193,7 +193,6 @@ mod test_sample_d {
         integer_mod_q::{MatZq, Modulus},
         rational::{MatQ, Q},
     };
-    
 
     // Appropriate inputs were tested in utils and thus omitted here.
     // This function only allows for a broader availability, which is tested here.

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -193,7 +193,7 @@ mod test_sample_d {
         integer_mod_q::{MatZq, Modulus},
         rational::{MatQ, Q},
     };
-    use std::str::FromStr;
+    
 
     // Appropriate inputs were tested in utils and thus omitted here.
     // This function only allows for a broader availability, which is tested here.
@@ -229,7 +229,7 @@ mod test_sample_d {
     /// Ensures that `sample_d_common` works properly.
     #[test]
     fn common() {
-        let modulus = Modulus::from_str("17").unwrap();
+        let modulus = Modulus::from(17);
 
         let _ = MatZq::sample_d_common(10, &modulus, 1024, 1.25f32).unwrap();
     }

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -69,7 +69,7 @@ mod test_sample_uniform {
         integer::Z,
         integer_mod_q::{MatZq, Modulus},
     };
-    use std::str::FromStr;
+    
 
     /// Checks whether the boundaries of the interval are kept for small moduli.
     #[test]
@@ -115,7 +115,7 @@ mod test_sample_uniform {
     /// implementing Into<Z> + Clone, i.e. u8, u16, u32, u64, i8, ...
     #[test]
     fn availability() {
-        let modulus = Modulus::from_str("7").unwrap();
+        let modulus = Modulus::from(7);
         let z = Z::from(7);
 
         let _ = MatZq::sample_uniform(1, 1, &7u8);

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -69,7 +69,6 @@ mod test_sample_uniform {
         integer::Z,
         integer_mod_q::{MatZq, Modulus},
     };
-    
 
     /// Checks whether the boundaries of the interval are kept for small moduli.
     #[test]

--- a/src/integer_mod_q/mat_zq/set.rs
+++ b/src/integer_mod_q/mat_zq/set.rs
@@ -65,7 +65,7 @@ impl SetEntry<&Z> for MatZq {
         value: &Z,
     ) -> Result<(), MathError> {
         // Calculate mod q before adding the entry to the matrix.
-        let value: Zq = Zq::from_z_modulus(value, &self.modulus);
+        let value: Zq = Zq::from((value, &self.modulus));
 
         self.set_entry(row, column, value)
     }

--- a/src/integer_mod_q/mat_zq/set.rs
+++ b/src/integer_mod_q/mat_zq/set.rs
@@ -92,7 +92,7 @@ impl SetEntry<&Zq> for MatZq {
     /// use std::str::FromStr;
     ///
     /// let mut matrix = MatZq::new(5, 10, 7);
-    /// let value = Zq::from_str("5 mod 7").unwrap();
+    /// let value = Zq::from((5, 7));
     /// matrix.set_entry(1, 1, &value).unwrap();
     /// ```
     ///
@@ -509,14 +509,10 @@ mod test_setter {
         let mut matrix = MatZq::new(5, 10, 56);
 
         matrix.set_entry(0, 0, Z::default()).unwrap();
-        matrix
-            .set_entry(0, 0, Zq::from_str("12 mod 56").unwrap())
-            .unwrap();
+        matrix.set_entry(0, 0, Zq::from((12, 56))).unwrap();
         matrix.set_entry(0, 0, 3).unwrap();
         matrix.set_entry(0, 0, &Z::default()).unwrap();
-        matrix
-            .set_entry(0, 0, &Zq::from_str("12 mod 56").unwrap())
-            .unwrap();
+        matrix.set_entry(0, 0, &Zq::from((12, 56))).unwrap();
     }
 
     /// Ensure that value is correctly reduced.
@@ -534,9 +530,7 @@ mod test_setter {
     #[test]
     fn modulus_error() {
         let mut matrix = MatZq::new(5, 10, 3);
-        assert!(matrix
-            .set_entry(1, 1, Zq::from_str("2 mod 5").unwrap())
-            .is_err());
+        assert!(matrix.set_entry(1, 1, Zq::from((2, 5))).is_err());
     }
 
     /// Ensures that setting columns works fine for small entries

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -41,10 +41,10 @@ impl MatZq {
     /// assert_eq!(y, mat*x);
     /// ```
     ///
-    /// Panics ...
-    /// - ... if the the number of rows of the matrix and the syndrome are different
-    /// - ... if the syndrome is not a column vector
-    /// - ... if the moduli mismatch
+    /// # Panics ...
+    /// - if the the number of rows of the matrix and the syndrome are different.
+    /// - if the syndrome is not a column vector.
+    /// - if the moduli mismatch.
     pub fn solve_gaussian_elimination(&self, y: &MatZq) -> Option<MatZq> {
         assert!(y.is_column_vector(), "The syndrome is not a column vector.");
         assert_eq!(

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -137,17 +137,11 @@ mod test_solve {
     /// column that is not invertible
     #[test]
     fn large_matrix() {
+        let modulus = Modulus::from(Z::from(2).pow(50).unwrap());
+
         // matrix of size `n x 2n\log q`, hence almost always invertible
-        let mat = MatZq::sample_uniform(
-            10,
-            10 * 2 * 50,
-            &Modulus::try_from(&Z::from(2).pow(50).unwrap()).unwrap(),
-        );
-        let y = MatZq::sample_uniform(
-            10,
-            1,
-            &Modulus::try_from(&Z::from(2).pow(50).unwrap()).unwrap(),
-        );
+        let mat = MatZq::sample_uniform(10, 10 * 2 * 50, &modulus);
+        let y = MatZq::sample_uniform(10, 1, &modulus);
 
         let x = mat.solve_gaussian_elimination(&y).unwrap();
 

--- a/src/integer_mod_q/mat_zq/tensor.rs
+++ b/src/integer_mod_q/mat_zq/tensor.rs
@@ -43,7 +43,7 @@ impl Tensor for MatZq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the moduli of both matrices mismatch.
+    /// - if the moduli of both matrices mismatch.
     /// Use [`tensor_product_safe`](crate::integer_mod_q::MatZq::tensor_product_safe) to get an error instead.
     fn tensor_product(&self, other: &Self) -> Self {
         self.tensor_product_safe(other).unwrap()

--- a/src/integer_mod_q/mat_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_zq/vector/dot_product.rs
@@ -40,7 +40,7 @@ impl MatZq {
     /// let dot_prod = vec_1.dot_product(&vec_2).unwrap();
     ///
     /// // 1*1 + 2*3 + 3*2 = 3 mod 5
-    /// assert_eq!(Zq::from_str("3 mod 5").unwrap(), dot_prod);
+    /// assert_eq!(Zq::from((3, 5)), dot_prod);
     /// ```
     ///
     /// Errors and Failures
@@ -108,7 +108,7 @@ mod test_dot_product {
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 
-        assert_eq!(dot_prod, Zq::from_str("1 mod 5").unwrap());
+        assert_eq!(dot_prod, Zq::from((1, 5)));
     }
 
     /// Check whether the dot product is calculated correctly for the combination:
@@ -120,7 +120,7 @@ mod test_dot_product {
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 
-        assert_eq!(dot_prod, Zq::from_str("1 mod 5").unwrap());
+        assert_eq!(dot_prod, Zq::from((1, 5)));
     }
 
     /// Check whether the dot product is calculated correctly for the combination:
@@ -132,7 +132,7 @@ mod test_dot_product {
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 
-        assert_eq!(dot_prod, Zq::from_str("1 mod 5").unwrap());
+        assert_eq!(dot_prod, Zq::from((1, 5)));
     }
 
     /// Check whether the dot product is calculated correctly for the combination:
@@ -144,7 +144,7 @@ mod test_dot_product {
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 
-        assert_eq!(dot_prod, Zq::from_str("1 mod 5").unwrap());
+        assert_eq!(dot_prod, Zq::from((1, 5)));
     }
 
     /// Check whether the dot product is calculated correctly with large numbers

--- a/src/integer_mod_q/mat_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_zq/vector/dot_product.rs
@@ -90,7 +90,7 @@ impl MatZq {
             unsafe { fmpz_addmul(&mut result.value, &self_entries[i], &other_entries[i]) }
         }
 
-        Ok(Zq::from_z_modulus(&result, &self.modulus))
+        Ok(Zq::from((result, &self.modulus)))
     }
 }
 

--- a/src/integer_mod_q/modulus.rs
+++ b/src/integer_mod_q/modulus.rs
@@ -41,6 +41,7 @@ mod to_string;
 /// let value = Z::from(10);
 ///
 /// // instantiations
+/// let _ = Modulus::from(10);
 /// let a = Modulus::from_str("42").unwrap();
 /// let b: Modulus = (&value).try_into().unwrap();
 ///

--- a/src/integer_mod_q/modulus/cmp.rs
+++ b/src/integer_mod_q/modulus/cmp.rs
@@ -26,9 +26,9 @@ impl PartialEq for Modulus {
     /// use qfall_math::integer_mod_q::Modulus;
     /// use std::str::FromStr;
     ///
-    /// let a = Modulus::from_str("3").unwrap();
-    /// let b = Modulus::from_str("3").unwrap();
-    /// let c = Modulus::from_str("4").unwrap();
+    /// let a = Modulus::from(3);
+    /// let b = Modulus::from(3);
+    /// let c = Modulus::from(4);
     ///
     /// assert_eq!(a, b);
     /// assert_ne!(a, c);
@@ -68,7 +68,7 @@ mod test_eq {
     /// Checks whether two equal, small Moduli created with different constructors are equal
     #[test]
     fn equal_small() {
-        let a = Modulus::from_str("2").unwrap();
+        let a = Modulus::from(2);
         let b = Modulus::from(&Z::from(2));
         let b_clone = b.clone();
 
@@ -80,8 +80,8 @@ mod test_eq {
     /// Checks whether unequal Moduli are unequal
     #[test]
     fn unequal() {
-        let one = Modulus::from_str("3").unwrap();
-        let two = Modulus::from_str("2").unwrap();
+        let one = Modulus::from(3);
+        let two = Modulus::from(2);
         let big = Modulus::from_str(&"1".repeat(65)).unwrap();
 
         assert_ne!(one, two);

--- a/src/integer_mod_q/modulus/from.rs
+++ b/src/integer_mod_q/modulus/from.rs
@@ -92,8 +92,8 @@ impl<Integer: AsInteger + IntoModulus> From<Integer> for Modulus {
     /// let _ = Modulus::from(Z::from(42));
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Panics if the provided value is not greater than `1`.
+    /// # Panics ...
+    /// - if the provided value is not greater than `1`.
     fn from(value: Integer) -> Self {
         match value.get_fmpz_ref() {
             Some(val) => Modulus::from_fmpz_ref(val).unwrap(),

--- a/src/integer_mod_q/modulus/ownership.rs
+++ b/src/integer_mod_q/modulus/ownership.rs
@@ -24,7 +24,7 @@ impl Clone for Modulus {
     /// use qfall_math::integer_mod_q::Modulus;
     /// use std::str::FromStr;
     ///
-    /// let a = Modulus::from_str("3").unwrap();
+    /// let a = Modulus::from(3);
     /// let b = a.clone();
     /// ```
     fn clone(&self) -> Self {
@@ -43,7 +43,7 @@ impl Drop for Modulus {
     /// use qfall_math::integer_mod_q::Modulus;
     /// use std::str::FromStr;
     /// {
-    ///     let a = Modulus::from_str("3").unwrap();
+    ///     let a = Modulus::from(3);
     /// } // as a's scope ends here, it get's dropped
     /// ```
     ///
@@ -51,7 +51,7 @@ impl Drop for Modulus {
     /// use qfall_math::integer_mod_q::Modulus;
     /// use std::str::FromStr;
     ///
-    /// let a = Modulus::from_str("3").unwrap();
+    /// let a = Modulus::from(3);
     /// drop(a); // explicitly drops a's value
     /// ```
     fn drop(&mut self) {
@@ -73,7 +73,7 @@ mod test_clone {
     /// Check if new references/ cloned Moduli's increase the Rc counter
     #[test]
     fn references_increased() {
-        let a = Modulus::from_str("3").unwrap();
+        let a = Modulus::from(3);
         assert_eq!(Rc::strong_count(&a.modulus), 1);
 
         let b = a.clone();
@@ -110,7 +110,7 @@ mod test_drop {
     /// Check whether references are decreased when dropping instances
     #[test]
     fn references_decreased() {
-        let a = Modulus::from_str("3").unwrap();
+        let a = Modulus::from(3);
         assert_eq!(Rc::strong_count(&a.modulus), 1);
 
         {

--- a/src/integer_mod_q/modulus/properties.rs
+++ b/src/integer_mod_q/modulus/properties.rs
@@ -32,7 +32,6 @@ impl Modulus {
 #[cfg(test)]
 mod test_is_prime {
     use crate::integer_mod_q::Modulus;
-    
 
     /// Ensure that if a [`Modulus`] is instantiated with a prime, `true` is returned
     #[test]

--- a/src/integer_mod_q/modulus/properties.rs
+++ b/src/integer_mod_q/modulus/properties.rs
@@ -21,7 +21,7 @@ impl Modulus {
     /// use std::str::FromStr;
     /// use qfall_math::integer_mod_q::Modulus;
     ///
-    /// let modulus = Modulus::from_str("17").unwrap();
+    /// let modulus = Modulus::from(17);
     /// assert!(modulus.is_prime())
     /// ```
     pub fn is_prime(&self) -> bool {
@@ -32,19 +32,19 @@ impl Modulus {
 #[cfg(test)]
 mod test_is_prime {
     use crate::integer_mod_q::Modulus;
-    use std::str::FromStr;
+    
 
     /// Ensure that if a [`Modulus`] is instantiated with a prime, `true` is returned
     #[test]
     fn modulus_is_prime() {
-        let modulus = Modulus::from_str(&format!("{}", 2_i32.pow(16) + 1)).unwrap();
+        let modulus = Modulus::from(2_i32.pow(16) + 1);
         assert!(modulus.is_prime())
     }
 
     /// Ensure that if a [`Modulus`] is instantiated with a non-prime, `false` is returned
     #[test]
     fn modulus_is_not_prime() {
-        let modulus = Modulus::from_str(&format!("{}", 2_i32.pow(16))).unwrap();
+        let modulus = Modulus::from(2_i32.pow(16));
         assert!(!modulus.is_prime())
     }
 }

--- a/src/integer_mod_q/modulus/serialize.rs
+++ b/src/integer_mod_q/modulus/serialize.rs
@@ -26,13 +26,13 @@ deserialize!("modulus", Modulus, Modulus);
 
 #[cfg(test)]
 mod test_serialize {
-    use crate::{integer::Z, integer_mod_q::Modulus};
+    use crate::integer_mod_q::Modulus;
     use std::str::FromStr;
 
     /// Tests whether the serialization of a positive [`Modulus`] works.
     #[test]
     fn serialize_output_positive() {
-        let z = Modulus::try_from(&Z::from(17)).unwrap();
+        let z = Modulus::from(17);
         let cmp_string = "{\"modulus\":\"17\"}";
 
         assert_eq!(cmp_string, serde_json::to_string(&z).unwrap())
@@ -51,17 +51,14 @@ mod test_serialize {
 
 #[cfg(test)]
 mod test_deserialize {
-    use crate::{integer::Z, integer_mod_q::Modulus};
+    use crate::integer_mod_q::Modulus;
     use std::str::FromStr;
 
     /// Tests whether the deserialization of a positive [`Modulus`] works.
     #[test]
     fn deserialize_positive() {
         let z_string = "{\"modulus\":\"17\"}";
-        assert_eq!(
-            Modulus::try_from(&Z::from(17)).unwrap(),
-            serde_json::from_str(z_string).unwrap()
-        )
+        assert_eq!(Modulus::from(17), serde_json::from_str(z_string).unwrap())
     }
 
     /// Tests whether the deserialization of a negative [`Modulus`] fails.

--- a/src/integer_mod_q/modulus/to_string.rs
+++ b/src/integer_mod_q/modulus/to_string.rs
@@ -25,7 +25,7 @@ impl fmt::Display for Modulus {
     /// use std::str::FromStr;
     /// use core::fmt;
     ///
-    /// let modulus = Modulus::from_str("42").unwrap();
+    /// let modulus = Modulus::from(42);
     /// println!("{}", modulus);
     /// ```
     ///
@@ -33,7 +33,7 @@ impl fmt::Display for Modulus {
     /// use qfall_math::integer_mod_q::Modulus;
     /// use std::str::FromStr;
     ///
-    /// let modulus = Modulus::from_str("42").unwrap();
+    /// let modulus = Modulus::from(42);
     /// let modulus_string = modulus.to_string();
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
@@ -76,7 +76,7 @@ mod test_partial_eq {
     use super::ModulusPolynomialRingZq;
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Demonstrate the different ways to use equal.
     /// We assume that they behave the same in the other tests.
@@ -140,8 +140,8 @@ mod test_partial_eq {
     /// (uses FLINT's pointer representation)
     #[test]
     fn equal_large() {
-        let max_str = format!("1  {} mod {}", u64::MAX, BITPRIME64);
-        let min_str = format!("1  {} mod {}", i64::MIN, BITPRIME64);
+        let max_str = format!("1  {} mod {}", u64::MAX, LARGE_PRIME);
+        let min_str = format!("1  {} mod {}", i64::MIN, LARGE_PRIME);
 
         let max_1 = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let max_2 = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
@@ -159,8 +159,8 @@ mod test_partial_eq {
     /// (uses FLINT's pointer representation)
     #[test]
     fn not_equal_large() {
-        let max_str = format!("1  {} mod {}", u64::MAX, BITPRIME64);
-        let min_str = format!("1  {} mod {}", i64::MIN, BITPRIME64);
+        let max_str = format!("1  {} mod {}", u64::MAX, LARGE_PRIME);
+        let min_str = format!("1  {} mod {}", i64::MIN, LARGE_PRIME);
 
         let max_1 = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let max_2 = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
@@ -178,8 +178,8 @@ mod test_partial_eq {
     /// and small polynomial with a small [`ModulusPolynomialRingZq`] (no pointer representation).
     #[test]
     fn equal_large_small() {
-        let max_str = format!("1  {} mod {}", u64::MAX, BITPRIME64);
-        let min_str = format!("1  {} mod {}", i64::MIN, BITPRIME64);
+        let max_str = format!("1  {} mod {}", u64::MAX, LARGE_PRIME);
+        let min_str = format!("1  {} mod {}", i64::MIN, LARGE_PRIME);
 
         let max = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let min = ModulusPolynomialRingZq::from_str(&min_str).unwrap();
@@ -202,8 +202,8 @@ mod test_partial_eq {
     /// and small [`ModulusPolynomialRingZq`] (no pointer representation).
     #[test]
     fn not_equal_large_small() {
-        let max_str = format!("1  {} mod {}", u64::MAX, BITPRIME64);
-        let min_str = format!("1  {} mod {}", i64::MIN, BITPRIME64);
+        let max_str = format!("1  {} mod {}", u64::MAX, LARGE_PRIME);
+        let min_str = format!("1  {} mod {}", i64::MIN, LARGE_PRIME);
 
         let max = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let min = ModulusPolynomialRingZq::from_str(&min_str).unwrap();

--- a/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
@@ -42,8 +42,8 @@ impl Add for &PolyOverZq {
     /// let f: PolyOverZq = c + &e;
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Panics if the moduli of both [`PolyOverZq`] mismatch.
+    /// # Panics ...
+    /// - if the moduli of both [`PolyOverZq`] mismatch.
     fn add(self, other: Self) -> Self::Output {
         self.add_safe(other).unwrap()
     }

--- a/src/integer_mod_q/poly_over_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/mul.rs
@@ -43,7 +43,7 @@ impl Mul for &PolyOverZq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the moduli of both [`PolyOverZq`] mismatch.
+    /// - if the moduli of both [`PolyOverZq`] mismatch.
     fn mul(self, other: Self) -> Self::Output {
         self.mul_safe(other).unwrap()
     }

--- a/src/integer_mod_q/poly_over_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/sub.rs
@@ -42,8 +42,8 @@ impl Sub for &PolyOverZq {
     /// let f: PolyOverZq = c - &e;
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Panics if the moduli of both [`PolyOverZq`] mismatch.
+    /// # Panics ...
+    /// - if the moduli of both [`PolyOverZq`] mismatch.
     fn sub(self, other: Self) -> Self::Output {
         self.sub_safe(other).unwrap()
     }

--- a/src/integer_mod_q/poly_over_zq/evaluate.rs
+++ b/src/integer_mod_q/poly_over_zq/evaluate.rs
@@ -80,7 +80,7 @@ impl Evaluate<&Zq, Zq> for PolyOverZq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the moduli of the polynomial and the input mismatch.
+    /// - if the moduli of the polynomial and the input mismatch.
     fn evaluate(&self, value: &Zq) -> Zq {
         self.evaluate_safe(value)
             .expect("The moduli of the provided inputs mismatch")

--- a/src/integer_mod_q/poly_over_zq/evaluate.rs
+++ b/src/integer_mod_q/poly_over_zq/evaluate.rs
@@ -141,7 +141,7 @@ mod test_evaluate_z {
 
         let res = poly.evaluate(Z::from(3));
 
-        assert_eq!(Zq::try_from((7, 17)).unwrap(), res)
+        assert_eq!(Zq::from((7, 17)), res)
     }
 
     /// Tests if evaluate with a reference works
@@ -151,7 +151,7 @@ mod test_evaluate_z {
 
         let res = poly.evaluate(&Z::from(3));
 
-        assert_eq!(Zq::try_from((7, 17)).unwrap(), res)
+        assert_eq!(Zq::from((7, 17)), res)
     }
 
     /// Tests if evaluate works with negative values
@@ -161,7 +161,7 @@ mod test_evaluate_z {
 
         let res = poly.evaluate(&Z::from(-5));
 
-        assert_eq!(Zq::try_from((8, 17)).unwrap(), res)
+        assert_eq!(Zq::from((8, 17)), res)
     }
 
     /// Tests if evaluate works with large integers

--- a/src/integer_mod_q/poly_over_zq/evaluate.rs
+++ b/src/integer_mod_q/poly_over_zq/evaluate.rs
@@ -41,7 +41,7 @@ impl Evaluate<&Z, Zq> for PolyOverZq {
     /// let res = poly.evaluate(&value);
     /// ```
     fn evaluate(&self, value: &Z) -> Zq {
-        let mut res = Zq::from_z_modulus(&Z::default(), &self.modulus);
+        let mut res = Zq::from((0, &self.modulus));
 
         unsafe {
             fmpz_mod_poly_evaluate_fmpz(

--- a/src/integer_mod_q/poly_over_zq/evaluate.rs
+++ b/src/integer_mod_q/poly_over_zq/evaluate.rs
@@ -75,7 +75,7 @@ impl Evaluate<&Zq, Zq> for PolyOverZq {
     /// use std::str::FromStr;
     ///
     /// let poly = PolyOverZq::from_str("5  0 1 2 -3 1 mod 17").unwrap();
-    /// let value = Zq::from_str("3 mod 17").unwrap();
+    /// let value = Zq::from((3, 17));
     /// let res = poly.evaluate(&value);
     /// ```
     ///
@@ -105,7 +105,7 @@ impl PolyOverZq {
     /// use std::str::FromStr;
     ///
     /// let poly = PolyOverZq::from_str("5  0 1 2 -3 1 mod 17").unwrap();
-    /// let value = Zq::from_str("3 mod 17").unwrap();
+    /// let value = Zq::from((3, 17));
     /// let res = poly.evaluate(&value);
     /// ```
     ///
@@ -171,7 +171,7 @@ mod test_evaluate_z {
 
         let res = poly.evaluate(&Z::from(u64::MAX - 1));
 
-        assert_eq!(Zq::from_str(&format!("1 mod {}", u64::MAX)).unwrap(), res)
+        assert_eq!(Zq::from((1, u64::MAX)), res)
     }
 
     /// Test if evaluate works with max of [`i64`], [`i32`], ...
@@ -223,12 +223,12 @@ mod test_evaluate_zq {
     #[test]
     fn evaluate_positive() {
         let poly = PolyOverZq::from_str("2  1 3 mod 17").unwrap();
-        let value = Zq::from_str("6 mod 17").unwrap();
+        let value = Zq::from((6, 17));
 
         let res_ref = poly.evaluate(&value);
         let res = poly.evaluate(value);
 
-        assert_eq!(Zq::from_str("2 mod 17").unwrap(), res);
+        assert_eq!(Zq::from((2, 17)), res);
         assert_eq!(res_ref, res);
     }
 
@@ -238,12 +238,12 @@ mod test_evaluate_zq {
         let poly =
             PolyOverZq::from_str(&format!("2  {} 1 mod {}", (u64::MAX - 1) / 2 + 2, u64::MAX))
                 .unwrap();
-        let value = Zq::from_str(&format!("{} mod {}", (u64::MAX - 1) / 2, u64::MAX)).unwrap();
+        let value = Zq::from(((u64::MAX - 1) / 2, u64::MAX));
 
         let res_ref = poly.evaluate(&value);
         let res = poly.evaluate(value);
 
-        assert_eq!(Zq::from_str(&format!("1 mod {}", u64::MAX)).unwrap(), res);
+        assert_eq!(Zq::from((1, u64::MAX)), res);
         assert_eq!(res_ref, res);
     }
 
@@ -252,7 +252,7 @@ mod test_evaluate_zq {
     #[should_panic]
     fn mismatching_modulus_panic() {
         let poly = PolyOverZq::from_str(&format!("2  3 1 mod {}", u64::MAX)).unwrap();
-        let value = Zq::from_str(&format!("3 mod {}", u64::MAX - 1)).unwrap();
+        let value = Zq::from((3, u64::MAX - 1));
 
         let _ = poly.evaluate(&value);
     }
@@ -261,7 +261,7 @@ mod test_evaluate_zq {
     #[test]
     fn mismatching_modulus_safe() {
         let poly = PolyOverZq::from_str(&format!("2  3 1 mod {}", u64::MAX)).unwrap();
-        let value = Zq::from_str(&format!("3 mod {}", u64::MAX - 1)).unwrap();
+        let value = Zq::from((3, u64::MAX - 1));
 
         assert!(poly.evaluate_safe(&value).is_err());
     }

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -105,7 +105,7 @@ impl From<&ModulusPolynomialRingZq> for PolyOverZq {
     /// assert_eq!(cmp_poly, poly_zq);
     /// ```
     fn from(modulus: &ModulusPolynomialRingZq) -> Self {
-        let modulus_q = Modulus::try_from(&modulus.get_q()).unwrap();
+        let modulus_q = Modulus::from(&modulus.get_q());
         let mut out = PolyOverZq::from(&modulus_q);
         unsafe {
             fmpz_mod_poly_set(
@@ -175,10 +175,7 @@ impl FromStr for PolyOverZq {
 #[cfg(test)]
 mod test_from_poly_z_modulus {
     use super::PolyOverZq;
-    use crate::{
-        integer::{PolyOverZ, Z},
-        integer_mod_q::Modulus,
-    };
+    use crate::{integer::PolyOverZ, integer_mod_q::Modulus};
     use std::str::FromStr;
 
     /// Test conversion of a [`PolyOverZ`] with small coefficients and small
@@ -186,7 +183,7 @@ mod test_from_poly_z_modulus {
     #[test]
     fn working_small() {
         let poly = PolyOverZ::from_str("4  0 1 -2 3").unwrap();
-        let modulus = Modulus::try_from(&Z::from(100)).unwrap();
+        let modulus = Modulus::from(100);
 
         let mod_poly = PolyOverZq::from((&poly, &modulus));
 
@@ -199,7 +196,7 @@ mod test_from_poly_z_modulus {
     #[test]
     fn working_large() {
         let poly = PolyOverZ::from_str(&format!("4  {} {} -2 3", u64::MAX - 1, u64::MAX)).unwrap();
-        let modulus = Modulus::try_from(&Z::from(u64::MAX)).unwrap();
+        let modulus = Modulus::from(u64::MAX);
 
         let mod_poly = PolyOverZq::from((&poly, &modulus));
 
@@ -211,7 +208,7 @@ mod test_from_poly_z_modulus {
     #[test]
     fn reduce() {
         let poly = PolyOverZ::from_str("4  100 101 -102 103").unwrap();
-        let modulus = Modulus::try_from(&Z::from(100)).unwrap();
+        let modulus = Modulus::from(100);
 
         let mod_poly = PolyOverZq::from((&poly, &modulus));
 

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -33,7 +33,7 @@ impl From<&Modulus> for PolyOverZq {
     /// use qfall_math::integer_mod_q::{PolyOverZq, Modulus};
     /// use std::str::FromStr;
     ///
-    /// let modulus = Modulus::from_str("100").unwrap();
+    /// let modulus = Modulus::from(100);
     /// let poly = PolyOverZq::from(&modulus);
     ///
     /// let poly_cmp = PolyOverZq::from_str("0 mod 100").unwrap();
@@ -63,7 +63,7 @@ impl From<(&PolyOverZ, &Modulus)> for PolyOverZq {
     /// use std::str::FromStr;
     ///
     /// let poly = PolyOverZ::from_str("4  0 1 102 3").unwrap();
-    /// let modulus = Modulus::from_str("100").unwrap();
+    /// let modulus = Modulus::from(100);
     ///
     /// let mod_poly = PolyOverZq::from((&poly, &modulus));
     ///

--- a/src/integer_mod_q/poly_over_zq/get.rs
+++ b/src/integer_mod_q/poly_over_zq/get.rs
@@ -45,8 +45,8 @@ impl GetCoefficient<Zq> for PolyOverZq {
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
     /// either the index is negative or it does not fit into an [`i64`].
     fn get_coeff(&self, index: impl TryInto<i64> + Display) -> Result<Zq, MathError> {
-        let out_z = self.get_coeff(index)?;
-        Ok(Zq::from_z_modulus(&out_z, &self.modulus))
+        let out_z: Z = self.get_coeff(index)?;
+        Ok(Zq::from((out_z, &self.modulus)))
     }
 }
 

--- a/src/integer_mod_q/poly_over_zq/sample/uniform.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/uniform.rs
@@ -47,7 +47,9 @@ impl PolyOverZq {
     /// if the given `modulus` isn't bigger than `1`, i.e. the interval size is at most `1`.
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
     /// the `nr_coeffs` is negative or it does not fit into an [`i64`].
-    /// - Panics if the provided modulus is not greater than `1`.
+    ///
+    /// # Panics ...
+    /// - if the provided modulus is not greater than `1`.
     pub fn sample_uniform(
         nr_coeffs: impl TryInto<i64> + Display + Copy,
         modulus: impl Into<Z>,

--- a/src/integer_mod_q/poly_over_zq/set.rs
+++ b/src/integer_mod_q/poly_over_zq/set.rs
@@ -96,7 +96,7 @@ impl SetCoefficient<&Zq> for PolyOverZq {
     /// use std::str::FromStr;
     ///
     /// let mut poly = PolyOverZq::from_str("4  0 1 2 3 mod 17").unwrap();
-    /// let value = Zq::try_from((1000,17)).unwrap();
+    /// let value = Zq::from((1000,17));
     ///
     /// assert!(poly.set_coeff(4, &value).is_ok());
     /// ```
@@ -204,7 +204,7 @@ mod test_set_coeff_zq {
     #[test]
     fn mismatching_moduli() {
         let mut poly = PolyOverZq::from_str(&format!("4  0 1 2 3 mod {}", u64::MAX - 58)).unwrap();
-        let value = Zq::try_from((u64::MAX, u64::MAX - 57)).unwrap();
+        let value = Zq::from((u64::MAX, u64::MAX - 57));
 
         assert!(poly.set_coeff(4, &value).is_err());
         assert_eq!(
@@ -217,7 +217,7 @@ mod test_set_coeff_zq {
     #[test]
     fn matching_moduli() {
         let mut poly = PolyOverZq::from_str(&format!("4  0 1 2 3 mod {}", u64::MAX - 58)).unwrap();
-        let value = Zq::try_from((u64::MAX, u64::MAX - 58)).unwrap();
+        let value = Zq::from((u64::MAX, u64::MAX - 58));
 
         assert!(poly.set_coeff(4, &value).is_ok());
         assert_eq!(

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/add.rs
@@ -49,7 +49,7 @@ impl Add for &PolynomialRingZq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the moduli of both [`PolynomialRingZq`] mismatch.
+    /// - if the moduli of both [`PolynomialRingZq`] mismatch.
     fn add(self, other: Self) -> Self::Output {
         self.add_safe(other).unwrap()
     }

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/mul.rs
@@ -49,7 +49,7 @@ impl Mul for &PolynomialRingZq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the moduli of both [`PolynomialRingZq`] mismatch.
+    /// - if the moduli of both [`PolynomialRingZq`] mismatch.
     fn mul(self, other: Self) -> Self::Output {
         self.mul_safe(other).unwrap()
     }

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/sub.rs
@@ -49,7 +49,7 @@ impl Sub for &PolynomialRingZq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the moduli of both [`PolynomialRingZq`] mismatch.
+    /// - if the moduli of both [`PolynomialRingZq`] mismatch.
     fn sub(self, other: Self) -> Self::Output {
         self.sub_safe(other).unwrap()
     }

--- a/src/integer_mod_q/polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/from.rs
@@ -53,15 +53,16 @@ mod test_from_poly_over_z_modulus_polynomial_ring_zq {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that the modulus is applied with a large prime and large coefficients
     #[test]
     fn is_reduced_large() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
 
-        let poly = PolyOverZ::from_str(&format!("4  {} {} 1 1", BITPRIME64 + 2, u64::MAX)).unwrap();
+        let poly =
+            PolyOverZ::from_str(&format!("4  {} {} 1 1", LARGE_PRIME + 2, u64::MAX)).unwrap();
         let poly_ring = PolynomialRingZq::from((&poly, &modulus));
 
         let cmp_poly = PolyOverZ::from_str("3  1 58 1").unwrap();
@@ -74,8 +75,9 @@ mod test_from_poly_over_z_modulus_polynomial_ring_zq {
     #[test]
     fn same_instantiation() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
-        let poly = PolyOverZ::from_str(&format!("4  {} {} 1 1", BITPRIME64 + 2, u64::MAX)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
+        let poly =
+            PolyOverZ::from_str(&format!("4  {} {} 1 1", LARGE_PRIME + 2, u64::MAX)).unwrap();
 
         let poly_ring_1 = PolynomialRingZq::from((&poly, &modulus));
         let poly_ring_2 = PolynomialRingZq::from((&poly, &modulus));

--- a/src/integer_mod_q/polynomial_ring_zq/reduce.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/reduce.rs
@@ -49,18 +49,19 @@ mod test_reduced {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that the entries are reduced
     #[test]
     fn reduces() {
         let modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
-        let poly = PolyOverZ::from_str(&format!("4  {} {} 1 1", BITPRIME64 + 2, u64::MAX)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
+        let poly =
+            PolyOverZ::from_str(&format!("4  {} {} 1 1", LARGE_PRIME + 2, u64::MAX)).unwrap();
         let mut poly_ring = PolynomialRingZq { poly, modulus };
 
         let cmp_modulus =
-            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", BITPRIME64)).unwrap();
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", LARGE_PRIME)).unwrap();
         let cmp_poly = PolyOverZ::from_str("3  1 58 1").unwrap();
         let cmp_poly_ring = PolynomialRingZq {
             poly: cmp_poly.clone(),

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -37,8 +37,8 @@ impl Add for &Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let a: Zq = Zq::try_from((23, 42)).unwrap();
-    /// let b: Zq = Zq::try_from((1, 42)).unwrap();
+    /// let a: Zq = Zq::from((23, 42));
+    /// let b: Zq = Zq::from((1, 42));
     ///
     /// let c: Zq = &a + &b;
     /// let d: Zq = a + b;
@@ -67,8 +67,8 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let a: Zq = Zq::try_from((23, 42)).unwrap();
-    /// let b: Zq = Zq::try_from((1, 42)).unwrap();
+    /// let a: Zq = Zq::from((23, 42));
+    /// let b: Zq = Zq::from((1, 42));
     ///
     /// let c: Zq = a.add_safe(&b).unwrap();
     /// ```
@@ -152,65 +152,62 @@ mod test_add {
     /// Testing addition for two [`Zq`]
     #[test]
     fn add() {
-        let a: Zq = Zq::try_from((11, 17)).unwrap();
-        let b: Zq = Zq::try_from((12, 17)).unwrap();
+        let a: Zq = Zq::from((11, 17));
+        let b: Zq = Zq::from((12, 17));
         let c: Zq = a + b;
-        assert_eq!(c, Zq::try_from((6, 17)).unwrap());
+        assert_eq!(c, Zq::from((6, 17)));
     }
 
     /// Testing addition for two borrowed [`Zq`]
     #[test]
     fn add_borrow() {
-        let a: Zq = Zq::try_from((10, 11)).unwrap();
-        let b: Zq = Zq::try_from((1, 11)).unwrap();
+        let a: Zq = Zq::from((10, 11));
+        let b: Zq = Zq::from((1, 11));
         let c: Zq = &a + &b;
-        assert_eq!(c, Zq::try_from((0, 11)).unwrap());
+        assert_eq!(c, Zq::from((0, 11)));
     }
 
     /// Testing addition for borrowed [`Zq`] and [`Zq`]
     #[test]
     fn add_first_borrowed() {
-        let a: Zq = Zq::try_from((2, 11)).unwrap();
-        let b: Zq = Zq::try_from((5, 11)).unwrap();
+        let a: Zq = Zq::from((2, 11));
+        let b: Zq = Zq::from((5, 11));
         let c: Zq = &a + b;
-        assert_eq!(c, Zq::try_from((7, 11)).unwrap());
+        assert_eq!(c, Zq::from((7, 11)));
     }
 
     /// Testing addition for [`Zq`] and borrowed [`Zq`]
     #[test]
     fn add_second_borrowed() {
-        let a: Zq = Zq::try_from((12, 11)).unwrap();
-        let b: Zq = Zq::try_from((10, 11)).unwrap();
+        let a: Zq = Zq::from((12, 11));
+        let b: Zq = Zq::from((10, 11));
         let c: Zq = a + &b;
-        assert_eq!(c, Zq::try_from((0, 11)).unwrap());
+        assert_eq!(c, Zq::from((0, 11)));
     }
 
     /// Testing addition for big [`Zq`]
     #[test]
     fn add_large_numbers() {
-        let a: Zq = Zq::try_from((u32::MAX, u32::MAX - 58)).unwrap();
-        let b: Zq = Zq::try_from((i32::MAX, u32::MAX - 58)).unwrap();
+        let a: Zq = Zq::from((u32::MAX, u32::MAX - 58));
+        let b: Zq = Zq::from((i32::MAX, u32::MAX - 58));
         let c: Zq = a + b;
-        assert_eq!(
-            c,
-            Zq::try_from(((u32::MAX - 1) / 2 + 58, u32::MAX - 58)).unwrap()
-        );
+        assert_eq!(c, Zq::from(((u32::MAX - 1) / 2 + 58, u32::MAX - 58)));
     }
 
     /// Testing addition for [`Zq`] with different moduli does not work
     #[test]
     #[should_panic]
     fn add_mismatching_modulus() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
-        let b: Zq = Zq::try_from((1, 3)).unwrap();
+        let a: Zq = Zq::from((4, 11));
+        let b: Zq = Zq::from((1, 3));
         let _c: Zq = a + b;
     }
 
     /// Testing whether add_safe throws an error for mismatching moduli
     #[test]
     fn add_safe_is_err() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
-        let b: Zq = Zq::try_from((1, 3)).unwrap();
+        let a: Zq = Zq::from((4, 11));
+        let b: Zq = Zq::from((1, 3));
         assert!(&a.add_safe(&b).is_err());
     }
 }
@@ -223,54 +220,51 @@ mod test_add_between_zq_and_z {
     /// Testing addition for [`Zq`] and [`Z`]
     #[test]
     fn add() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = a + b;
-        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+        assert_eq!(c, Zq::from((2, 11)));
     }
 
     /// Testing addition for both borrowed [`Zq`] and [`Z`]
     #[test]
     fn add_borrow() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = &a + &b;
-        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+        assert_eq!(c, Zq::from((2, 11)));
     }
 
     /// Testing addition for borrowed [`Zq`] and [`Z`]
     #[test]
     fn add_first_borrowed() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = &a + b;
-        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+        assert_eq!(c, Zq::from((2, 11)));
     }
 
     /// Testing addition for [`Zq`] and borrowed [`Z`]
     #[test]
     fn add_second_borrowed() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = a + &b;
-        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+        assert_eq!(c, Zq::from((2, 11)));
     }
 
     /// Testing addition for big numbers
     #[test]
     fn add_large_numbers() {
-        let a: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
-        let b: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let a: Zq = Zq::from((i64::MAX, u64::MAX - 58));
+        let b: Zq = Zq::from((i64::MAX - 1, i64::MAX));
         let c: Z = Z::from(u64::MAX);
 
         let d: Zq = a + &c;
         let e: Zq = b + c;
 
-        assert_eq!(
-            d,
-            Zq::try_from(((u64::MAX - 1) / 2 + 58, u64::MAX - 58)).unwrap()
-        );
-        assert_eq!(e, Zq::try_from((0, i64::MAX)).unwrap());
+        assert_eq!(d, Zq::from(((u64::MAX - 1) / 2 + 58, u64::MAX - 58)));
+        assert_eq!(e, Zq::from((0, i64::MAX)));
     }
 }
 
@@ -282,7 +276,7 @@ mod test_add_between_types {
     #[test]
     #[allow(clippy::op_ref)]
     fn add() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: u64 = 1;
         let c: u32 = 1;
         let d: u16 = 1;
@@ -319,23 +313,23 @@ mod test_add_between_types {
         let _: Zq = &a + h;
         let _: Zq = &a + i;
 
-        let _: Zq = &b + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &c + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &d + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &e + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &f + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &g + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &h + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &i + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &b + Zq::from((4, 11));
+        let _: Zq = &c + Zq::from((4, 11));
+        let _: Zq = &d + Zq::from((4, 11));
+        let _: Zq = &e + Zq::from((4, 11));
+        let _: Zq = &f + Zq::from((4, 11));
+        let _: Zq = &g + Zq::from((4, 11));
+        let _: Zq = &h + Zq::from((4, 11));
+        let _: Zq = &i + Zq::from((4, 11));
 
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + &b;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + &c;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + &d;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + &e;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + &f;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + &g;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + &h;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + &i;
+        let _: Zq = Zq::from((4, 11)) + &b;
+        let _: Zq = Zq::from((4, 11)) + &c;
+        let _: Zq = Zq::from((4, 11)) + &d;
+        let _: Zq = Zq::from((4, 11)) + &e;
+        let _: Zq = Zq::from((4, 11)) + &f;
+        let _: Zq = Zq::from((4, 11)) + &g;
+        let _: Zq = Zq::from((4, 11)) + &h;
+        let _: Zq = Zq::from((4, 11)) + &i;
 
         let _: Zq = b + &a;
         let _: Zq = c + &a;
@@ -346,22 +340,22 @@ mod test_add_between_types {
         let _: Zq = h + &a;
         let _: Zq = i + &a;
 
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + b;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + c;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + d;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + e;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + f;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + g;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + h;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() + i;
+        let _: Zq = Zq::from((4, 11)) + b;
+        let _: Zq = Zq::from((4, 11)) + c;
+        let _: Zq = Zq::from((4, 11)) + d;
+        let _: Zq = Zq::from((4, 11)) + e;
+        let _: Zq = Zq::from((4, 11)) + f;
+        let _: Zq = Zq::from((4, 11)) + g;
+        let _: Zq = Zq::from((4, 11)) + h;
+        let _: Zq = Zq::from((4, 11)) + i;
 
-        let _: Zq = b + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = c + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = d + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = e + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = f + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = g + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = h + Zq::try_from((4, 11)).unwrap();
-        let _: Zq = i + Zq::try_from((4, 11)).unwrap();
+        let _: Zq = b + Zq::from((4, 11));
+        let _: Zq = c + Zq::from((4, 11));
+        let _: Zq = d + Zq::from((4, 11));
+        let _: Zq = e + Zq::from((4, 11));
+        let _: Zq = f + Zq::from((4, 11));
+        let _: Zq = g + Zq::from((4, 11));
+        let _: Zq = h + Zq::from((4, 11));
+        let _: Zq = i + Zq::from((4, 11));
     }
 }

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -117,7 +117,7 @@ impl Add<&Z> for &Zq {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Zq = Zq::from_str("42 mod 19").unwrap();
+    /// let a: Zq = Zq::from((42, 19));
     /// let b: Z = Z::from(42);
     ///
     /// let c: Zq = &a + &b;

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -83,7 +83,7 @@ impl Zq {
                 self, other
             )));
         }
-        let mut out = Zq::from_z_modulus(&Z::from(1), &self.modulus);
+        let mut out = Zq::from((1, &self.modulus));
         unsafe {
             fmpz_mod_add(
                 &mut out.value.value,

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -47,7 +47,7 @@ impl Add for &Zq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the moduli of both [`Zq`] mismatch.
+    /// - if the moduli of both [`Zq`] mismatch.
     fn add(self, other: Self) -> Self::Output {
         self.add_safe(other).unwrap()
     }

--- a/src/integer_mod_q/z_q/arithmetic/mul.rs
+++ b/src/integer_mod_q/z_q/arithmetic/mul.rs
@@ -46,8 +46,8 @@ impl Mul for &Zq {
     /// let f: Zq = c * &e;
     /// ```
     ///
-    /// # Panics
-    /// - Panics if the moduli of both [`Zq`] mismatch.
+    /// # Panics ...
+    /// - if the moduli of both [`Zq`] mismatch.
     fn mul(self, other: Self) -> Self::Output {
         self.mul_safe(other).unwrap()
     }

--- a/src/integer_mod_q/z_q/arithmetic/mul.rs
+++ b/src/integer_mod_q/z_q/arithmetic/mul.rs
@@ -116,7 +116,7 @@ impl Mul<&Z> for &Zq {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Zq = Zq::from_str("42 mod 19").unwrap();
+    /// let a: Zq = Zq::from((42, 19));
     /// let b: Z = Z::from(42);
     ///
     /// let c: Zq = &a * &b;

--- a/src/integer_mod_q/z_q/arithmetic/mul.rs
+++ b/src/integer_mod_q/z_q/arithmetic/mul.rs
@@ -83,7 +83,7 @@ impl Zq {
                 self, other
             )));
         }
-        let mut out = Zq::from_z_modulus(&Z::from(1), &self.modulus);
+        let mut out = Zq::from((1, &self.modulus));
         unsafe {
             fmpz_mod_mul(
                 &mut out.value.value,

--- a/src/integer_mod_q/z_q/arithmetic/mul.rs
+++ b/src/integer_mod_q/z_q/arithmetic/mul.rs
@@ -37,8 +37,8 @@ impl Mul for &Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let a: Zq = Zq::try_from((23, 42)).unwrap();
-    /// let b: Zq = Zq::try_from((1, 42)).unwrap();
+    /// let a: Zq = Zq::from((23, 42));
+    /// let b: Zq = Zq::from((1, 42));
     ///
     /// let c: Zq = &a * &b;
     /// let d: Zq = a * b;
@@ -67,8 +67,8 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let a: Zq = Zq::try_from((23, 42)).unwrap();
-    /// let b: Zq = Zq::try_from((1, 42)).unwrap();
+    /// let a: Zq = Zq::from((23, 42));
+    /// let b: Zq = Zq::from((1, 42));
     ///
     /// let c: Zq = a.mul_safe(&b).unwrap();
     /// ```
@@ -152,48 +152,48 @@ mod test_mul {
     /// Testing multiplication for two [`Zq`]
     #[test]
     fn mul() {
-        let a: Zq = Zq::try_from((11, 17)).unwrap();
-        let b: Zq = Zq::try_from((12, 17)).unwrap();
+        let a: Zq = Zq::from((11, 17));
+        let b: Zq = Zq::from((12, 17));
         let c: Zq = a * b;
-        assert_eq!(c, Zq::try_from((13, 17)).unwrap());
+        assert_eq!(c, Zq::from((13, 17)));
     }
 
     /// Testing multiplication for two borrowed [`Zq`]
     #[test]
     fn mul_borrow() {
-        let a: Zq = Zq::try_from((10, 11)).unwrap();
-        let b: Zq = Zq::try_from((1, 11)).unwrap();
+        let a: Zq = Zq::from((10, 11));
+        let b: Zq = Zq::from((1, 11));
         let c: Zq = &a * &b;
-        assert_eq!(c, Zq::try_from((10, 11)).unwrap());
+        assert_eq!(c, Zq::from((10, 11)));
     }
 
     /// Testing multiplication for borrowed [`Zq`] and [`Zq`]
     #[test]
     fn mul_first_borrowed() {
-        let a: Zq = Zq::try_from((2, 11)).unwrap();
-        let b: Zq = Zq::try_from((5, 11)).unwrap();
+        let a: Zq = Zq::from((2, 11));
+        let b: Zq = Zq::from((5, 11));
         let c: Zq = &a * b;
-        assert_eq!(c, Zq::try_from((10, 11)).unwrap());
+        assert_eq!(c, Zq::from((10, 11)));
     }
 
     /// Testing multiplication for [`Zq`] and borrowed [`Zq`]
     #[test]
     fn mul_second_borrowed() {
-        let a: Zq = Zq::try_from((12, 11)).unwrap();
-        let b: Zq = Zq::try_from((10, 11)).unwrap();
+        let a: Zq = Zq::from((12, 11));
+        let b: Zq = Zq::from((10, 11));
         let c: Zq = a * &b;
-        assert_eq!(c, Zq::try_from((-1, 11)).unwrap());
+        assert_eq!(c, Zq::from((-1, 11)));
     }
 
     /// Testing multiplication for big [`Zq`]
     #[test]
     fn mul_large_numbers() {
-        let a: Zq = Zq::try_from((u32::MAX, u32::MAX - 58)).unwrap();
-        let b: Zq = Zq::try_from((i32::MAX, u32::MAX - 58)).unwrap();
+        let a: Zq = Zq::from((u32::MAX, u32::MAX - 58));
+        let b: Zq = Zq::from((i32::MAX, u32::MAX - 58));
         let c: Zq = a * b;
         assert_eq!(
             c,
-            Zq::try_from((u64::from((u32::MAX - 1) / 2) * 58, u32::MAX - 58)).unwrap()
+            Zq::from((u64::from((u32::MAX - 1) / 2) * 58, u32::MAX - 58))
         );
     }
 
@@ -201,16 +201,16 @@ mod test_mul {
     #[test]
     #[should_panic]
     fn mul_mismatching_modulus() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
-        let b: Zq = Zq::try_from((1, 3)).unwrap();
+        let a: Zq = Zq::from((4, 11));
+        let b: Zq = Zq::from((1, 3));
         let _c: Zq = a * b;
     }
 
     /// Testing whether mul_safe throws an error for mismatching moduli
     #[test]
     fn mul_safe_is_err() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
-        let b: Zq = Zq::try_from((1, 3)).unwrap();
+        let a: Zq = Zq::from((4, 11));
+        let b: Zq = Zq::from((1, 3));
         assert!(&a.mul_safe(&b).is_err());
     }
 }
@@ -223,44 +223,44 @@ mod test_mul_between_zq_and_z {
     /// Testing multiplication for [`Zq`] and [`Z`]
     #[test]
     fn mul() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = a * b;
-        assert_eq!(c, Zq::try_from((3, 11)).unwrap());
+        assert_eq!(c, Zq::from((3, 11)));
     }
 
     /// Testing multiplication for both borrowed [`Zq`] and [`Z`]
     #[test]
     fn mul_borrow() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = &a * &b;
-        assert_eq!(c, Zq::try_from((3, 11)).unwrap());
+        assert_eq!(c, Zq::from((3, 11)));
     }
 
     /// Testing multiplication for borrowed [`Zq`] and [`Z`]
     #[test]
     fn mul_first_borrowed() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = &a * b;
-        assert_eq!(c, Zq::try_from((3, 11)).unwrap());
+        assert_eq!(c, Zq::from((3, 11)));
     }
 
     /// Testing multiplication for [`Zq`] and borrowed [`Z`]
     #[test]
     fn mul_second_borrowed() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = a * &b;
-        assert_eq!(c, Zq::try_from((3, 11)).unwrap());
+        assert_eq!(c, Zq::from((3, 11)));
     }
 
     /// Testing multiplication for big numbers
     #[test]
     fn mul_large_numbers() {
-        let a: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
-        let b: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let a: Zq = Zq::from((i64::MAX, u64::MAX - 58));
+        let b: Zq = Zq::from((i64::MAX - 1, i64::MAX));
         let c: Z = Z::from(u64::MAX);
 
         let d: Zq = a * &c;
@@ -268,13 +268,9 @@ mod test_mul_between_zq_and_z {
 
         assert_eq!(
             d,
-            Zq::try_from(((u64::MAX - 1) / 2, u64::MAX - 58)).unwrap()
-                * Zq::try_from((u64::MAX, u64::MAX - 58)).unwrap()
+            Zq::from(((u64::MAX - 1) / 2, u64::MAX - 58)) * Zq::from((u64::MAX, u64::MAX - 58))
         );
-        assert_eq!(
-            e,
-            Zq::try_from((-1, i64::MAX)).unwrap() * Zq::try_from((u64::MAX, i64::MAX)).unwrap()
-        );
+        assert_eq!(e, Zq::from((-1, i64::MAX)) * Zq::from((u64::MAX, i64::MAX)));
     }
 }
 
@@ -286,7 +282,7 @@ mod test_mul_between_types {
     #[test]
     #[allow(clippy::op_ref)]
     fn mul() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: u64 = 1;
         let c: u32 = 1;
         let d: u16 = 1;
@@ -323,23 +319,23 @@ mod test_mul_between_types {
         let _: Zq = &a * h;
         let _: Zq = &a * i;
 
-        let _: Zq = &b * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &c * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &d * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &e * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &f * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &g * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &h * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &i * Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &b * Zq::from((4, 11));
+        let _: Zq = &c * Zq::from((4, 11));
+        let _: Zq = &d * Zq::from((4, 11));
+        let _: Zq = &e * Zq::from((4, 11));
+        let _: Zq = &f * Zq::from((4, 11));
+        let _: Zq = &g * Zq::from((4, 11));
+        let _: Zq = &h * Zq::from((4, 11));
+        let _: Zq = &i * Zq::from((4, 11));
 
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * &b;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * &c;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * &d;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * &e;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * &f;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * &g;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * &h;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * &i;
+        let _: Zq = Zq::from((4, 11)) * &b;
+        let _: Zq = Zq::from((4, 11)) * &c;
+        let _: Zq = Zq::from((4, 11)) * &d;
+        let _: Zq = Zq::from((4, 11)) * &e;
+        let _: Zq = Zq::from((4, 11)) * &f;
+        let _: Zq = Zq::from((4, 11)) * &g;
+        let _: Zq = Zq::from((4, 11)) * &h;
+        let _: Zq = Zq::from((4, 11)) * &i;
 
         let _: Zq = b * &a;
         let _: Zq = c * &a;
@@ -350,22 +346,22 @@ mod test_mul_between_types {
         let _: Zq = h * &a;
         let _: Zq = i * &a;
 
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * b;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * c;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * d;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * e;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * f;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * g;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * h;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() * i;
+        let _: Zq = Zq::from((4, 11)) * b;
+        let _: Zq = Zq::from((4, 11)) * c;
+        let _: Zq = Zq::from((4, 11)) * d;
+        let _: Zq = Zq::from((4, 11)) * e;
+        let _: Zq = Zq::from((4, 11)) * f;
+        let _: Zq = Zq::from((4, 11)) * g;
+        let _: Zq = Zq::from((4, 11)) * h;
+        let _: Zq = Zq::from((4, 11)) * i;
 
-        let _: Zq = b * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = c * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = d * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = e * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = f * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = g * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = h * Zq::try_from((4, 11)).unwrap();
-        let _: Zq = i * Zq::try_from((4, 11)).unwrap();
+        let _: Zq = b * Zq::from((4, 11));
+        let _: Zq = c * Zq::from((4, 11));
+        let _: Zq = d * Zq::from((4, 11));
+        let _: Zq = e * Zq::from((4, 11));
+        let _: Zq = f * Zq::from((4, 11));
+        let _: Zq = g * Zq::from((4, 11));
+        let _: Zq = h * Zq::from((4, 11));
+        let _: Zq = i * Zq::from((4, 11));
     }
 }

--- a/src/integer_mod_q/z_q/arithmetic/pow.rs
+++ b/src/integer_mod_q/z_q/arithmetic/pow.rs
@@ -33,12 +33,12 @@ impl Pow<&Z> for Zq {
     /// use qfall_math::integer_mod_q::Zq;
     /// use qfall_math::traits::*;
     ///
-    /// let base = Zq::try_from((2, 9)).unwrap();
+    /// let base = Zq::from((2, 9));
     /// let exp = Z::from(4);
     ///
     /// let powered_value = base.pow(&exp).unwrap();
     ///
-    /// let cmp = Zq::try_from((7, 9)).unwrap();
+    /// let cmp = Zq::from((7, 9));
     /// assert_eq!(cmp, powered_value);
     /// ```
     ///
@@ -74,7 +74,7 @@ mod test_pow {
     /// Ensure that `pow` works for [`Zq`] properly for small values
     #[test]
     fn small() {
-        let base = Zq::try_from((2, 9)).unwrap();
+        let base = Zq::from((2, 9));
         let exp_0 = Z::from(4);
         let exp_1 = Z::ZERO;
         let exp_2 = Z::from(-2);
@@ -83,21 +83,21 @@ mod test_pow {
         let res_1 = base.pow(&exp_1).unwrap();
         let res_2 = base.pow(&exp_2).unwrap();
 
-        assert_eq!(Zq::try_from((7, 9)).unwrap(), res_0);
-        assert_eq!(Zq::try_from((1, 9)).unwrap(), res_1);
-        assert_eq!(Zq::try_from((7, 9)).unwrap(), res_2);
+        assert_eq!(Zq::from((7, 9)), res_0);
+        assert_eq!(Zq::from((1, 9)), res_1);
+        assert_eq!(Zq::from((7, 9)), res_2);
     }
 
     /// Ensure that `pow` works for [`Zq`] properly for large values
     #[test]
     fn large() {
-        let base = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
+        let base = Zq::from((i64::MAX, u64::MAX));
         let exp_0 = Z::from(4);
         let exp_1 = Z::ZERO;
         let exp_2 = Z::from(-1);
-        let cmp_0 = Zq::try_from((1152921504606846976_i64, u64::MAX)).unwrap();
-        let cmp_1 = Zq::try_from((1, u64::MAX)).unwrap();
-        let cmp_2 = Zq::try_from((18446744073709551613_u64, u64::MAX)).unwrap();
+        let cmp_0 = Zq::from((1152921504606846976_i64, u64::MAX));
+        let cmp_1 = Zq::from((1, u64::MAX));
+        let cmp_2 = Zq::from((18446744073709551613_u64, u64::MAX));
 
         let res_0 = base.pow(&exp_0).unwrap();
         let res_1 = base.pow(&exp_1).unwrap();
@@ -111,7 +111,7 @@ mod test_pow {
     /// Ensures that the `pow` trait is available for other types
     #[test]
     fn availability() {
-        let base = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
+        let base = Zq::from((i64::MAX, u64::MAX));
         let exp = Z::from(4);
 
         let _ = base.pow(exp);
@@ -129,7 +129,7 @@ mod test_pow {
     /// powered by a negative exponent
     #[test]
     fn non_invertible_detection() {
-        let base = Zq::try_from((2, 4)).unwrap();
+        let base = Zq::from((2, 4));
 
         assert!(base.pow(-1).is_err());
     }

--- a/src/integer_mod_q/z_q/arithmetic/sub.rs
+++ b/src/integer_mod_q/z_q/arithmetic/sub.rs
@@ -37,8 +37,8 @@ impl Sub for &Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let a: Zq = Zq::try_from((23, 42)).unwrap();
-    /// let b: Zq = Zq::try_from((1, 42)).unwrap();
+    /// let a: Zq = Zq::from((23, 42));
+    /// let b: Zq = Zq::from((1, 42));
     ///
     /// let c: Zq = &a - &b;
     /// let d: Zq = a - b;
@@ -67,8 +67,8 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let a: Zq = Zq::try_from((23, 42)).unwrap();
-    /// let b: Zq = Zq::try_from((1, 42)).unwrap();
+    /// let a: Zq = Zq::from((23, 42));
+    /// let b: Zq = Zq::from((1, 42));
     ///
     /// let c: Zq = a.sub_safe(&b).unwrap();
     /// ```
@@ -152,65 +152,62 @@ mod test_sub {
     /// Testing subtraction for two [`Zq`]
     #[test]
     fn sub() {
-        let a: Zq = Zq::try_from((11, 17)).unwrap();
-        let b: Zq = Zq::try_from((12, 17)).unwrap();
+        let a: Zq = Zq::from((11, 17));
+        let b: Zq = Zq::from((12, 17));
         let c: Zq = a - b;
-        assert_eq!(c, Zq::try_from((16, 17)).unwrap());
+        assert_eq!(c, Zq::from((16, 17)));
     }
 
     /// Testing subtraction for two borrowed [`Zq`]
     #[test]
     fn sub_borrow() {
-        let a: Zq = Zq::try_from((10, 11)).unwrap();
-        let b: Zq = Zq::try_from((1, 11)).unwrap();
+        let a: Zq = Zq::from((10, 11));
+        let b: Zq = Zq::from((1, 11));
         let c: Zq = &a - &b;
-        assert_eq!(c, Zq::try_from((9, 11)).unwrap());
+        assert_eq!(c, Zq::from((9, 11)));
     }
 
     /// Testing subtraction for borrowed [`Zq`] and [`Zq`]
     #[test]
     fn sub_first_borrowed() {
-        let a: Zq = Zq::try_from((2, 11)).unwrap();
-        let b: Zq = Zq::try_from((5, 11)).unwrap();
+        let a: Zq = Zq::from((2, 11));
+        let b: Zq = Zq::from((5, 11));
         let c: Zq = &a - b;
-        assert_eq!(c, Zq::try_from((-3, 11)).unwrap());
+        assert_eq!(c, Zq::from((-3, 11)));
     }
 
     /// Testing subtraction for [`Zq`] and borrowed [`Zq`]
     #[test]
     fn sub_second_borrowed() {
-        let a: Zq = Zq::try_from((12, 11)).unwrap();
-        let b: Zq = Zq::try_from((10, 11)).unwrap();
+        let a: Zq = Zq::from((12, 11));
+        let b: Zq = Zq::from((10, 11));
         let c: Zq = a - &b;
-        assert_eq!(c, Zq::try_from((2, 11)).unwrap());
+        assert_eq!(c, Zq::from((2, 11)));
     }
 
     /// Testing subtraction for big [`Zq`]
     #[test]
     fn sub_large_numbers() {
-        let a: Zq = Zq::try_from((u32::MAX, u32::MAX - 58)).unwrap();
-        let b: Zq = Zq::try_from((i32::MAX, u32::MAX - 58)).unwrap();
+        let a: Zq = Zq::from((u32::MAX, u32::MAX - 58));
+        let b: Zq = Zq::from((i32::MAX, u32::MAX - 58));
         let c: Zq = a - b;
-        assert_eq!(
-            c,
-            Zq::try_from((u32::MAX - (u32::MAX - 1) / 2, u32::MAX - 58)).unwrap()
-        );
+        assert_eq!(c, Zq::from((u32::MAX - (u32::MAX - 1) / 2, u32::MAX - 58)));
     }
 
     /// Testing subtraction for [`Zq`] with different moduli does not work
     #[test]
     #[should_panic]
     fn sub_mismatching_modulus() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
-        let b: Zq = Zq::try_from((1, 3)).unwrap();
+        let a: Zq = Zq::from((4, 11));
+        let b: Zq = Zq::from((1, 3));
         let _c: Zq = a - b;
     }
 
     /// Testing whether sub_safe throws an error for mismatching moduli
     #[test]
     fn sub_safe_is_err() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
-        let b: Zq = Zq::try_from((1, 3)).unwrap();
+        let a: Zq = Zq::from((4, 11));
+        let b: Zq = Zq::from((1, 3));
         assert!(&a.sub_safe(&b).is_err());
     }
 }
@@ -223,54 +220,51 @@ mod test_sub_between_z_and_zq {
     /// Testing subtraction for [`Q`] and [`Z`]
     #[test]
     fn sub() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = a - b;
-        assert_eq!(c, Zq::try_from((6, 11)).unwrap());
+        assert_eq!(c, Zq::from((6, 11)));
     }
 
     /// Testing subtraction for both borrowed [`Q`] and [`Z`]
     #[test]
     fn sub_borrow() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = &a - &b;
-        assert_eq!(c, Zq::try_from((6, 11)).unwrap());
+        assert_eq!(c, Zq::from((6, 11)));
     }
 
     /// Testing subtraction for borrowed [`Q`] and [`Z`]
     #[test]
     fn sub_first_borrowed() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = &a - b;
-        assert_eq!(c, Zq::try_from((6, 11)).unwrap());
+        assert_eq!(c, Zq::from((6, 11)));
     }
 
     /// Testing subtraction for [`Q`] and borrowed [`Z`]
     #[test]
     fn sub_second_borrowed() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: Z = Z::from(9);
         let c: Zq = a - &b;
-        assert_eq!(c, Zq::try_from((6, 11)).unwrap());
+        assert_eq!(c, Zq::from((6, 11)));
     }
 
     /// Testing subtraction for big numbers
     #[test]
     fn sub_large_numbers() {
-        let a: Zq = Zq::try_from((i64::MAX, u64::MAX - 58)).unwrap();
-        let b: Zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let a: Zq = Zq::from((i64::MAX, u64::MAX - 58));
+        let b: Zq = Zq::from((i64::MAX - 1, i64::MAX));
         let c: Z = Z::from(u64::MAX);
 
         let d: Zq = a - &c;
         let e: Zq = b - c;
 
-        assert_eq!(
-            d,
-            Zq::try_from(((u64::MAX - 1) / 2 - 58, u64::MAX - 58)).unwrap()
-        );
-        assert_eq!(e, Zq::try_from((-2, i64::MAX)).unwrap());
+        assert_eq!(d, Zq::from(((u64::MAX - 1) / 2 - 58, u64::MAX - 58)));
+        assert_eq!(e, Zq::from((-2, i64::MAX)));
     }
 }
 
@@ -282,7 +276,7 @@ mod test_add_between_types {
     #[test]
     #[allow(clippy::op_ref)]
     fn add() {
-        let a: Zq = Zq::try_from((4, 11)).unwrap();
+        let a: Zq = Zq::from((4, 11));
         let b: u64 = 1;
         let c: u32 = 1;
         let d: u16 = 1;
@@ -319,23 +313,23 @@ mod test_add_between_types {
         let _: Zq = &a - h;
         let _: Zq = &a - i;
 
-        let _: Zq = &b - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &c - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &d - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &e - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &f - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &g - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &h - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = &i - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = &b - Zq::from((4, 11));
+        let _: Zq = &c - Zq::from((4, 11));
+        let _: Zq = &d - Zq::from((4, 11));
+        let _: Zq = &e - Zq::from((4, 11));
+        let _: Zq = &f - Zq::from((4, 11));
+        let _: Zq = &g - Zq::from((4, 11));
+        let _: Zq = &h - Zq::from((4, 11));
+        let _: Zq = &i - Zq::from((4, 11));
 
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - &b;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - &c;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - &d;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - &e;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - &f;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - &g;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - &h;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - &i;
+        let _: Zq = Zq::from((4, 11)) - &b;
+        let _: Zq = Zq::from((4, 11)) - &c;
+        let _: Zq = Zq::from((4, 11)) - &d;
+        let _: Zq = Zq::from((4, 11)) - &e;
+        let _: Zq = Zq::from((4, 11)) - &f;
+        let _: Zq = Zq::from((4, 11)) - &g;
+        let _: Zq = Zq::from((4, 11)) - &h;
+        let _: Zq = Zq::from((4, 11)) - &i;
 
         let _: Zq = b - &a;
         let _: Zq = c - &a;
@@ -346,22 +340,22 @@ mod test_add_between_types {
         let _: Zq = h - &a;
         let _: Zq = i - &a;
 
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - b;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - c;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - d;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - e;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - f;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - g;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - h;
-        let _: Zq = Zq::try_from((4, 11)).unwrap() - i;
+        let _: Zq = Zq::from((4, 11)) - b;
+        let _: Zq = Zq::from((4, 11)) - c;
+        let _: Zq = Zq::from((4, 11)) - d;
+        let _: Zq = Zq::from((4, 11)) - e;
+        let _: Zq = Zq::from((4, 11)) - f;
+        let _: Zq = Zq::from((4, 11)) - g;
+        let _: Zq = Zq::from((4, 11)) - h;
+        let _: Zq = Zq::from((4, 11)) - i;
 
-        let _: Zq = b - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = c - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = d - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = e - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = f - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = g - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = h - Zq::try_from((4, 11)).unwrap();
-        let _: Zq = i - Zq::try_from((4, 11)).unwrap();
+        let _: Zq = b - Zq::from((4, 11));
+        let _: Zq = c - Zq::from((4, 11));
+        let _: Zq = d - Zq::from((4, 11));
+        let _: Zq = e - Zq::from((4, 11));
+        let _: Zq = f - Zq::from((4, 11));
+        let _: Zq = g - Zq::from((4, 11));
+        let _: Zq = h - Zq::from((4, 11));
+        let _: Zq = i - Zq::from((4, 11));
     }
 }

--- a/src/integer_mod_q/z_q/arithmetic/sub.rs
+++ b/src/integer_mod_q/z_q/arithmetic/sub.rs
@@ -83,7 +83,7 @@ impl Zq {
                 self, other
             )));
         }
-        let mut out = Zq::from_z_modulus(&Z::from(1), &self.modulus);
+        let mut out = Zq::from((1, &self.modulus));
         unsafe {
             fmpz_mod_sub(
                 &mut out.value.value,

--- a/src/integer_mod_q/z_q/arithmetic/sub.rs
+++ b/src/integer_mod_q/z_q/arithmetic/sub.rs
@@ -47,7 +47,7 @@ impl Sub for &Zq {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the moduli of both [`Zq`] mismatch.
+    /// - if the moduli of both [`Zq`] mismatch.
     fn sub(self, other: Self) -> Self::Output {
         self.sub_safe(other).unwrap()
     }

--- a/src/integer_mod_q/z_q/arithmetic/sub.rs
+++ b/src/integer_mod_q/z_q/arithmetic/sub.rs
@@ -117,7 +117,7 @@ impl Sub<&Z> for &Zq {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Zq = Zq::from_str("42 mod 19").unwrap();
+    /// let a: Zq = Zq::from((42, 19));
     /// let b: Z = Z::from(42);
     ///
     /// let c: Zq = &a - &b;

--- a/src/integer_mod_q/z_q/distance.rs
+++ b/src/integer_mod_q/z_q/distance.rs
@@ -138,7 +138,7 @@ impl<T: Into<Z>> Distance<T> for Zq {
     /// assert_eq!(Z::from(2), distance_1);
     /// ```
     fn distance(&self, other: T) -> Self::Output {
-        let other = Zq::from_z_modulus(&other.into(), &self.modulus.clone());
+        let other = Zq::from((&other.into(), &self.modulus));
         self.distance(&other)
     }
 }

--- a/src/integer_mod_q/z_q/distance.rs
+++ b/src/integer_mod_q/z_q/distance.rs
@@ -29,8 +29,8 @@ impl Zq {
     ///     integer_mod_q::Zq,
     /// };
     ///
-    /// let a = Zq::try_from((-1, 13)).unwrap();
-    /// let b = Zq::try_from((5, 13)).unwrap();
+    /// let a = Zq::from((-1, 13));
+    /// let b = Zq::from((5, 13));
     ///
     /// let distance = a.distance_safe(&b).unwrap();
     ///
@@ -83,8 +83,8 @@ impl Distance<&Zq> for Zq {
     ///     traits::*,
     /// };
     ///
-    /// let a = Zq::try_from((-1, 13)).unwrap();
-    /// let b = Zq::try_from((5, 13)).unwrap();
+    /// let a = Zq::from((-1, 13));
+    /// let b = Zq::from((5, 13));
     ///
     /// let distance = a.distance(&b);
     ///
@@ -129,7 +129,7 @@ impl<T: Into<Z>> Distance<T> for Zq {
     ///     traits::*,
     /// };
     ///
-    /// let a = Zq::try_from((-1, 13)).unwrap();
+    /// let a = Zq::from((-1, 13));
     ///
     /// let distance_0 = a.distance(5);
     /// let distance_1 = a.distance(10);
@@ -151,9 +151,9 @@ mod test_distance_safe {
     /// and whether distance(a,b) == distance(b,a) and distance(a,a) == 0
     #[test]
     fn small_values() {
-        let a = Zq::try_from((1, 29)).unwrap();
-        let b = Zq::try_from((-12, 29)).unwrap();
-        let zero = Zq::try_from((0, 29)).unwrap();
+        let a = Zq::from((1, 29));
+        let b = Zq::from((-12, 29));
+        let zero = Zq::from((0, 29));
 
         let res_0 = a.distance_safe(&zero).unwrap();
         let res_1 = zero.distance_safe(&a).unwrap();
@@ -180,9 +180,9 @@ mod test_distance_safe {
     /// and whether distance(a,b) == distance(b,a), and distance(a,a) == 0
     #[test]
     fn large_values() {
-        let a = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
-        let b = Zq::try_from((i64::MIN, u64::MAX)).unwrap();
-        let zero = Zq::try_from((0, u64::MAX)).unwrap();
+        let a = Zq::from((i64::MAX, u64::MAX));
+        let b = Zq::from((i64::MIN, u64::MAX));
+        let zero = Zq::from((0, u64::MAX));
 
         let res_0 = a.distance_safe(&b).unwrap();
         let res_1 = b.distance_safe(&a).unwrap();
@@ -204,8 +204,8 @@ mod test_distance_safe {
     /// Check whether mismatching provided moduli result in an error
     #[test]
     fn mismatching_moduli() {
-        let a = Zq::try_from((0, 17)).unwrap();
-        let b = Zq::try_from((0, 19)).unwrap();
+        let a = Zq::from((0, 17));
+        let b = Zq::from((0, 19));
 
         assert!(a.distance_safe(&b).is_err());
     }
@@ -218,7 +218,7 @@ mod test_distance {
     /// Check whether distance is available for owned [`Zq`] and other types
     #[test]
     fn availability() {
-        let a = Zq::try_from((0, u64::MAX)).unwrap();
+        let a = Zq::from((0, u64::MAX));
         let b = a.clone();
 
         let u_0 = a.distance(0_u8);
@@ -248,8 +248,8 @@ mod test_distance {
     #[test]
     #[should_panic]
     fn mismatching_moduli() {
-        let a = Zq::try_from((0, 17)).unwrap();
-        let b = Zq::try_from((0, 19)).unwrap();
+        let a = Zq::from((0, 17));
+        let b = Zq::from((0, 19));
 
         let _ = a.distance(&b);
     }

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -79,7 +79,7 @@ mod test_as_integer_zq {
     /// for small values (FLINT is not using pointers).
     #[test]
     fn small_into_fmpz() {
-        let zq = Zq::try_from((Z::from(42), Z::from(100))).unwrap();
+        let zq = Zq::from((42, 100));
 
         let copy_1 = unsafe { Z::from_fmpz((&zq).into_fmpz()) };
         let copy_2 = unsafe { Z::from_fmpz(zq.into_fmpz()) };
@@ -92,7 +92,7 @@ mod test_as_integer_zq {
     /// for large values (FLINT uses pointers).
     #[test]
     fn large_into_fmpz() {
-        let z = Zq::try_from((Z::from(u64::MAX - 1), Z::from(u64::MAX))).unwrap();
+        let z = Zq::from((u64::MAX - 1, u64::MAX));
 
         let copy_1 = unsafe { Z::from_fmpz((&z).into_fmpz()) };
         let copy_2 = unsafe { Z::from_fmpz(z.into_fmpz()) };
@@ -105,7 +105,7 @@ mod test_as_integer_zq {
     /// (Also as a pointer representation)
     #[test]
     fn memory_safety() {
-        let zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let zq = Zq::from((i64::MAX - 1, i64::MAX));
 
         let value = unsafe { (&zq).into_fmpz() };
 
@@ -117,7 +117,7 @@ mod test_as_integer_zq {
     #[test]
     #[allow(clippy::needless_borrow)]
     fn get_ref_small() {
-        let zq = Zq::try_from((10, 100)).unwrap();
+        let zq = Zq::from((10, 100));
 
         let zq_ref_value_1 = zq.get_fmpz_ref().unwrap();
         let zq_ref_value_2 = (&zq).get_fmpz_ref().unwrap();
@@ -130,7 +130,7 @@ mod test_as_integer_zq {
     #[test]
     #[allow(clippy::needless_borrow)]
     fn get_ref_large() {
-        let zq = Zq::try_from((i64::MAX - 1, i64::MAX)).unwrap();
+        let zq = Zq::from((i64::MAX - 1, i64::MAX));
 
         let zq_ref_value_1 = zq.get_fmpz_ref().unwrap();
         let zq_ref_value_2 = (&zq).get_fmpz_ref().unwrap();

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -160,7 +160,7 @@ mod test_from_z_modulus {
     #[test]
     fn working_small() {
         let value = Z::from(10);
-        let modulus = Modulus::try_from(&Z::from(15)).unwrap();
+        let modulus = Modulus::from(&Z::from(15));
 
         let _ = Zq::from_z_modulus(&value, &modulus);
     }
@@ -169,7 +169,7 @@ mod test_from_z_modulus {
     #[test]
     fn working_large() {
         let value = Z::from(u64::MAX - 1);
-        let modulus = Modulus::try_from(&Z::from(u64::MAX)).unwrap();
+        let modulus = Modulus::from(&Z::from(u64::MAX));
 
         let _ = Zq::from_z_modulus(&value, &modulus);
     }

--- a/src/integer_mod_q/z_q/get.rs
+++ b/src/integer_mod_q/z_q/get.rs
@@ -84,7 +84,7 @@ mod test_get_value {
 
 #[cfg(test)]
 mod test_get_mod {
-    use super::{Modulus, Zq, Z};
+    use super::{Modulus, Zq};
 
     /// Check whether `get_mod` outputs the correct modulus for small moduli
     #[test]
@@ -93,7 +93,7 @@ mod test_get_mod {
 
         let modulus = value.get_mod();
 
-        assert_eq!(modulus, Modulus::try_from(&Z::from(20)).unwrap());
+        assert_eq!(modulus, Modulus::from(20));
     }
 
     /// Check whether `get_mod` outputs the correct modulus for large moduli
@@ -103,6 +103,6 @@ mod test_get_mod {
 
         let modulus = value.get_mod();
 
-        assert_eq!(modulus, Modulus::try_from(&Z::from(u64::MAX)).unwrap());
+        assert_eq!(modulus, Modulus::from(u64::MAX));
     }
 }

--- a/src/integer_mod_q/z_q/get.rs
+++ b/src/integer_mod_q/z_q/get.rs
@@ -23,7 +23,7 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     /// use qfall_math::integer::Z;
-    /// let zq_value = Zq::try_from((4, 7)).unwrap();
+    /// let zq_value = Zq::from((4, 7));
     ///
     /// let z_value = zq_value.get_value();
     ///
@@ -39,7 +39,7 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::{Zq, Modulus};
     /// use std::str::FromStr;
-    /// let value = Zq::try_from((4, 7)).unwrap();
+    /// let value = Zq::from((4, 7));
     /// let cmp = Modulus::from_str("7").unwrap();
     ///
     /// let modulus = value.get_mod();
@@ -58,8 +58,8 @@ mod test_get_value {
     /// Check whether `get_value` outputs the correct value for small values
     #[test]
     fn get_small() {
-        let value_0 = Zq::try_from((2, 20)).unwrap();
-        let value_1 = Zq::try_from((-2, 20)).unwrap();
+        let value_0 = Zq::from((2, 20));
+        let value_1 = Zq::from((-2, 20));
 
         let res_0 = value_0.get_value();
         let res_1 = value_1.get_value();
@@ -71,8 +71,8 @@ mod test_get_value {
     /// Check whether `get_value` outputs the correct value for large values
     #[test]
     fn get_large() {
-        let value_0 = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
-        let value_1 = Zq::try_from((i64::MIN, u64::MAX)).unwrap();
+        let value_0 = Zq::from((i64::MAX, u64::MAX));
+        let value_1 = Zq::from((i64::MIN, u64::MAX));
 
         let res_0 = value_0.get_value();
         let res_1 = value_1.get_value();
@@ -89,7 +89,7 @@ mod test_get_mod {
     /// Check whether `get_mod` outputs the correct modulus for small moduli
     #[test]
     fn get_small() {
-        let value = Zq::try_from((2, 20)).unwrap();
+        let value = Zq::from((2, 20));
 
         let modulus = value.get_mod();
 
@@ -99,7 +99,7 @@ mod test_get_mod {
     /// Check whether `get_mod` outputs the correct modulus for large moduli
     #[test]
     fn get_large() {
-        let value = Zq::try_from((2, u64::MAX)).unwrap();
+        let value = Zq::from((2, u64::MAX));
 
         let modulus = value.get_mod();
 

--- a/src/integer_mod_q/z_q/get.rs
+++ b/src/integer_mod_q/z_q/get.rs
@@ -40,7 +40,7 @@ impl Zq {
     /// use qfall_math::integer_mod_q::{Zq, Modulus};
     /// use std::str::FromStr;
     /// let value = Zq::from((4, 7));
-    /// let cmp = Modulus::from_str("7").unwrap();
+    /// let cmp = Modulus::from(7);
     ///
     /// let modulus = value.get_mod();
     ///

--- a/src/integer_mod_q/z_q/properties.rs
+++ b/src/integer_mod_q/z_q/properties.rs
@@ -111,7 +111,7 @@ mod test_is_zero {
     /// Ensure that is_zero returns `true` for `0`.
     #[test]
     fn zero_detection() {
-        let zero = Zq::from_str("0 mod 7").unwrap();
+        let zero = Zq::from((0, 7));
 
         assert!(zero.is_zero());
     }
@@ -136,7 +136,7 @@ mod test_is_one {
     /// Ensure that is_one returns `true` for `1`.
     #[test]
     fn one_detection() {
-        let one = Zq::from_str("8 mod 7").unwrap();
+        let one = Zq::from((8, 7));
 
         assert!(one.is_one());
     }
@@ -144,7 +144,7 @@ mod test_is_one {
     /// Ensure that is_one returns `false` for other values.
     #[test]
     fn one_rejection() {
-        let small = Zq::from_str("12 mod 7").unwrap();
+        let small = Zq::from((12, 7));
         let large =
             Zq::from_str(&format!("{} mod {}", (u128::MAX - 1) / 2 + 2, u128::MAX)).unwrap();
 

--- a/src/integer_mod_q/z_q/properties.rs
+++ b/src/integer_mod_q/z_q/properties.rs
@@ -19,11 +19,11 @@ impl Zq {
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
-    /// let value = Zq::try_from((4, 7)).unwrap();
+    /// let value = Zq::from((4, 7));
     ///
     /// let inverse = value.inverse().unwrap();
     ///
-    /// assert_eq!(Zq::try_from((2, 7)).unwrap(), inverse);
+    /// assert_eq!(Zq::from((2, 7)), inverse);
     /// ```
     pub fn inverse(&self) -> Option<Zq> {
         self.pow(-1).ok()
@@ -37,7 +37,7 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let value = Zq::try_from((0,7)).unwrap();
+    /// let value = Zq::from((0,7));
     /// assert!(value.is_zero());
     /// ```
     pub fn is_zero(&self) -> bool {
@@ -52,7 +52,7 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let value = Zq::try_from((1,7)).unwrap();
+    /// let value = Zq::from((1,7));
     /// assert!(value.is_one());
     /// ```
     pub fn is_one(&self) -> bool {
@@ -67,41 +67,35 @@ mod test_inv {
     /// Checks whether the inverse is correctly computed for small values.
     #[test]
     fn small_values() {
-        let val_0 = Zq::try_from((4, 7)).unwrap();
-        let val_1 = Zq::try_from((-2, 7)).unwrap();
+        let val_0 = Zq::from((4, 7));
+        let val_1 = Zq::from((-2, 7));
 
         let inv_0 = val_0.inverse().unwrap();
         let inv_1 = val_1.inverse().unwrap();
 
-        assert_eq!(Zq::try_from((2, 7)).unwrap(), inv_0);
-        assert_eq!(Zq::try_from((3, 7)).unwrap(), inv_1);
+        assert_eq!(Zq::from((2, 7)), inv_0);
+        assert_eq!(Zq::from((3, 7)), inv_1);
     }
 
     /// Checks whether the inverse is correctly computed for large values.
     #[test]
     fn large_values() {
-        let val_0 = Zq::try_from((i64::MAX, u64::MAX)).unwrap();
-        let val_1 = Zq::try_from((i64::MIN, u64::MAX)).unwrap();
+        let val_0 = Zq::from((i64::MAX, u64::MAX));
+        let val_1 = Zq::from((i64::MIN, u64::MAX));
 
         let inv_0 = val_0.inverse().unwrap();
         let inv_1 = val_1.inverse().unwrap();
 
-        assert_eq!(
-            Zq::try_from((18446744073709551613_u64, u64::MAX)).unwrap(),
-            inv_0
-        );
-        assert_eq!(
-            Zq::try_from((18446744073709551613_u64, u64::MAX)).unwrap(),
-            inv_1
-        );
+        assert_eq!(Zq::from((18446744073709551613_u64, u64::MAX)), inv_0);
+        assert_eq!(Zq::from((18446744073709551613_u64, u64::MAX)), inv_1);
     }
 
     /// Checks whether `inv` returns `None` for any values without an inverse.
     #[test]
     fn no_inverse_returns_none() {
-        let val_0 = Zq::try_from((4, 8)).unwrap();
-        let val_1 = Zq::try_from((3, 9)).unwrap();
-        let val_2 = Zq::try_from((0, 7)).unwrap();
+        let val_0 = Zq::from((4, 8));
+        let val_1 = Zq::from((3, 9));
+        let val_2 = Zq::from((0, 7));
 
         assert!(val_0.inverse().is_none());
         assert!(val_1.inverse().is_none());

--- a/src/integer_mod_q/z_q/reduce.rs
+++ b/src/integer_mod_q/z_q/reduce.rs
@@ -51,18 +51,17 @@ mod test_reduce {
         integer::Z,
         integer_mod_q::{Modulus, Zq},
     };
-    use std::str::FromStr;
 
     const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that large entries are reduced correctly
     #[test]
     fn reduces_large() {
-        let modulus = Modulus::from_str(&format!("{}", LARGE_PRIME)).unwrap();
-        let value = Z::from_str(&format!("{}", u64::MAX)).unwrap();
+        let modulus = Modulus::from(LARGE_PRIME);
+        let value = Z::from(u64::MAX);
         let mut original = Zq { value, modulus };
 
-        let cmp_modulus = Modulus::from_str(&format!("{}", LARGE_PRIME)).unwrap();
+        let cmp_modulus = Modulus::from(LARGE_PRIME);
         let cmp_value = Z::from(58);
 
         let cmp = Zq {
@@ -80,11 +79,11 @@ mod test_reduce {
     /// Ensure that small entries are reduced correctly
     #[test]
     fn reduces_small() {
-        let modulus = Modulus::from_str("17").unwrap();
+        let modulus = Modulus::from(17);
         let value = Z::from(20);
         let mut original = Zq { value, modulus };
 
-        let cmp_modulus = Modulus::from_str("17").unwrap();
+        let cmp_modulus = Modulus::from(17);
         let cmp_value = Z::from(3);
 
         let cmp = Zq {

--- a/src/integer_mod_q/z_q/reduce.rs
+++ b/src/integer_mod_q/z_q/reduce.rs
@@ -29,9 +29,8 @@ impl Zq {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let modulus = Modulus::from_str("17").unwrap();
-    /// let z = Z::from(18);
-    /// let mut zq = Zq::from_z_modulus(&z, &modulus);
+    /// let modulus = Modulus::from(17);
+    /// let mut zq = Zq::from((18, &modulus));
     ///
     /// zq.reduce();
     /// ```

--- a/src/integer_mod_q/z_q/reduce.rs
+++ b/src/integer_mod_q/z_q/reduce.rs
@@ -54,16 +54,16 @@ mod test_reduce {
     };
     use std::str::FromStr;
 
-    const BITPRIME64: u64 = u64::MAX - 58;
+    const LARGE_PRIME: u64 = u64::MAX - 58;
 
     /// Ensure that large entries are reduced correctly
     #[test]
     fn reduces_large() {
-        let modulus = Modulus::from_str(&format!("{}", BITPRIME64)).unwrap();
+        let modulus = Modulus::from_str(&format!("{}", LARGE_PRIME)).unwrap();
         let value = Z::from_str(&format!("{}", u64::MAX)).unwrap();
         let mut original = Zq { value, modulus };
 
-        let cmp_modulus = Modulus::from_str(&format!("{}", BITPRIME64)).unwrap();
+        let cmp_modulus = Modulus::from_str(&format!("{}", LARGE_PRIME)).unwrap();
         let cmp_value = Z::from(58);
 
         let cmp = Zq {

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -55,7 +55,6 @@ mod test_sample_uniform {
         integer::Z,
         integer_mod_q::{Modulus, Zq},
     };
-    
 
     /// Checks whether the boundaries of the interval are kept for small moduli.
     /// These should be protected by the sampling algorithm and [`Zq`]s instantiation.

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -55,7 +55,7 @@ mod test_sample_uniform {
         integer::Z,
         integer_mod_q::{Modulus, Zq},
     };
-    use std::str::FromStr;
+    
 
     /// Checks whether the boundaries of the interval are kept for small moduli.
     /// These should be protected by the sampling algorithm and [`Zq`]s instantiation.
@@ -101,7 +101,7 @@ mod test_sample_uniform {
     /// implementing Into<Z> + Clone, i.e. u8, u16, u32, u64, i8, ...
     #[test]
     fn availability() {
-        let modulus = Modulus::from_str("7").unwrap();
+        let modulus = Modulus::from(7);
         let z = Z::from(7);
 
         let _ = Zq::sample_uniform(&7u8);

--- a/src/integer_mod_q/z_q/to_string.rs
+++ b/src/integer_mod_q/z_q/to_string.rs
@@ -26,8 +26,8 @@ impl fmt::Display for Zq {
     /// use std::str::FromStr;
     /// use core::fmt;
     ///
-    /// let integer = Zq::from_str("42 mod 3").unwrap();
-    /// println!("{}", integer);
+    /// let integer_mod_q = Zq::from((42, 3));
+    /// println!("{}", integer_mod_q);
     /// ```
     ///
     /// ```
@@ -35,8 +35,8 @@ impl fmt::Display for Zq {
     /// use std::str::FromStr;
     /// use core::fmt;
     ///
-    /// let integer = Zq::from_str("42 mod 3").unwrap();
-    /// let integer_string = integer.to_string();
+    /// let integer_mod_q = Zq::from((42, 3));
+    /// let integer_string = integer_mod_q.to_string();
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} mod {}", self.value, self.modulus)
@@ -85,7 +85,7 @@ mod test_to_string {
     /// string that can be used to create a [`Zq`]
     #[test]
     fn working_use_result_of_to_string_as_input() {
-        let cmp = Zq::from_str("42 mod 10").unwrap();
+        let cmp = Zq::from((42, 10));
 
         let cmp_string = cmp.to_string();
 

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -223,7 +223,7 @@ macro_rules! arithmetic_between_types_zq {
                 paste::paste! {
                     #[doc = "Documentation at [`Zq::" $trait_function "`]."]
                     fn $trait_function(self, other: &$other_type) -> Self::Output {
-                    self.$trait_function(Zq::from_z_modulus(&Z::from(*other),&self.modulus))
+                    self.$trait_function(Zq::from((*other,&self.modulus)))
                     }
                 }
             }
@@ -237,7 +237,7 @@ macro_rules! arithmetic_between_types_zq {
                 paste::paste! {
                     #[doc = "Documentation at [`Zq::" $trait_function "`]."]
                     fn $trait_function(self, other: &Zq) -> Self::Output {
-                    other.$trait_function(Zq::from_z_modulus(&Z::from(*self),&other.modulus))
+                    other.$trait_function(Zq::from((*self,&other.modulus)))
                     }
                 }
             }

--- a/src/rational/mat_q.rs
+++ b/src/rational/mat_q.rs
@@ -54,10 +54,10 @@ mod vector;
 ///
 /// // clone object, set and get entry
 /// let mut clone = id_mat.clone();
-/// clone.set_entry(0, 0, Q::try_from((&2, &1)).unwrap());
+/// clone.set_entry(0, 0, Q::from(2));
 /// assert_eq!(
 ///     clone.get_entry(1, 1).unwrap(),
-///     Q::try_from((&1, &1)).unwrap()
+///     Q::ONE
 /// );
 ///
 /// // to_string

--- a/src/rational/mat_q/arithmetic/add.rs
+++ b/src/rational/mat_q/arithmetic/add.rs
@@ -41,8 +41,8 @@ impl Add for &MatQ {
     /// let f: MatQ = c + &e;
     /// ```
     ///
-    /// # Panics
-    /// - Panics if the dimensions of both matrices mismatch
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
     fn add(self, other: Self) -> Self::Output {
         self.add_safe(other).unwrap()
     }

--- a/src/rational/mat_q/arithmetic/add.rs
+++ b/src/rational/mat_q/arithmetic/add.rs
@@ -154,8 +154,7 @@ mod test_add {
             MatQ::from_str(&format!(
                 "[[2, 4, -{}],[6, 5, {}]]",
                 u64::MAX,
-                Q::from_str(format!("{}", i64::MAX).as_str()).unwrap()
-                    + Q::from_str(format!("1/{}", i64::MAX).as_str()).unwrap()
+                Q::from(i64::MAX) + Q::from((1, i64::MAX))
             ))
             .unwrap()
         );

--- a/src/rational/mat_q/arithmetic/mul.rs
+++ b/src/rational/mat_q/arithmetic/mul.rs
@@ -176,13 +176,9 @@ mod test_mul {
         let mat = MatQ::from_str(&format!("[[{},1],[0,2]]", i64::MAX)).unwrap();
         let vec = MatQ::from_str(&format!("[[1/{}],[0]]", i64::MAX)).unwrap();
         let mut cmp = MatQ::new(2, 1);
-        let max: Q = Q::from_str(format!("{}", i64::MAX).as_str()).unwrap();
-        cmp.set_entry(
-            0,
-            0,
-            &(&max * Q::from_str(format!("1/{}", i64::MAX).as_str()).unwrap()),
-        )
-        .unwrap();
+        let max: Q = Q::from(i64::MAX);
+        cmp.set_entry(0, 0, &(&max * Q::from((1, i64::MAX))))
+            .unwrap();
 
         assert_eq!(cmp, mat * vec);
     }

--- a/src/rational/mat_q/arithmetic/mul.rs
+++ b/src/rational/mat_q/arithmetic/mul.rs
@@ -46,7 +46,7 @@ impl Mul for &MatQ {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the dimensions of `self` and `other` do not match for multiplication.
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
     fn mul(self, other: Self) -> Self::Output {
         self.mul_safe(other).unwrap()
     }
@@ -82,8 +82,8 @@ impl Mul<&MatZ> for &MatQ {
     /// let f = c * &e;
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Panics if the dimensions of `self` and `other` do not match for multiplication.
+    /// # Panics ...
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
     fn mul(self, other: &MatZ) -> Self::Output {
         if self.get_num_columns() != other.get_num_rows() {
             panic!("Tried to multiply matrices with mismatching matrix dimensions.");

--- a/src/rational/mat_q/arithmetic/mul_scalar.rs
+++ b/src/rational/mat_q/arithmetic/mul_scalar.rs
@@ -225,7 +225,7 @@ mod test_mul_q {
         let mat1 = MatQ::from_str("[[2/3,1],[1/2,2]]").unwrap();
         let mat2 = mat1.clone();
         let mat3 = MatQ::from_str("[[1,3/2],[3/4,3]]").unwrap();
-        let rational = Q::try_from((&3, &2)).unwrap();
+        let rational = Q::from((3, 2));
 
         let mat1 = &mat1 * &rational;
         let mat2 = &mat2 * &rational;
@@ -240,8 +240,8 @@ mod test_mul_q {
         let mat1 = MatQ::from_str("[[2/3,1],[1/2,2]]").unwrap();
         let mat2 = mat1.clone();
         let mat3 = MatQ::from_str("[[1,3/2],[3/4,3]]").unwrap();
-        let rational1 = Q::try_from((&3, &2)).unwrap();
-        let rational2 = Q::try_from((&3, &2)).unwrap();
+        let rational1 = Q::from((3, 2));
+        let rational2 = Q::from((3, 2));
 
         let mat1 = mat1 * rational1;
         let mat2 = rational2 * mat2;
@@ -258,8 +258,8 @@ mod test_mul_q {
         let mat3 = mat1.clone();
         let mat4 = mat1.clone();
         let mat5 = MatQ::from_str("[[1,3/2],[3/4,3]]").unwrap();
-        let rational1 = Q::try_from((&3, &2)).unwrap();
-        let rational2 = Q::try_from((&3, &2)).unwrap();
+        let rational1 = Q::from((3, 2));
+        let rational2 = Q::from((3, 2));
 
         let mat1 = mat1 * &rational1;
         let mat2 = &rational2 * mat2;
@@ -294,7 +294,7 @@ mod test_mul_q {
         let mat2 = MatQ::from_str("[[2,5/8,6],[1,3,1/7]]").unwrap();
         let mat3 = MatQ::from_str("[[3/4],[0],[6]]").unwrap();
         let mat4 = MatQ::from_str("[[3,15/16,9],[3/2,9/2,3/14]]").unwrap();
-        let rational = Q::try_from((&3, &2)).unwrap();
+        let rational = Q::from((3, 2));
 
         assert_eq!(mat3, &rational * mat1);
         assert_eq!(mat4, rational * mat2);
@@ -313,9 +313,9 @@ mod test_mul_q {
         .unwrap();
         let mat4 = MatQ::from_str(&format!("[[{}/2]]", 3 * i64::MAX as i128)).unwrap();
         let mat5 = MatQ::from_str(&format!("[[6/{}]]", i64::MAX)).unwrap();
-        let rational1 = Q::try_from((&3, &2)).unwrap();
-        let rational2 = Q::try_from((&i64::MAX, &2)).unwrap();
-        let rational3 = Q::try_from((&2, &i64::MAX)).unwrap();
+        let rational1 = Q::from((3, 2));
+        let rational2 = Q::from((i64::MAX, 2));
+        let rational3 = Q::from((2, i64::MAX));
 
         assert_eq!(mat3, rational1 * mat1);
         assert_eq!(mat4, rational2 * &mat2);

--- a/src/rational/mat_q/arithmetic/sub.rs
+++ b/src/rational/mat_q/arithmetic/sub.rs
@@ -150,8 +150,7 @@ mod test_sub {
             MatQ::from_str(&format!(
                 "[[0, 1, -{}],[0, -13, {}]]",
                 u64::MAX,
-                Q::from_str(format!("{}", u64::MAX).as_str()).unwrap()
-                    - Q::from_str(format!("1/{}", i64::MAX).as_str()).unwrap()
+                Q::from(u64::MAX) - Q::from((1, i64::MAX))
             ))
             .unwrap()
         );

--- a/src/rational/mat_q/arithmetic/sub.rs
+++ b/src/rational/mat_q/arithmetic/sub.rs
@@ -41,8 +41,8 @@ impl Sub for &MatQ {
     /// let f: MatQ = c - &e;
     /// ```
     ///
-    /// # Panics
-    /// - Panics if the dimensions of both matrices mismatch
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
     fn sub(self, other: Self) -> Self::Output {
         self.sub_safe(other).unwrap()
     }

--- a/src/rational/mat_q/cmp.rs
+++ b/src/rational/mat_q/cmp.rs
@@ -61,7 +61,7 @@ mod test_partial_eq {
     fn equality_between_instantiations() {
         let a = MatQ::from_str("[[0,1/2],[0/2,0]]").unwrap();
         let mut b = MatQ::new(2, 2);
-        b.set_entry(0, 1, Q::from_str("2/4").unwrap()).unwrap();
+        b.set_entry(0, 1, Q::from((2, 4))).unwrap();
 
         assert_eq!(a, b);
     }

--- a/src/rational/mat_q/determinant.rs
+++ b/src/rational/mat_q/determinant.rs
@@ -68,7 +68,7 @@ mod test_determinant {
 
         let cmp1 = Q::ONE;
         let cmp2 = Q::from(i64::MAX);
-        let cmp3 = Q::try_from((&-1, &i64::MIN)).unwrap();
+        let cmp3 = Q::from((-1, i64::MIN));
         let cmp4 = Q::ZERO;
         let cmp5 = Q::from(17);
 

--- a/src/rational/mat_q/from.rs
+++ b/src/rational/mat_q/from.rs
@@ -128,7 +128,7 @@ impl From<&MatZ> for MatQ {
 #[cfg(test)]
 mod test_from_mat_zq {
     use crate::{
-        integer::{MatZ, Z},
+        integer::MatZ,
         rational::{MatQ, Q},
         traits::{GetEntry, GetNumColumns, GetNumRows, SetEntry},
     };
@@ -157,16 +157,10 @@ mod test_from_mat_zq {
         let matq_1 = MatQ::from(&matz);
         let matq_2 = MatQ::from_mat_z(&matz);
 
-        assert_eq!(Q::from(Z::from(i64::MIN)), matq_1.get_entry(0, 1).unwrap());
-        assert_eq!(
-            Q::from(Z::from(u64::MAX - 58)),
-            matq_1.get_entry(0, 0).unwrap()
-        );
-        assert_eq!(Q::from(Z::from(i64::MIN)), matq_2.get_entry(0, 1).unwrap());
-        assert_eq!(
-            Q::from(Z::from(u64::MAX - 58)),
-            matq_2.get_entry(0, 0).unwrap()
-        );
+        assert_eq!(Q::from(i64::MIN), matq_1.get_entry(0, 1).unwrap());
+        assert_eq!(Q::from(u64::MAX - 58), matq_1.get_entry(0, 0).unwrap());
+        assert_eq!(Q::from(i64::MIN), matq_2.get_entry(0, 1).unwrap());
+        assert_eq!(Q::from(u64::MAX - 58), matq_2.get_entry(0, 0).unwrap());
     }
 }
 

--- a/src/rational/mat_q/from.rs
+++ b/src/rational/mat_q/from.rs
@@ -185,7 +185,7 @@ mod test_from_str {
         let matrix_str1 = "[[1/2,2/3,3/4],[4/5,5/6,6/7]]";
 
         assert_eq!(
-            Q::from_str("1/2").unwrap(),
+            Q::from((1, 2)),
             MatQ::from_str(matrix_str1)
                 .unwrap()
                 .get_entry(0, 0)
@@ -283,7 +283,7 @@ mod test_from_str {
         let matrix_str1 = "[[  1/2, 2/3 ,  3/4  ],[3/4 ,4/5,5/6 ]]";
 
         assert_eq!(
-            Q::from_str("1/2").unwrap(),
+            Q::from((1, 2)),
             MatQ::from_str(matrix_str1)
                 .unwrap()
                 .get_entry(0, 0)

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -227,7 +227,7 @@ mod test_get_entry {
     #[test]
     fn max_int_positive() {
         let mut matrix = MatQ::new(5, 10);
-        let value1 = Q::from((i64::MAX, 1));
+        let value1 = Q::from(i64::MAX);
         let value2 = Q::from((1, i64::MAX));
         matrix.set_entry(0, 0, value1).unwrap();
         matrix.set_entry(1, 1, value2).unwrap();
@@ -326,7 +326,7 @@ mod test_get_entry {
         let value = Q::from(u64::MAX);
         matrix.set_entry(1, 1, value).unwrap();
         let entry = matrix.get_entry(1, 1).unwrap();
-        matrix.set_entry(1, 1, Q::from(0)).unwrap();
+        matrix.set_entry(1, 1, Q::ZERO).unwrap();
 
         assert_eq!(Q::from(u64::MAX), entry);
     }

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -227,48 +227,48 @@ mod test_get_entry {
     #[test]
     fn max_int_positive() {
         let mut matrix = MatQ::new(5, 10);
-        let value1 = Q::from_str(&format!("{}/1", i64::MAX)).unwrap();
-        let value2 = Q::from_str(&format!("1/{}", i64::MAX)).unwrap();
+        let value1 = Q::from((i64::MAX, 1));
+        let value2 = Q::from((1, i64::MAX));
         matrix.set_entry(0, 0, value1).unwrap();
         matrix.set_entry(1, 1, value2).unwrap();
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(1, 1).unwrap();
 
-        assert_eq!(Q::from_str(&format!("{}", i64::MAX)).unwrap(), entry1);
-        assert_eq!(Q::from_str(&format!("1/{}", i64::MAX)).unwrap(), entry2);
+        assert_eq!(Q::from(i64::MAX), entry1);
+        assert_eq!(Q::from((1, i64::MAX)), entry2);
     }
 
     /// Ensure that getting entries works with large numerators and denominators (larger than [`i64`]).
     #[test]
     fn big_positive() {
         let mut matrix = MatQ::new(5, 10);
-        let value1 = Q::from_str(&format!("{}", u64::MAX)).unwrap();
-        let value2 = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let value1 = Q::from(u64::MAX);
+        let value2 = Q::from((1, u64::MAX));
         matrix.set_entry(0, 0, value1).unwrap();
         matrix.set_entry(1, 1, value2).unwrap();
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(1, 1).unwrap();
 
-        assert_eq!(Q::from_str(&format!("{}", u64::MAX)).unwrap(), entry1);
-        assert_eq!(Q::from_str(&format!("1/{}", u64::MAX)).unwrap(), entry2);
+        assert_eq!(Q::from(u64::MAX), entry1);
+        assert_eq!(Q::from((1, u64::MAX)), entry2);
     }
 
     /// Ensure that getting entries works with large negative numerators and denominators.
     #[test]
     fn max_int_negative() {
         let mut matrix = MatQ::new(5, 10);
-        let value1 = Q::from_str(&format!("{}", i64::MIN)).unwrap();
-        let value2 = Q::from_str(&format!("1/{}", i64::MIN)).unwrap();
+        let value1 = Q::from(i64::MIN);
+        let value2 = Q::from((1, i64::MIN));
         matrix.set_entry(0, 0, value1).unwrap();
         matrix.set_entry(1, 1, value2).unwrap();
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(1, 1).unwrap();
 
-        assert_eq!(Q::from_str(&format!("{}", i64::MIN)).unwrap(), entry1);
-        assert_eq!(Q::from_str(&format!("1/{}", i64::MIN)).unwrap(), entry2);
+        assert_eq!(Q::from(i64::MIN), entry1);
+        assert_eq!(Q::from((1, i64::MIN)), entry2);
     }
 
     /// Ensure that getting entries works with large negative numerators and denominators (larger than [`i64`]).
@@ -295,12 +295,12 @@ mod test_get_entry {
     #[test]
     fn getting_at_zero() {
         let mut matrix = MatQ::new(5, 10);
-        let value = Q::from_str(&format!("{}", i64::MIN)).unwrap();
+        let value = Q::from(i64::MIN);
         matrix.set_entry(0, 0, value).unwrap();
 
         let entry = matrix.get_entry(0, 0).unwrap();
 
-        assert_eq!(entry, Q::from_str(&format!("{}", i64::MIN)).unwrap());
+        assert_eq!(entry, Q::from(i64::MIN));
     }
 
     /// Ensure that a wrong number of rows yields an Error.
@@ -323,12 +323,12 @@ mod test_get_entry {
     #[test]
     fn memory_test() {
         let mut matrix = MatQ::new(5, 10);
-        let value = Q::from_str(&format!("{}", u64::MAX)).unwrap();
+        let value = Q::from(u64::MAX);
         matrix.set_entry(1, 1, value).unwrap();
         let entry = matrix.get_entry(1, 1).unwrap();
-        matrix.set_entry(1, 1, Q::from_str("0/1").unwrap()).unwrap();
+        matrix.set_entry(1, 1, Q::from(0)).unwrap();
 
-        assert_eq!(Q::from_str(&format!("{}", u64::MAX)).unwrap(), entry);
+        assert_eq!(Q::from(u64::MAX), entry);
     }
 }
 

--- a/src/rational/mat_q/ownership.rs
+++ b/src/rational/mat_q/ownership.rs
@@ -92,7 +92,7 @@ mod test_clone {
         assert_eq!(a.get_entry(0, 0).unwrap(), Q::from((1, 2)));
         assert_eq!(a.get_entry(0, 1).unwrap(), Q::from((2, 3)));
         assert_eq!(a.get_entry(0, 2).unwrap(), Q::from((3, 4)));
-        assert_eq!(a.get_entry(1, 0).unwrap(), Q::from((3, 1)));
+        assert_eq!(a.get_entry(1, 0).unwrap(), Q::from(3));
         assert_eq!(a.get_entry(1, 1).unwrap(), Q::from((4, 2)));
         assert_eq!(a.get_entry(1, 2).unwrap(), Q::from((5, 4)));
     }

--- a/src/rational/mat_q/ownership.rs
+++ b/src/rational/mat_q/ownership.rs
@@ -89,12 +89,12 @@ mod test_clone {
         assert_eq!(a.get_num_rows(), 2);
         assert_eq!(a.get_num_columns(), 3);
 
-        assert_eq!(a.get_entry(0, 0).unwrap(), Q::from_str("1/2").unwrap());
-        assert_eq!(a.get_entry(0, 1).unwrap(), Q::from_str("2/3").unwrap());
-        assert_eq!(a.get_entry(0, 2).unwrap(), Q::from_str("3/4").unwrap());
-        assert_eq!(a.get_entry(1, 0).unwrap(), Q::from_str("3/1").unwrap());
-        assert_eq!(a.get_entry(1, 1).unwrap(), Q::from_str("4/2").unwrap());
-        assert_eq!(a.get_entry(1, 2).unwrap(), Q::from_str("5/4").unwrap());
+        assert_eq!(a.get_entry(0, 0).unwrap(), Q::from((1, 2)));
+        assert_eq!(a.get_entry(0, 1).unwrap(), Q::from((2, 3)));
+        assert_eq!(a.get_entry(0, 2).unwrap(), Q::from((3, 4)));
+        assert_eq!(a.get_entry(1, 0).unwrap(), Q::from((3, 1)));
+        assert_eq!(a.get_entry(1, 1).unwrap(), Q::from((4, 2)));
+        assert_eq!(a.get_entry(1, 2).unwrap(), Q::from((5, 4)));
     }
 
     /// check whether the cloned large entries are stored separately

--- a/src/rational/mat_q/set.rs
+++ b/src/rational/mat_q/set.rs
@@ -49,7 +49,7 @@ impl SetEntry<&Q> for MatQ {
     /// use qfall_math::traits::*;
     ///
     /// let mut matrix = MatQ::new(5, 10);
-    /// let value = Q::from_str("5/2").unwrap();
+    /// let value = Q::from((5, 2));
     /// matrix.set_entry(1, 1, &value).unwrap();
     /// ```
     ///
@@ -381,48 +381,48 @@ mod test_setter {
     #[test]
     fn max_int_positive() {
         let mut matrix = MatQ::new(5, 10);
-        let value1 = Q::from_str(&format!("{}/1", i64::MAX)).unwrap();
-        let value2 = Q::from_str(&format!("1/{}", i64::MAX)).unwrap();
+        let value1 = Q::from((i64::MAX, 1));
+        let value2 = Q::from((1, i64::MAX));
         matrix.set_entry(0, 0, value1).unwrap();
         matrix.set_entry(1, 1, value2).unwrap();
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(1, 1).unwrap();
 
-        assert_eq!(Q::from_str(&format!("{}", i64::MAX)).unwrap(), entry1);
-        assert_eq!(Q::from_str(&format!("1/{}", i64::MAX)).unwrap(), entry2);
+        assert_eq!(Q::from(i64::MAX), entry1);
+        assert_eq!(Q::from((1, i64::MAX)), entry2);
     }
 
     /// Ensure that setting entries works with large numerators and denominators (larger than [`i64`]).
     #[test]
     fn big_positive() {
         let mut matrix = MatQ::new(5, 10);
-        let value1 = Q::from_str(&format!("{}", u64::MAX)).unwrap();
-        let value2 = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let value1 = Q::from(u64::MAX);
+        let value2 = Q::from((1, u64::MAX));
         matrix.set_entry(0, 0, value1).unwrap();
         matrix.set_entry(1, 1, value2).unwrap();
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(1, 1).unwrap();
 
-        assert_eq!(Q::from_str(&format!("{}", u64::MAX)).unwrap(), entry1);
-        assert_eq!(Q::from_str(&format!("1/{}", u64::MAX)).unwrap(), entry2);
+        assert_eq!(Q::from(u64::MAX), entry1);
+        assert_eq!(Q::from((1, u64::MAX)), entry2);
     }
 
     /// Ensure that setting entries works with large negative numerators and denominators.
     #[test]
     fn max_int_negative() {
         let mut matrix = MatQ::new(5, 10);
-        let value1 = Q::from_str(&format!("{}", i64::MIN)).unwrap();
-        let value2 = Q::from_str(&format!("1/{}", i64::MIN)).unwrap();
+        let value1 = Q::from(i64::MIN);
+        let value2 = Q::from((1, i64::MIN));
         matrix.set_entry(0, 0, value1).unwrap();
         matrix.set_entry(1, 1, value2).unwrap();
 
         let entry1 = matrix.get_entry(0, 0).unwrap();
         let entry2 = matrix.get_entry(1, 1).unwrap();
 
-        assert_eq!(Q::from_str(&format!("{}", i64::MIN)).unwrap(), entry1);
-        assert_eq!(Q::from_str(&format!("1/{}", i64::MIN)).unwrap(), entry2);
+        assert_eq!(Q::from(i64::MIN), entry1);
+        assert_eq!(Q::from((1, i64::MIN)), entry2);
     }
 
     /// Ensure that setting entries works with large negative numerators and denominators (larger than [`i64`]).
@@ -449,12 +449,12 @@ mod test_setter {
     #[test]
     fn getting_at_zero() {
         let mut matrix = MatQ::new(5, 10);
-        let value = Q::from_str(&format!("{}", i64::MIN)).unwrap();
+        let value = Q::from(i64::MIN);
         matrix.set_entry(0, 0, value).unwrap();
 
         let entry = matrix.get_entry(0, 0).unwrap();
 
-        assert_eq!(entry, Q::from_str(&format!("{}", i64::MIN)).unwrap());
+        assert_eq!(entry, Q::from(i64::MIN));
     }
 
     /// Ensure that a wrong number of rows yields an Error.

--- a/src/rational/mat_q/set.rs
+++ b/src/rational/mat_q/set.rs
@@ -381,7 +381,7 @@ mod test_setter {
     #[test]
     fn max_int_positive() {
         let mut matrix = MatQ::new(5, 10);
-        let value1 = Q::from((i64::MAX, 1));
+        let value1 = Q::from(i64::MAX);
         let value2 = Q::from((1, i64::MAX));
         matrix.set_entry(0, 0, value1).unwrap();
         matrix.set_entry(1, 1, value2).unwrap();

--- a/src/rational/mat_q/trace.rs
+++ b/src/rational/mat_q/trace.rs
@@ -62,8 +62,8 @@ mod test_trace {
         let trace1 = mat1.trace().unwrap();
         let trace2 = mat2.trace().unwrap();
 
-        assert_eq!(Q::try_from((&10, &3)).unwrap(), trace1);
-        assert_eq!(Q::try_from((&0, &1)).unwrap(), trace2);
+        assert_eq!(Q::from((10, 3)), trace1);
+        assert_eq!(Q::ZERO, trace2);
     }
 
     /// Test whether `trace` works for big values
@@ -77,12 +77,9 @@ mod test_trace {
         let trace2 = mat2.trace().unwrap();
         let trace3 = mat3.trace().unwrap();
 
-        assert_eq!(Q::try_from((&(2 * i64::MAX as u64), &1)).unwrap(), trace1);
-        assert_eq!(Q::try_from((&i64::MIN, &1)).unwrap(), trace2);
-        assert_eq!(
-            Q::try_from((&i64::MIN, &1)).unwrap() + Q::try_from((&1, &i64::MAX)).unwrap(),
-            trace3
-        );
+        assert_eq!(Q::from(2 * i64::MAX as u64), trace1);
+        assert_eq!(Q::from(i64::MIN), trace2);
+        assert_eq!(Q::from(i64::MIN) + Q::from((1, i64::MAX)), trace3);
     }
 
     /// Ensure that a matrix that is not square yields an error.

--- a/src/rational/mat_q/vector/dot_product.rs
+++ b/src/rational/mat_q/vector/dot_product.rs
@@ -137,7 +137,7 @@ mod test_dot_product {
     fn large_numbers() {
         let vec_1 = MatQ::from_str(&format!("[[1,-1,{}]]", i64::MAX)).unwrap();
         let vec_2 = MatQ::from_str(&format!("[[1,{},1]]", i64::MIN)).unwrap();
-        let cmp = Q::MINUS_ONE * Q::from(i64::MIN) + Q::from(i64::MAX) + Q::from(1);
+        let cmp = -1 * Q::from(i64::MIN) + Q::from(i64::MAX) + 1;
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 

--- a/src/rational/mat_q/vector/dot_product.rs
+++ b/src/rational/mat_q/vector/dot_product.rs
@@ -93,7 +93,7 @@ mod test_dot_product {
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 
-        assert_eq!(dot_prod, Q::from_str("1/2").unwrap());
+        assert_eq!(dot_prod, Q::from((1, 2)));
     }
 
     /// Check whether the dot product is calculated correctly for the combination:
@@ -105,7 +105,7 @@ mod test_dot_product {
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 
-        assert_eq!(dot_prod, Q::from_str("1/2").unwrap());
+        assert_eq!(dot_prod, Q::from((1, 2)));
     }
 
     /// Check whether the dot product is calculated correctly for the combination:
@@ -117,7 +117,7 @@ mod test_dot_product {
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 
-        assert_eq!(dot_prod, Q::from_str("1/2").unwrap());
+        assert_eq!(dot_prod, Q::from((1, 2)));
     }
 
     /// Check whether the dot product is calculated correctly for the combination:
@@ -129,7 +129,7 @@ mod test_dot_product {
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 
-        assert_eq!(dot_prod, Q::from_str("1/2").unwrap());
+        assert_eq!(dot_prod, Q::from((1, 2)));
     }
 
     /// Check whether the dot product is calculated correctly with large numbers
@@ -137,9 +137,7 @@ mod test_dot_product {
     fn large_numbers() {
         let vec_1 = MatQ::from_str(&format!("[[1,-1,{}]]", i64::MAX)).unwrap();
         let vec_2 = MatQ::from_str(&format!("[[1,{},1]]", i64::MIN)).unwrap();
-        let cmp = Q::MINUS_ONE * Q::from_str(&format!("{}", i64::MIN)).unwrap()
-            + Q::from_str(&format!("{}", i64::MAX)).unwrap()
-            + Q::from(1);
+        let cmp = Q::MINUS_ONE * Q::from(i64::MIN) + Q::from(i64::MAX) + Q::from(1);
 
         let dot_prod = vec_1.dot_product(&vec_2).unwrap();
 

--- a/src/rational/mat_q/vector/norm.rs
+++ b/src/rational/mat_q/vector/norm.rs
@@ -30,7 +30,7 @@ impl MatQ {
     /// let sqrd_2_norm = vec.norm_eucl_sqrd().unwrap();
     ///
     /// // 1*1 + 2*2 + 3*3 = 14
-    /// assert_eq!(Q::try_from((&14, &1)).unwrap(), sqrd_2_norm);
+    /// assert_eq!(Q::from(14), sqrd_2_norm);
     /// ```
     ///
     /// Errors and Failures
@@ -69,7 +69,7 @@ impl MatQ {
     /// let infty_norm = vec.norm_infty().unwrap();
     ///
     /// // max { 1, 2, 3 } = 3
-    /// assert_eq!(Q::try_from((&3, &1)).unwrap(), infty_norm);
+    /// assert_eq!(Q::from(3), infty_norm);
     /// ```
     ///
     /// Errors and Failures
@@ -116,14 +116,8 @@ mod test_norm_eucl_sqrd {
         let vec_3 = MatQ::from_str("[[1,10,100, 1000]]").unwrap();
 
         assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Q::ONE);
-        assert_eq!(
-            vec_2.norm_eucl_sqrd().unwrap(),
-            Q::try_from((&10101, &1)).unwrap()
-        );
-        assert_eq!(
-            vec_3.norm_eucl_sqrd().unwrap(),
-            Q::try_from((&1010101, &1)).unwrap()
-        );
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Q::from(10101));
+        assert_eq!(vec_3.norm_eucl_sqrd().unwrap(), Q::from(1010101));
     }
 
     /// Check whether the squared euclidean norm for row vectors
@@ -131,9 +125,9 @@ mod test_norm_eucl_sqrd {
     #[test]
     fn row_vector_large_entries() {
         let vec = MatQ::from_str(&format!("[[{}/1,{}/-1, 2/1]]", i64::MAX, i64::MIN)).unwrap();
-        let max = Q::try_from((&i64::MAX, &1)).unwrap();
-        let min = Q::try_from((&i64::MIN, &1)).unwrap();
-        let cmp = &min * &min + &max * &max + Q::try_from((&4, &1)).unwrap();
+        let max = Q::from(i64::MAX);
+        let min = Q::from(i64::MIN);
+        let cmp = &min * &min + &max * &max + Q::from(4);
 
         assert_eq!(vec.norm_eucl_sqrd().unwrap(), cmp);
     }
@@ -145,14 +139,8 @@ mod test_norm_eucl_sqrd {
         let vec_1 = MatQ::from_str("[[1],[-100/10],[100]]").unwrap();
         let vec_2 = MatQ::from_str("[[1],[-10/-1],[100],[1000]]").unwrap();
 
-        assert_eq!(
-            vec_1.norm_eucl_sqrd().unwrap(),
-            Q::try_from((&10101, &1)).unwrap()
-        );
-        assert_eq!(
-            vec_2.norm_eucl_sqrd().unwrap(),
-            Q::try_from((&1010101, &1)).unwrap()
-        );
+        assert_eq!(vec_1.norm_eucl_sqrd().unwrap(), Q::from(10101));
+        assert_eq!(vec_2.norm_eucl_sqrd().unwrap(), Q::from(1010101));
     }
 
     /// Check whether the squared euclidean norm for column vectors
@@ -160,9 +148,9 @@ mod test_norm_eucl_sqrd {
     #[test]
     fn column_vector_large_entries() {
         let vec = MatQ::from_str(&format!("[[{}/-1],[-1/{}],[2]]", i64::MAX, i64::MIN)).unwrap();
-        let max = Q::try_from((&i64::MAX, &1)).unwrap();
-        let min = Q::try_from((&1, &i64::MIN)).unwrap();
-        let cmp = &min * &min + &max * &max + Q::try_from((&4, &1)).unwrap();
+        let max = Q::from(i64::MAX);
+        let min = Q::from((1, i64::MIN));
+        let cmp = &min * &min + &max * &max + Q::from(4);
 
         assert_eq!(vec.norm_eucl_sqrd().unwrap(), cmp);
     }
@@ -190,14 +178,8 @@ mod test_norm_infty {
         let vec_3 = MatQ::from_str("[[1,-10/-1,-100/1, 1000]]").unwrap();
 
         assert_eq!(vec_1.norm_infty().unwrap(), Q::ONE);
-        assert_eq!(
-            vec_2.norm_infty().unwrap(),
-            Q::try_from((&100, &1)).unwrap()
-        );
-        assert_eq!(
-            vec_3.norm_infty().unwrap(),
-            Q::try_from((&1000, &1)).unwrap()
-        );
+        assert_eq!(vec_2.norm_infty().unwrap(), Q::from(100));
+        assert_eq!(vec_3.norm_infty().unwrap(), Q::from(1000));
     }
 
     /// Check whether the infinity norm for row vectors
@@ -205,7 +187,7 @@ mod test_norm_infty {
     #[test]
     fn row_vector_large_entries() {
         let vec = MatQ::from_str(&format!("[[{}/-1,{}/1, 2]]", i64::MAX, i64::MIN)).unwrap();
-        let cmp = Q::try_from((&(-1), &1)).unwrap() * Q::try_from((&i64::MIN, &1)).unwrap();
+        let cmp = -1 * Q::from(i64::MIN);
 
         assert_eq!(vec.norm_infty().unwrap(), cmp);
     }
@@ -217,14 +199,8 @@ mod test_norm_infty {
         let vec_1 = MatQ::from_str("[[1],[100/10],[100]]").unwrap();
         let vec_2 = MatQ::from_str("[[-1/1],[10/-1],[-100/-1],[1000]]").unwrap();
 
-        assert_eq!(
-            vec_1.norm_infty().unwrap(),
-            Q::try_from((&100, &1)).unwrap()
-        );
-        assert_eq!(
-            vec_2.norm_infty().unwrap(),
-            Q::try_from((&1000, &1)).unwrap()
-        );
+        assert_eq!(vec_1.norm_infty().unwrap(), Q::from(100));
+        assert_eq!(vec_2.norm_infty().unwrap(), Q::from(1000));
     }
 
     /// Check whether the infinity norm for column vectors
@@ -232,7 +208,7 @@ mod test_norm_infty {
     #[test]
     fn column_vector_large_entries() {
         let vec = MatQ::from_str(&format!("[[{}/1],[{}],[2]]", i64::MAX, i64::MIN)).unwrap();
-        let cmp = Q::try_from((&-1, &1)).unwrap() * Q::try_from((&i64::MIN, &1)).unwrap();
+        let cmp = Q::from(-1) * Q::from(i64::MIN);
 
         assert_eq!(vec.norm_infty().unwrap(), cmp);
     }

--- a/src/rational/poly_over_q/arithmetic/add.rs
+++ b/src/rational/poly_over_q/arithmetic/add.rs
@@ -119,8 +119,7 @@ mod test_add {
             PolyOverQ::from_str(&format!(
                 "3  {} {} {}",
                 u128::from(u64::MAX) * 2,
-                (Q::from_str(&format!("{}/{}", i64::MIN, u128::MAX)).unwrap()
-                    + Q::from_str(&format!("{}", i64::MAX)).unwrap()),
+                (Q::from_str(&format!("{}/{}", i64::MIN, u128::MAX)).unwrap() + Q::from(i64::MAX)),
                 i64::MAX
             ))
             .unwrap()

--- a/src/rational/poly_over_q/arithmetic/exp.rs
+++ b/src/rational/poly_over_q/arithmetic/exp.rs
@@ -43,7 +43,6 @@ mod test_exp_series {
         traits::{Evaluate, GetCoefficient},
     };
     use flint_sys::fmpq::fmpq_get_d;
-    
 
     #[test]
     fn coefficient_set_correctly() {

--- a/src/rational/poly_over_q/arithmetic/exp.rs
+++ b/src/rational/poly_over_q/arithmetic/exp.rs
@@ -43,7 +43,7 @@ mod test_exp_series {
         traits::{Evaluate, GetCoefficient},
     };
     use flint_sys::fmpq::fmpq_get_d;
-    use std::str::FromStr;
+    
 
     #[test]
     fn coefficient_set_correctly() {
@@ -52,7 +52,7 @@ mod test_exp_series {
         let mut fac_value = Q::ONE;
         assert_eq!(fac_value, poly.get_coeff(0).unwrap());
         for i in 1..length {
-            fac_value = fac_value * Q::from_str(&format!("1/{}", i)).unwrap();
+            fac_value = fac_value * Q::from((1, i));
             assert_eq!(fac_value, poly.get_coeff(i).unwrap())
         }
     }

--- a/src/rational/poly_over_q/arithmetic/sub.rs
+++ b/src/rational/poly_over_q/arithmetic/sub.rs
@@ -131,7 +131,7 @@ mod test_sub {
             c == PolyOverQ::from_str(&format!(
                 "3  0 {} {}",
                 (Q::from_str(&format!("{}/{}", i64::MIN, u128::MAX - 126)).unwrap()
-                    - Q::from_str(&format!("{}", i64::MAX)).unwrap()),
+                    - Q::from(i64::MAX)),
                 i64::MAX
             ))
             .unwrap()

--- a/src/rational/poly_over_q/evaluate.rs
+++ b/src/rational/poly_over_q/evaluate.rs
@@ -36,7 +36,7 @@ impl Evaluate<&Q, Q> for PolyOverQ {
     /// use std::str::FromStr;
     ///
     /// let poly = PolyOverQ::from_str("5  0 1 2/3 -3/2 1").unwrap();
-    /// let value = Q::from_str("3/2").unwrap();
+    /// let value = Q::from((3, 2));
     /// let res = poly.evaluate(&value);
     /// ```
     fn evaluate(&self, value: &Q) -> Q {
@@ -65,7 +65,7 @@ impl Evaluate<&Z, Q> for PolyOverQ {
     /// use std::str::FromStr;
     ///
     /// let poly = PolyOverQ::from_str("5  0 1 2/3 -3/2 1").unwrap();
-    /// let value = Q::from_str("3/2").unwrap();
+    /// let value = Q::from((3, 2));
     /// let res = poly.evaluate(&value);
     /// ```
     fn evaluate(&self, value: &Z) -> Q {
@@ -94,9 +94,9 @@ mod test_evaluate {
     fn eval_q_working() {
         let poly = PolyOverQ::from_str("2  1 2/7").unwrap();
 
-        let res = poly.evaluate(Q::from_str("7/3").unwrap());
+        let res = poly.evaluate(Q::from((7, 3)));
 
-        assert_eq!(Q::from_str("5/3").unwrap(), res)
+        assert_eq!(Q::from((5, 3)), res)
     }
 
     /// Tests if evaluate works with negative values
@@ -104,9 +104,9 @@ mod test_evaluate {
     fn eval_q_negative() {
         let poly = PolyOverQ::from_str("2  1 2/7").unwrap();
 
-        let res = poly.evaluate(Q::from_str("-7/3").unwrap());
+        let res = poly.evaluate(Q::from((-7, 3)));
 
-        assert_eq!(Q::from_str("1/3").unwrap(), res)
+        assert_eq!(Q::from((1, 3)), res)
     }
 
     /// Tests if evaluate works with large rationals
@@ -137,7 +137,7 @@ mod test_evaluate_z {
 
         let res = poly.evaluate(Z::from(3));
 
-        assert_eq!(Q::from_str("13/7").unwrap(), res)
+        assert_eq!(Q::from((13, 7)), res)
     }
 
     /// Tests if evaluate works with negative values
@@ -147,7 +147,7 @@ mod test_evaluate_z {
 
         let res = poly.evaluate(&Z::from(-5));
 
-        assert_eq!(Q::from_str("-3/7").unwrap(), res)
+        assert_eq!(Q::from((-3, 7)), res)
     }
 
     /// Test if evaluate works with large nominators and denominators
@@ -212,9 +212,9 @@ mod test_evaluate_q {
     fn eval_q_working() {
         let poly = PolyOverQ::from_str("2  1 2/7").unwrap();
 
-        let res = poly.evaluate(&Q::from_str("7/3").unwrap());
+        let res = poly.evaluate(&Q::from((7, 3)));
 
-        assert_eq!(Q::from_str("5/3").unwrap(), res)
+        assert_eq!(Q::from((5, 3)), res)
     }
 
     /// Tests if evaluate works with negative values
@@ -222,9 +222,9 @@ mod test_evaluate_q {
     fn eval_q_negative() {
         let poly = PolyOverQ::from_str("2  1 2/7").unwrap();
 
-        let res = poly.evaluate(&Q::from_str("-7/3").unwrap());
+        let res = poly.evaluate(&Q::from((-7, 3)));
 
-        assert_eq!(Q::from_str("1/3").unwrap(), res)
+        assert_eq!(Q::from((1, 3)), res)
     }
 
     /// Tests if evaluate works with large rationals

--- a/src/rational/poly_over_q/evaluate.rs
+++ b/src/rational/poly_over_q/evaluate.rs
@@ -119,7 +119,7 @@ mod test_evaluate {
 
         let res = poly.evaluate(Q::from_str(&q_str_rev).unwrap());
 
-        assert_eq!(Q::from(1), res)
+        assert_eq!(Q::ONE, res)
     }
 }
 
@@ -237,6 +237,6 @@ mod test_evaluate_q {
 
         let res = poly.evaluate(&Q::from_str(&q_str_rev).unwrap());
 
-        assert_eq!(Q::from(1), res)
+        assert_eq!(Q::ONE, res)
     }
 }

--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -131,8 +131,8 @@ impl<T: Into<Q>> From<T> for PolyOverQ {
     /// assert_eq!(one_half.get_degree(), 0);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Panics if the provided value can not be converted into a [`Q`].
+    /// # Panics ...
+    /// - if the provided value can not be converted into a [`Q`].
     ///   For example, because of a division by zero.
     fn from(value: T) -> Self {
         let mut out = PolyOverQ::default();

--- a/src/rational/poly_over_q/get.rs
+++ b/src/rational/poly_over_q/get.rs
@@ -81,7 +81,7 @@ mod test_get_coeff {
 
         let zero_coeff = poly.get_coeff(4).unwrap();
 
-        assert_eq!(Q::from((0, 1)), zero_coeff)
+        assert_eq!(Q::ZERO, zero_coeff)
     }
 
     /// Test if indices smaller than `0` return an error

--- a/src/rational/poly_over_q/get.rs
+++ b/src/rational/poly_over_q/get.rs
@@ -81,7 +81,7 @@ mod test_get_coeff {
 
         let zero_coeff = poly.get_coeff(4).unwrap();
 
-        assert_eq!(Q::from_str("0/1").unwrap(), zero_coeff)
+        assert_eq!(Q::from((0, 1)), zero_coeff)
     }
 
     /// Test if indices smaller than `0` return an error
@@ -99,7 +99,7 @@ mod test_get_coeff {
 
         let coeff = poly.get_coeff(3).unwrap();
 
-        assert_eq!(Q::from_str("-3/2").unwrap(), coeff)
+        assert_eq!(Q::from((-3, 2)), coeff)
     }
 
     /// Tests if positive coefficients are returned correctly
@@ -109,7 +109,7 @@ mod test_get_coeff {
 
         let coeff = poly.get_coeff(2).unwrap();
 
-        assert_eq!(Q::from_str("2/3").unwrap(), coeff)
+        assert_eq!(Q::from((2, 3)), coeff)
     }
 
     /// Tests if large coefficients are returned correctly
@@ -120,24 +120,17 @@ mod test_get_coeff {
         let poly = PolyOverQ::from_str(&large_string).unwrap();
 
         assert_eq!(Q::from_str(&q_str).unwrap(), poly.get_coeff(0).unwrap());
-        assert_eq!(
-            Q::from_str(&u64::MAX.to_string()).unwrap(),
-            poly.get_coeff(1).unwrap()
-        );
+        assert_eq!(Q::from(u64::MAX), poly.get_coeff(1).unwrap());
     }
 
     /// Tests if large negative coefficients are returned correctly
     #[test]
     fn large_coeff_neg() {
-        let q_str = format!("{}/{}", u64::MAX, i64::MIN,);
-        let large_string = format!("2  {} {}", q_str, u64::MAX);
+        let large_string = format!("2  {}/{} {}", u64::MAX, i64::MIN, u64::MAX);
         let poly = PolyOverQ::from_str(&large_string).unwrap();
 
-        assert_eq!(Q::from_str(&q_str).unwrap(), poly.get_coeff(0).unwrap());
-        assert_eq!(
-            Q::from_str(&u64::MAX.to_string()).unwrap(),
-            poly.get_coeff(1).unwrap()
-        );
+        assert_eq!(Q::from((u64::MAX, i64::MIN)), poly.get_coeff(0).unwrap());
+        assert_eq!(Q::from(u64::MAX), poly.get_coeff(1).unwrap());
     }
 }
 

--- a/src/rational/poly_over_q/norm.rs
+++ b/src/rational/poly_over_q/norm.rs
@@ -27,7 +27,7 @@ impl PolyOverQ {
     /// let sqrd_2_norm = poly.norm_eucl_sqrd();
     ///
     /// // (1*1 + 2*2 + 3*3)/49 = 14/49 = 2/7
-    /// assert_eq!(Q::from_str("2/7").unwrap(), sqrd_2_norm);
+    /// assert_eq!(Q::from((2, 7)), sqrd_2_norm);
     /// ```
     pub fn norm_eucl_sqrd(&self) -> Q {
         let mut res = Q::ZERO;
@@ -54,7 +54,7 @@ impl PolyOverQ {
     /// let infty_norm = poly.norm_infty();
     ///
     /// // max coefficient is 3/7
-    /// assert_eq!(Q::from_str("3/7").unwrap(), infty_norm);
+    /// assert_eq!(Q::from((3, 7)), infty_norm);
     /// ```
     pub fn norm_infty(&self) -> Q {
         let mut res = Q::ZERO;
@@ -84,12 +84,10 @@ mod test_norm_eucl_sqrd {
         let poly3 = PolyOverQ::from_str("3  1/8 2010/19 90/29").unwrap();
 
         assert_eq!(poly1.norm_eucl_sqrd(), Q::ZERO);
-        assert_eq!(poly2.norm_eucl_sqrd(), Q::from_str("2/7").unwrap());
+        assert_eq!(poly2.norm_eucl_sqrd(), Q::from((2, 7)));
         assert_eq!(
             poly3.norm_eucl_sqrd(),
-            Q::from_str("1/64").unwrap()
-                + Q::from_str("2010/19").unwrap() * Q::from_str("2010/19").unwrap()
-                + Q::from_str("8100/841").unwrap()
+            Q::from((1, 64)) + Q::from((2010, 19)) * Q::from((2010, 19)) + Q::from((8100, 841))
         );
     }
 
@@ -109,8 +107,7 @@ mod test_norm_eucl_sqrd {
             poly2.norm_eucl_sqrd(),
             Q::from(u64::MAX) * Q::from(u64::MAX)
                 + Q::from(i64::MIN) * Q::from(i64::MIN)
-                + Q::from_str(&format!("1/{}", i64::MAX)).unwrap()
-                    * Q::from_str(&format!("1/{}", i64::MAX)).unwrap()
+                + Q::from((1, i64::MAX)) * Q::from((1, i64::MAX))
         );
     }
 }
@@ -129,8 +126,8 @@ mod test_norm_infty {
         let poly3 = PolyOverQ::from_str("3  1/8 2010/19 90/29").unwrap();
 
         assert_eq!(poly1.norm_infty(), Q::ZERO);
-        assert_eq!(poly2.norm_infty(), Q::from_str("3/7").unwrap());
-        assert_eq!(poly3.norm_infty(), Q::from_str("2010/19").unwrap());
+        assert_eq!(poly2.norm_infty(), Q::from((3, 7)));
+        assert_eq!(poly3.norm_infty(), Q::from((2010, 19)));
     }
 
     /// Check whether the infinity norm for polynomials

--- a/src/rational/poly_over_q/set.rs
+++ b/src/rational/poly_over_q/set.rs
@@ -90,7 +90,7 @@ impl SetCoefficient<&Q> for PolyOverQ {
     /// use std::str::FromStr;
     ///
     /// let mut poly = PolyOverQ::from_str("4  0 1 2/3 3/17").unwrap();
-    /// let value = Q::from_str("3/17").unwrap();
+    /// let value = Q::from((3, 17));
     ///
     /// assert!(poly.set_coeff(4, &value).is_ok());
     /// ```
@@ -208,7 +208,7 @@ mod test_set_coeff_q {
     #[test]
     fn large_coeff() {
         let mut poly = PolyOverQ::from_str("1  1").unwrap();
-        let q = Q::from_str(&format!("{}/{}", u64::MAX - 1, u64::MAX)).unwrap();
+        let q = Q::from((u64::MAX - 1, u64::MAX));
 
         poly.set_coeff(2, &q).unwrap();
 

--- a/src/rational/q.rs
+++ b/src/rational/q.rs
@@ -40,7 +40,7 @@ mod to_string;
 ///
 /// // instantiations
 /// let a = Q::from_str("-876543/235")?;
-/// let b = Q::from((21, 1));
+/// let b = Q::from(21);
 /// let zero = Q::default();
 /// let _ = a.clone();
 ///

--- a/src/rational/q/arithmetic/add.rs
+++ b/src/rational/q/arithmetic/add.rs
@@ -205,8 +205,8 @@ mod test_add_between_q_and_z {
         let c: Z = Z::from(u64::MAX);
         let d: Q = a + &c;
         let e: Q = b + c;
-        assert_eq!(d, Q::from((u64::MAX, 1)) + Q::from((u64::MAX, 2)));
-        assert_eq!(e, Q::from((1, u64::MAX)) + Q::from((u64::MAX, 1)));
+        assert_eq!(d, Q::from(u64::MAX) + Q::from((u64::MAX, 2)));
+        assert_eq!(e, Q::from((1, u64::MAX)) + Q::from(u64::MAX));
     }
 }
 

--- a/src/rational/q/arithmetic/add.rs
+++ b/src/rational/q/arithmetic/add.rs
@@ -74,7 +74,7 @@ impl Add<&Z> for &Q {
     /// use std::str::FromStr;
     ///
     /// let a: Q = Q::from_str("42/19").unwrap();
-    /// let b: Z = Z::from_str("-42").unwrap();
+    /// let b: Z = Z::from(-42);
     ///
     /// let c: Q = &a + &b;
     /// let d: Q = a + b;

--- a/src/rational/q/arithmetic/add.rs
+++ b/src/rational/q/arithmetic/add.rs
@@ -36,7 +36,7 @@ impl Add for &Q {
     /// use std::str::FromStr;
     ///
     /// let a: Q = Q::from(42);
-    /// let b: Q = Q::from_str("-42/2").unwrap();
+    /// let b: Q = Q::from((-42, 2));
     ///
     /// let c: Q = &a + &b;
     /// let d: Q = a + b;
@@ -73,7 +73,7 @@ impl Add<&Z> for &Q {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Q = Q::from_str("42/19").unwrap();
+    /// let a: Q = Q::from((42, 19));
     /// let b: Z = Z::from(-42);
     ///
     /// let c: Q = &a + &b;
@@ -102,7 +102,7 @@ mod test_add {
     #[test]
     fn add() {
         let a: Q = Q::from(42);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = a + b;
         assert_eq!(c, Q::from(63));
     }
@@ -111,7 +111,7 @@ mod test_add {
     #[test]
     fn add_borrow() {
         let a: Q = Q::from(42);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = &a + &b;
         assert_eq!(c, Q::from(63));
     }
@@ -119,17 +119,17 @@ mod test_add {
     /// Testing addition for borrowed [`Q`] and [`Q`]
     #[test]
     fn add_first_borrowed() {
-        let a: Q = Q::from_str("42/5").unwrap();
-        let b: Q = Q::from_str("42/10").unwrap();
+        let a: Q = Q::from((42, 5));
+        let b: Q = Q::from((42, 10));
         let c: Q = &a + b;
-        assert_eq!(c, Q::from_str("63/5").unwrap());
+        assert_eq!(c, Q::from((63, 5)));
     }
 
     /// Testing addition for [`Q`] and borrowed [`Q`]
     #[test]
     fn add_second_borrowed() {
         let a: Q = Q::from(42);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = a + &b;
         assert_eq!(c, Q::from(63));
     }
@@ -137,10 +137,10 @@ mod test_add {
     #[test]
     /// Testing addition for large numerators and divisors
     fn add_large() {
-        let a: Q = Q::from_str(&(i64::MAX).to_string()).unwrap();
-        let b: Q = Q::from_str(&(u64::MAX - 1).to_string()).unwrap();
-        let c: Q = Q::from_str(&format!("1/{}", (i32::MAX))).unwrap();
-        let d: Q = Q::from_str(&format!("1/{}", (u32::MAX))).unwrap();
+        let a: Q = Q::from(i64::MAX);
+        let b: Q = Q::from(u64::MAX - 1);
+        let c: Q = Q::from((1, i32::MAX));
+        let d: Q = Q::from((1, u32::MAX));
         let e: Q = &a + &a;
         let f: Q = c + d;
         assert_eq!(e, b);
@@ -160,62 +160,53 @@ mod test_add {
 mod test_add_between_q_and_z {
     use crate::integer::Z;
     use crate::rational::Q;
-    use std::str::FromStr;
 
     /// Testing addition for [`Q`] and [`Z`]
     #[test]
     fn add() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = a + b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        assert_eq!(c, Q::from((33, 7)));
     }
 
     /// Testing addition for both borrowed [`Q`] and [`Z`]
     #[test]
     fn add_borrow() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = &a + &b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        assert_eq!(c, Q::from((33, 7)));
     }
 
     /// Testing addition for borrowed [`Q`] and [`Z`]
     #[test]
     fn add_first_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = &a + b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        assert_eq!(c, Q::from((33, 7)));
     }
 
     /// Testing addition for [`Q`] and borrowed [`Z`]
     #[test]
     fn add_second_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = a + &b;
-        assert_eq!(c, Q::from_str("33/7").unwrap());
+        assert_eq!(c, Q::from((33, 7)));
     }
 
     /// Testing addition for big numbers
     #[test]
     fn add_large_numbers() {
-        let a: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
-        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let a: Q = Q::from((u64::MAX, 2));
+        let b: Q = Q::from((1, u64::MAX));
         let c: Z = Z::from(u64::MAX);
         let d: Q = a + &c;
         let e: Q = b + c;
-        assert_eq!(
-            d,
-            Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-                + Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
-        );
-        assert_eq!(
-            e,
-            Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
-                + Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-        );
+        assert_eq!(d, Q::from((u64::MAX, 1)) + Q::from((u64::MAX, 2)));
+        assert_eq!(e, Q::from((1, u64::MAX)) + Q::from((u64::MAX, 1)));
     }
 }
 

--- a/src/rational/q/arithmetic/div.rs
+++ b/src/rational/q/arithmetic/div.rs
@@ -257,8 +257,8 @@ mod test_div_between_q_and_z {
         let d: Q = a / &c;
         let e: Q = b / c;
 
-        assert_eq!(d, Q::from((u64::MAX, 2)) / Q::from((u64::MAX, 1)));
-        assert_eq!(e, Q::from((1, u64::MAX)) / Q::from((u64::MAX, 1)));
+        assert_eq!(d, Q::from((u64::MAX, 2)) / Q::from(u64::MAX));
+        assert_eq!(e, Q::from((1, u64::MAX)) / Q::from(u64::MAX));
     }
 
     /// Testing division by `0` panics

--- a/src/rational/q/arithmetic/div.rs
+++ b/src/rational/q/arithmetic/div.rs
@@ -45,7 +45,7 @@ impl Div for &Q {
     /// ```
     ///
     /// # Panics ...
-    /// - ... if the `other` value is `0`.
+    /// - if the `other` value is `0`.
     fn div(self, other: Self) -> Self::Output {
         self.div_safe(other).unwrap()
     }

--- a/src/rational/q/arithmetic/div.rs
+++ b/src/rational/q/arithmetic/div.rs
@@ -72,7 +72,7 @@ impl Div<&Z> for &Q {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Q = Q::from_str("42/19").unwrap();
+    /// let a: Q = Q::from((42, 19));
     /// let b: Z = Z::from(-42);
     ///
     /// let c: Q = &a / &b;
@@ -136,65 +136,56 @@ impl Q {
 #[cfg(test)]
 mod test_div {
     use super::Q;
-    use std::str::FromStr;
 
     /// Testing division for two [`Q`]
     #[test]
     fn div() {
         let a: Q = Q::from(2);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = a / b;
-        assert_eq!(c, Q::from_str("4/42").unwrap());
+        assert_eq!(c, Q::from((4, 42)));
     }
 
     /// Testing division for two borrowed [`Q`]
     #[test]
     fn div_borrow() {
         let a: Q = Q::from(2);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = &a / &b;
-        assert_eq!(c, Q::from_str("4/42").unwrap());
+        assert_eq!(c, Q::from((4, 42)));
     }
 
     /// Testing division for borrowed [`Q`] and [`Q`]
     #[test]
     fn div_first_borrowed() {
         let a: Q = Q::from(4);
-        let b: Q = Q::from_str("42/10").unwrap();
+        let b: Q = Q::from((42, 10));
         let c: Q = &a / b;
-        assert_eq!(c, Q::from_str("40/42").unwrap());
+        assert_eq!(c, Q::from((40, 42)));
     }
 
     /// Testing division for [`Q`] and borrowed [`Q`]
     #[test]
     fn div_second_borrowed() {
         let a: Q = Q::from(2);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = a / &b;
-        assert_eq!(c, Q::from_str("4/42").unwrap());
+        assert_eq!(c, Q::from((4, 42)));
     }
 
     #[test]
     /// Testing division for large numerators and divisors
     fn div_large() {
-        let a: Q = Q::from_str(&(u64::MAX - 1).to_string()).unwrap();
+        let a: Q = Q::from(u64::MAX - 1);
         let b: Q = Q::from(2);
-        let c: Q = Q::from_str(&format!("1/{}", (i32::MAX))).unwrap();
-        let d: Q = Q::from_str(&format!("1/{}", (u32::MAX))).unwrap();
+        let c: Q = Q::from((1, i32::MAX));
+        let d: Q = Q::from((1, u32::MAX));
 
         let e: Q = &a / &b;
         let f: Q = c / d;
 
-        assert_eq!(e, Q::from_str(&(i64::MAX).to_string()).unwrap());
-        assert_eq!(
-            f,
-            Q::from_str(&format!(
-                "{}/{}",
-                u64::from(u32::MAX),
-                u64::from((u32::MAX - 1) / 2)
-            ))
-            .unwrap()
-        );
+        assert_eq!(e, Q::from(i64::MAX));
+        assert_eq!(f, Q::from((u32::MAX, (u32::MAX - 1) / 2)));
     }
 
     /// Testing division by `0` panics
@@ -219,71 +210,62 @@ mod test_div {
 mod test_div_between_q_and_z {
     use crate::integer::Z;
     use crate::rational::Q;
-    use std::str::FromStr;
 
     /// Testing division for [`Q`] and [`Z`]
     #[test]
     fn div() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = a / b;
-        assert_eq!(c, Q::from_str("5/28").unwrap());
+        assert_eq!(c, Q::from((5, 28)));
     }
 
     /// Testing division for both borrowed [`Q`] and [`Z`]
     #[test]
     fn div_borrow() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = &a / &b;
-        assert_eq!(c, Q::from_str("5/28").unwrap());
+        assert_eq!(c, Q::from((5, 28)));
     }
 
     /// Testing division for borrowed [`Q`] and [`Z`]
     #[test]
     fn div_first_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = &a / b;
-        assert_eq!(c, Q::from_str("5/28").unwrap());
+        assert_eq!(c, Q::from((5, 28)));
     }
 
     /// Testing division for [`Q`] and borrowed [`Z`]
     #[test]
     fn div_second_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = a / &b;
-        assert_eq!(c, Q::from_str("5/28").unwrap());
+        assert_eq!(c, Q::from((5, 28)));
     }
 
     /// Testing division for big numbers
     #[test]
     fn div_large_numbers() {
-        let a: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
-        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let a: Q = Q::from((u64::MAX, 2));
+        let b: Q = Q::from((1, u64::MAX));
         let c: Z = Z::from(u64::MAX);
 
         let d: Q = a / &c;
         let e: Q = b / c;
 
-        assert_eq!(
-            d,
-            Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
-                / Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-        );
-        assert_eq!(
-            e,
-            Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
-                / Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-        );
+        assert_eq!(d, Q::from((u64::MAX, 2)) / Q::from((u64::MAX, 1)));
+        assert_eq!(e, Q::from((1, u64::MAX)) / Q::from((u64::MAX, 1)));
     }
 
     /// Testing division by `0` panics
     #[test]
     #[should_panic]
     fn div_by_zero() {
-        let a: Q = Q::from_str("2/3").unwrap();
+        let a: Q = Q::from((2, 3));
         let b: Z = Z::ZERO;
         let _c = a / b;
     }

--- a/src/rational/q/arithmetic/exp.rs
+++ b/src/rational/q/arithmetic/exp.rs
@@ -28,7 +28,7 @@ impl Q {
     /// use std::str::FromStr;
     ///
     /// // sum_{k=0}^999 (17/3)^k/k!
-    /// let evaluation = Q::from_str("17/3").unwrap().exp_taylor(1000_u32);
+    /// let evaluation = Q::from((17, 3)).exp_taylor(1000_u32);
     /// ```
     pub fn exp_taylor(&self, length_taylor_polynomial: impl Into<u32>) -> Self {
         let exp_taylor_series = PolyOverQ::exp_function_taylor(length_taylor_polynomial);
@@ -39,12 +39,11 @@ impl Q {
 #[cfg(test)]
 mod test_exp {
     use crate::rational::Q;
-    use std::str::FromStr;
 
     /// Ensure that `0` is returned if the length `0` is provided
     #[test]
     fn zero_length() {
-        let q = Q::from_str("17/3").unwrap();
+        let q = Q::from((17, 3));
 
         assert_eq!(Q::default(), q.exp_taylor(0_u32));
     }
@@ -52,17 +51,14 @@ mod test_exp {
     /// Test correct evaluation for some explicit values
     #[test]
     fn ten_length_value() {
+        assert_eq!(Q::from((98641, 36288)), Q::ONE.exp_taylor(10_u32));
         assert_eq!(
-            Q::from_str("98641/36288").unwrap(),
-            Q::ONE.exp_taylor(10_u32)
+            Q::from((2492063827u64, 1785641760)),
+            Q::from((1, 3)).exp_taylor(10_u32)
         );
         assert_eq!(
-            Q::from_str("2492063827/1785641760").unwrap(),
-            Q::from_str("1/3").unwrap().exp_taylor(10_u32)
-        );
-        assert_eq!(
-            Q::from_str("5729869/11160261").unwrap(),
-            Q::from_str("-2/3").unwrap().exp_taylor(10_u32)
+            Q::from((5729869, 11160261)),
+            Q::from((-2, 3)).exp_taylor(10_u32)
         );
     }
 }

--- a/src/rational/q/arithmetic/mul.rs
+++ b/src/rational/q/arithmetic/mul.rs
@@ -72,7 +72,7 @@ impl Mul<&Z> for &Q {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Q = Q::from_str("42/19").unwrap();
+    /// let a: Q = Q::from((42, 19));
     /// let b: Z = Z::from(-42);
     ///
     /// let c: Q = &a * &b;
@@ -101,7 +101,7 @@ mod test_mul {
     #[test]
     fn mul() {
         let a: Q = Q::from(2);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = a * b;
         assert_eq!(c, Q::from(42));
     }
@@ -110,7 +110,7 @@ mod test_mul {
     #[test]
     fn mul_borrow() {
         let a: Q = Q::from(2);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = &a * &b;
         assert_eq!(c, Q::from(42));
     }
@@ -119,16 +119,16 @@ mod test_mul {
     #[test]
     fn mul_first_borrowed() {
         let a: Q = Q::from(4);
-        let b: Q = Q::from_str("42/10").unwrap();
+        let b: Q = Q::from((42, 10));
         let c: Q = &a * b;
-        assert_eq!(c, Q::from_str("168/10").unwrap());
+        assert_eq!(c, Q::from((168, 10)));
     }
 
     /// Testing multiplication for [`Q`] and borrowed [`Q`]
     #[test]
     fn mul_second_borrowed() {
         let a: Q = Q::from(2);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = a * &b;
         assert_eq!(c, Q::from(42));
     }
@@ -138,13 +138,13 @@ mod test_mul {
     fn mul_large() {
         let a: Q = Q::from(i64::MAX);
         let b: Q = Q::from(2);
-        let c: Q = Q::from_str(&format!("1/{}", (i32::MAX))).unwrap();
-        let d: Q = Q::from_str(&format!("1/{}", (u32::MAX))).unwrap();
+        let c: Q = Q::from((1, i32::MAX));
+        let d: Q = Q::from((1, u32::MAX));
 
         let e: Q = &a * &b;
         let f: Q = c * d;
 
-        assert_eq!(e, Q::from_str(&(u64::MAX - 1).to_string()).unwrap());
+        assert_eq!(e, Q::from(u64::MAX - 1));
         assert_eq!(
             f,
             Q::from_str(&format!(
@@ -160,62 +160,55 @@ mod test_mul {
 mod test_mul_between_q_and_z {
     use crate::integer::Z;
     use crate::rational::Q;
-    use std::str::FromStr;
 
     /// Testing multiplication for [`Q`] and [`Z`]
     #[test]
     fn mul() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = a * b;
-        assert_eq!(c, Q::from_str("20/7").unwrap());
+        assert_eq!(c, Q::from((20, 7)));
     }
 
     /// Testing multiplication for both borrowed [`Q`] and [`Z`]
     #[test]
     fn mul_borrow() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = &a * &b;
-        assert_eq!(c, Q::from_str("20/7").unwrap());
+        assert_eq!(c, Q::from((20, 7)));
     }
 
     /// Testing multiplication for borrowed [`Q`] and [`Z`]
     #[test]
     fn mul_first_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = &a * b;
-        assert_eq!(c, Q::from_str("20/7").unwrap());
+        assert_eq!(c, Q::from((20, 7)));
     }
 
     /// Testing multiplication for [`Q`] and borrowed [`Z`]
     #[test]
     fn mul_second_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = a * &b;
-        assert_eq!(c, Q::from_str("20/7").unwrap());
+        assert_eq!(c, Q::from((20, 7)));
     }
 
     /// Testing multiplication for big numbers
     #[test]
     fn mul_large_numbers() {
-        let a: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
-        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let a: Q = Q::from((u64::MAX, 2));
+        let b: Q = Q::from((1, u64::MAX));
         let c: Z = Z::from(u64::MAX);
 
         let d: Q = a * &c;
         let e: Q = b * c;
 
-        assert_eq!(
-            d,
-            Q::from(u64::MAX) * Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
-        );
-        assert_eq!(
-            e,
-            Q::from_str(&format!("1/{}", u64::MAX)).unwrap() * Q::from(u64::MAX)
-        );
+        assert_eq!(d, Q::from(u64::MAX) * Q::from((u64::MAX, 2)));
+        assert_eq!(e, Q::from((1, u64::MAX)) * Q::from(u64::MAX));
     }
 }
 

--- a/src/rational/q/arithmetic/pow.rs
+++ b/src/rational/q/arithmetic/pow.rs
@@ -32,12 +32,12 @@ impl Pow<&Z> for Q {
     /// use qfall_math::{rational::Q, integer::Z};
     /// use qfall_math::traits::*;
     ///
-    /// let base = Q::try_from((&3, &1)).unwrap();
+    /// let base = Q::from(3);
     /// let exp = Z::from(-2);
     ///
     /// let powered_value = base.pow(&exp).unwrap();
     ///
-    /// assert_eq!(Q::try_from((&1, &9)).unwrap(), powered_value);
+    /// assert_eq!(Q::from((1, 9)), powered_value);
     /// ```
     ///
     /// # Errors and Failures
@@ -77,8 +77,8 @@ mod test_pow {
     /// Ensure that `pow` works correctly for base values `1` and `-1`
     #[test]
     fn one() {
-        let base_pos = Q::try_from((&1, &1)).unwrap();
-        let base_neg = Q::try_from((&-1, &1)).unwrap();
+        let base_pos = Q::ONE;
+        let base_neg = Q::MINUS_ONE;
 
         assert_eq!(Q::ONE, base_pos.pow(0).unwrap());
         assert_eq!(Q::ONE, base_pos.pow(1).unwrap());
@@ -93,8 +93,8 @@ mod test_pow {
     /// Ensure that `pow` works for [`Q`] properly for small values
     #[test]
     fn small() {
-        let base_0 = Q::try_from((&2, &1)).unwrap();
-        let base_1 = Q::try_from((&1, &2)).unwrap();
+        let base_0 = Q::from(2);
+        let base_1 = Q::from((1, 2));
         let exp_pos = Z::from(4);
 
         let res_0 = base_0.pow(&exp_pos).unwrap();
@@ -102,17 +102,17 @@ mod test_pow {
         let res_2 = base_1.pow(&exp_pos).unwrap();
         let res_3 = base_1.pow(0).unwrap();
 
-        assert_eq!(Q::try_from((&16, &1)).unwrap(), res_0);
-        assert_eq!(Q::try_from((&1, &1)).unwrap(), res_1);
-        assert_eq!(Q::try_from((&1, &16)).unwrap(), res_2);
-        assert_eq!(Q::try_from((&1, &1)).unwrap(), res_3);
+        assert_eq!(Q::from(16), res_0);
+        assert_eq!(Q::ONE, res_1);
+        assert_eq!(Q::from((1, 16)), res_2);
+        assert_eq!(Q::ONE, res_3);
     }
 
     /// Ensure that `pow` works for [`Q`] properly for large values
     #[test]
     fn large() {
-        let base_0 = Q::try_from((&i64::MIN, &1)).unwrap();
-        let base_1 = Q::try_from((&1, &i64::MIN)).unwrap();
+        let base_0 = Q::from(i64::MIN);
+        let base_1 = Q::from((1, i64::MIN));
         let exp_pos = Z::from(3);
         let cmp_0 = &base_0 * &base_0 * &base_0;
         let cmp_1 = &base_1 * &base_1 * &base_1;
@@ -126,16 +126,16 @@ mod test_pow {
 
         assert_eq!(cmp_0, res_0);
         assert_eq!(Q::ONE, res_1);
-        assert_eq!(Q::try_from((&1, &i64::MIN)).unwrap(), res_2);
+        assert_eq!(Q::from((1, i64::MIN)), res_2);
         assert_eq!(cmp_1, res_3);
         assert_eq!(Q::ONE, res_4);
-        assert_eq!(Q::try_from((&i64::MIN, &1)).unwrap(), res_5);
+        assert_eq!(Q::from(i64::MIN), res_5);
     }
 
     /// Ensures that the `pow` trait is available for other types
     #[test]
     fn availability() {
-        let base = Q::try_from((&i64::MAX, &1)).unwrap();
+        let base = Q::from(i64::MAX);
         let exp = Z::from(4);
 
         let _ = base.pow(exp);
@@ -153,7 +153,7 @@ mod test_pow {
     /// i.e. for [`Q`] only 0, is powered by a negative exponent
     #[test]
     fn non_invertible_detection() {
-        let base = Q::try_from((&0, &1)).unwrap();
+        let base = Q::ZERO;
 
         assert!(base.pow(-1).is_err());
     }

--- a/src/rational/q/arithmetic/root.rs
+++ b/src/rational/q/arithmetic/root.rs
@@ -151,7 +151,7 @@ mod test_sqrt {
             Q::from((1, 3)),
             Q::from((10, 3)),
             Q::from((100000, 3)),
-            Q::from((u64::MAX, 1)),
+            Q::from(u64::MAX),
             Q::from((1, u64::MAX)),
             Q::from((u64::MAX, u64::MAX - 1)) * Q::from(u64::MAX),
         ];

--- a/src/rational/q/arithmetic/sub.rs
+++ b/src/rational/q/arithmetic/sub.rs
@@ -195,8 +195,8 @@ mod test_sub_between_z_and_q {
         let c: Z = Z::from(u64::MAX);
         let d: Q = a - &c;
         let e: Q = b - c;
-        assert_eq!(d, Q::from((u64::MAX, 2)) - Q::from((u64::MAX, 1)));
-        assert_eq!(e, Q::from((1, u64::MAX)) - Q::from((u64::MAX, 1)));
+        assert_eq!(d, Q::from((u64::MAX, 2)) - Q::from(u64::MAX));
+        assert_eq!(e, Q::from((1, u64::MAX)) - Q::from(u64::MAX));
     }
 }
 

--- a/src/rational/q/arithmetic/sub.rs
+++ b/src/rational/q/arithmetic/sub.rs
@@ -35,7 +35,7 @@ impl Sub for &Q {
     /// use std::str::FromStr;
     ///
     /// let a: Q = Q::from(42);
-    /// let b: Q = Q::from_str("-42/2").unwrap();
+    /// let b: Q = Q::from((-42, 2));
     ///
     /// let c: Q = &a - &b;
     /// let d: Q = a - b;
@@ -72,7 +72,7 @@ impl Sub<&Z> for &Q {
     /// use qfall_math::integer::Z;
     /// use std::str::FromStr;
     ///
-    /// let a: Q = Q::from_str("42/19").unwrap();
+    /// let a: Q = Q::from((42, 19));
     /// let b: Z = Z::from(42);
     ///
     /// let c: Q = &a - &b;
@@ -95,13 +95,12 @@ arithmetic_trait_mixed_borrowed_owned!(Sub, sub, Q, Z, Q);
 #[cfg(test)]
 mod test_sub {
     use super::Q;
-    use std::str::FromStr;
 
     /// Testing subtraction for two [`Q`]
     #[test]
     fn sub() {
         let a: Q = Q::from(42);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = a - b;
         assert_eq!(c, Q::from(21));
     }
@@ -110,7 +109,7 @@ mod test_sub {
     #[test]
     fn sub_borrow() {
         let a: Q = Q::from(42);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = &a - &b;
         assert_eq!(c, Q::from(21));
     }
@@ -118,17 +117,17 @@ mod test_sub {
     /// Testing subtraction for borrowed [`Q`] and [`Q`]
     #[test]
     fn sub_first_borrowed() {
-        let a: Q = Q::from_str("42/5").unwrap();
-        let b: Q = Q::from_str("42/10").unwrap();
+        let a: Q = Q::from((42, 5));
+        let b: Q = Q::from((42, 10));
         let c: Q = &a - b;
-        assert_eq!(c, Q::from_str("21/5").unwrap());
+        assert_eq!(c, Q::from((21, 5)));
     }
 
     /// Testing subtraction for [`Q`] and borrowed [`Q`]
     #[test]
     fn sub_second_borrowed() {
         let a: Q = Q::from(42);
-        let b: Q = Q::from_str("42/2").unwrap();
+        let b: Q = Q::from((42, 2));
         let c: Q = a - &b;
         assert_eq!(c, Q::from(21));
     }
@@ -136,18 +135,14 @@ mod test_sub {
     #[test]
     /// Testing subtraction for large numerators and divisors
     fn sub_large() {
-        let a: Q = Q::from_str(&(i64::MAX).to_string()).unwrap();
-        let b: Q = Q::from_str(&(u64::MAX - 1).to_string()).unwrap();
-        let c: Q = Q::from_str(&format!("1/{}", (i64::MAX))).unwrap();
-        let d: Q = Q::from_str(&format!("1/{}", (u64::MAX))).unwrap();
+        let a: Q = Q::from(i64::MAX);
+        let b: Q = Q::from(u64::MAX - 1);
+        let c: Q = Q::from((1, i64::MAX));
+        let d: Q = Q::from((1, u64::MAX));
         let e: Q = &b - &a;
         let f: Q = &c - &d;
         assert_eq!(e, a);
-        assert_eq!(
-            f,
-            Q::from_str(&format!("-1/{}", (u64::MAX))).unwrap()
-                + Q::from_str(&format!("1/{}", (i64::MAX))).unwrap()
-        );
+        assert_eq!(f, Q::from((-1, u64::MAX)) + Q::from((1, i64::MAX)));
     }
 }
 
@@ -155,62 +150,53 @@ mod test_sub {
 mod test_sub_between_z_and_q {
     use super::Z;
     use crate::rational::Q;
-    use std::str::FromStr;
 
     /// Testing subtraction for [`Q`] and [`Z`]
     #[test]
     fn sub() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = a - b;
-        assert_eq!(c, Q::from_str("-23/7").unwrap());
+        assert_eq!(c, Q::from((-23, 7)));
     }
 
     /// Testing subtraction for both borrowed [`Q`] and [`Z`]
     #[test]
     fn sub_borrow() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = &a - &b;
-        assert_eq!(c, Q::from_str("-23/7").unwrap());
+        assert_eq!(c, Q::from((-23, 7)));
     }
 
     /// Testing subtraction for borrowed [`Q`] and [`Z`]
     #[test]
     fn sub_first_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = &a - b;
-        assert_eq!(c, Q::from_str("-23/7").unwrap());
+        assert_eq!(c, Q::from((-23, 7)));
     }
 
     /// Testing subtraction for [`Q`] and borrowed [`Z`]
     #[test]
     fn sub_second_borrowed() {
-        let a: Q = Q::from_str("5/7").unwrap();
+        let a: Q = Q::from((5, 7));
         let b: Z = Z::from(4);
         let c: Q = a - &b;
-        assert_eq!(c, Q::from_str("-23/7").unwrap());
+        assert_eq!(c, Q::from((-23, 7)));
     }
 
     /// Testing subtraction for big numbers
     #[test]
     fn sub_large_numbers() {
-        let a: Q = Q::from_str(&format!("{}/2", u64::MAX)).unwrap();
-        let b: Q = Q::from_str(&format!("1/{}", u64::MAX)).unwrap();
+        let a: Q = Q::from((u64::MAX, 2));
+        let b: Q = Q::from((1, u64::MAX));
         let c: Z = Z::from(u64::MAX);
         let d: Q = a - &c;
         let e: Q = b - c;
-        assert_eq!(
-            d,
-            Q::from_str(&format!("{}/2", u64::MAX)).unwrap()
-                - Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-        );
-        assert_eq!(
-            e,
-            Q::from_str(&format!("1/{}", u64::MAX)).unwrap()
-                - Q::from_str(&format!("{}/1", u64::MAX)).unwrap()
-        );
+        assert_eq!(d, Q::from((u64::MAX, 2)) - Q::from((u64::MAX, 1)));
+        assert_eq!(e, Q::from((1, u64::MAX)) - Q::from((u64::MAX, 1)));
     }
 }
 

--- a/src/rational/q/cmp.rs
+++ b/src/rational/q/cmp.rs
@@ -25,8 +25,8 @@ impl PartialEq for Q {
     /// ```
     /// use qfall_math::rational::Q;
     /// use std::str::FromStr;
-    /// let a: Q = Q::from_str("42/24").unwrap();
-    /// let b: Q = Q::from_str("24/42").unwrap();
+    /// let a: Q = Q::from((42, 24));
+    /// let b: Q = Q::from((24, 42));
     ///
     /// // These are all equivalent and return false.
     /// let compared: bool = (a == b);
@@ -268,8 +268,8 @@ mod test_partial_eq {
     /// Ensure that two elements are equal
     #[test]
     fn equal_rational() {
-        let a = Q::from_str("1/2").unwrap();
-        let b = Q::from_str("2/4").unwrap();
+        let a = Q::from((1, 2));
+        let b = Q::from((2, 4));
 
         assert_eq!(a, b);
     }
@@ -277,8 +277,8 @@ mod test_partial_eq {
     /// assert not equal when denominator is different
     #[test]
     fn not_equal_different_denominator() {
-        let a = Q::from_str("1/2").unwrap();
-        let b = Q::from_str("1/4").unwrap();
+        let a = Q::from((1, 2));
+        let b = Q::from((1, 4));
 
         assert_ne!(a, b);
     }
@@ -286,8 +286,8 @@ mod test_partial_eq {
     /// assert equal for `0` when denominator is different
     #[test]
     fn zero_equal_different_denominator() {
-        let a = Q::from_str("0/2").unwrap();
-        let b = Q::from_str("0/4").unwrap();
+        let a = Q::from((0, 2));
+        let b = Q::from((0, 4));
 
         assert_eq!(a, b);
     }

--- a/src/rational/q/cmp.rs
+++ b/src/rational/q/cmp.rs
@@ -314,8 +314,8 @@ mod test_partial_ord {
     #[test]
     fn less_small() {
         let one_1 = Q::ONE;
-        let small_negative = Q::from(-1);
-        let one_half = Q::try_from((&1, &2)).unwrap();
+        let small_negative = Q::MINUS_ONE;
+        let one_half = Q::from((1, 2));
 
         assert!(small_negative < one_1);
 
@@ -327,9 +327,9 @@ mod test_partial_ord {
     /// and small [`Q`] (not using pointers).
     #[test]
     fn less_large_small() {
-        let large = Q::try_from((&u64::MAX, &2)).unwrap();
+        let large = Q::from((u64::MAX, 2));
         let small_positive = Q::ONE;
-        let small_negative = Q::try_from((&(i64::MIN + 1), &i64::MAX)).unwrap();
+        let small_negative = Q::from((i64::MIN + 1, i64::MAX));
         let large_negative = Q::from(i64::MIN);
 
         // Comparisons with max
@@ -357,7 +357,7 @@ mod test_partial_ord {
     fn less_equal_small() {
         let small_positive_1 = Q::ONE;
         let small_positive_2 = Q::ONE;
-        let small_negative = Q::from(-1);
+        let small_negative = Q::MINUS_ONE;
 
         assert!(small_positive_1 <= small_positive_2);
         assert!(small_positive_2 <= small_positive_1);
@@ -373,7 +373,7 @@ mod test_partial_ord {
     fn less_equal_large_small() {
         let max = Q::from(u64::MAX);
         let small_positive = Q::ONE;
-        let small_negative = Q::from(-1);
+        let small_negative = Q::MINUS_ONE;
         let max_negative = Q::from(i64::MIN);
 
         // Comparisons with max
@@ -406,7 +406,7 @@ mod test_partial_ord {
     #[test]
     fn greater_small() {
         let small_positive_1 = Q::ONE;
-        let small_negative = Q::from(-1);
+        let small_negative = Q::MINUS_ONE;
 
         assert!(small_positive_1 > small_negative);
     }
@@ -417,7 +417,7 @@ mod test_partial_ord {
     fn greater_large_small() {
         let max = Q::from(u64::MAX);
         let small_positive = Q::ONE;
-        let small_negative = Q::from(-1);
+        let small_negative = Q::MINUS_ONE;
         let max_negative = Q::from(i64::MIN);
 
         // Comparisons with max
@@ -445,7 +445,7 @@ mod test_partial_ord {
     fn greater_equal_small() {
         let small_positive_1 = Q::ONE;
         let small_positive_2 = Q::ONE;
-        let small_negative = Q::from(-1);
+        let small_negative = Q::MINUS_ONE;
 
         assert!(small_positive_1 >= small_positive_2);
         assert!(small_positive_2 >= small_positive_1);
@@ -461,7 +461,7 @@ mod test_partial_ord {
     fn greater_equal_large_small() {
         let max = Q::from(u64::MAX);
         let small_positive = Q::ONE;
-        let small_negative = Q::from(-1);
+        let small_negative = Q::MINUS_ONE;
         let max_negative = Q::from(i64::MIN);
 
         // Comparisons with max
@@ -492,7 +492,7 @@ mod test_partial_ord {
     /// Compare a number close to zero with zero
     #[test]
     fn close_to_zero() {
-        let small = Q::try_from((&1, &u64::MAX)).unwrap();
+        let small = Q::from((1, u64::MAX));
         let zero = Q::ZERO;
 
         assert!(small > zero);

--- a/src/rational/q/default.rs
+++ b/src/rational/q/default.rs
@@ -126,18 +126,18 @@ mod tests_init {
     /// Ensure that `ZERO` initializes [`Q`] with `0`.
     #[test]
     fn init_zero() {
-        assert_eq!(Q::try_from((&0, &1)).unwrap(), Q::ZERO);
+        assert_eq!(Q::from(0), Q::ZERO);
     }
 
     /// Ensure that `ONE` initializes [`Q`] with `1`.
     #[test]
     fn init_one() {
-        assert_eq!(Q::try_from((&1, &1)).unwrap(), Q::ONE);
+        assert_eq!(Q::from(1), Q::ONE);
     }
 
     /// Ensure that `MINUS_ONE` initializes [`Q`] with `-1`.
     #[test]
     fn init_minus_one() {
-        assert_eq!(Q::try_from((&-1, &1)).unwrap(), Q::MINUS_ONE);
+        assert_eq!(Q::from(-1), Q::MINUS_ONE);
     }
 }

--- a/src/rational/q/distance.rs
+++ b/src/rational/q/distance.rs
@@ -57,15 +57,15 @@ mod test_distance {
     #[test]
     fn small_values() {
         let a = Q::ONE;
-        let b = Q::try_from((&5, &-15)).unwrap();
+        let b = Q::from((5, -15));
         let zero = Q::ZERO;
 
         assert_eq!(Q::ONE, a.distance(&zero));
         assert_eq!(Q::ONE, zero.distance(&a));
-        assert_eq!(Q::try_from((&4, &3)).unwrap(), a.distance(&b));
-        assert_eq!(Q::try_from((&4, &3)).unwrap(), b.distance(&a));
-        assert_eq!(Q::try_from((&1, &3)).unwrap(), b.distance(&zero));
-        assert_eq!(Q::try_from((&1, &3)).unwrap(), zero.distance(&b));
+        assert_eq!(Q::from((4, 3)), a.distance(&b));
+        assert_eq!(Q::from((4, 3)), b.distance(&a));
+        assert_eq!(Q::from((1, 3)), b.distance(&zero));
+        assert_eq!(Q::from((1, 3)), zero.distance(&b));
         assert_eq!(Q::ZERO, b.distance(&b))
     }
 
@@ -110,7 +110,7 @@ mod test_distance {
         assert_eq!(Q::from(15), i_1);
         assert_eq!(Q::from(35), i_2);
         assert_eq!(Q::from(i64::MIN).abs(), i_3);
-        assert_eq!(Q::try_from((&425, &100)).unwrap(), f_0);
-        assert_eq!(Q::try_from((&169, &256)).unwrap(), f_1);
+        assert_eq!(Q::from((425, 100)), f_0);
+        assert_eq!(Q::from((169, 256)), f_1);
     }
 }

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -691,7 +691,6 @@ mod test_try_from_int_int {
 mod test_from_z {
     use super::Q;
     use crate::integer::Z;
-    use std::str::FromStr;
 
     /// Ensure that the `from_int` function is available and works correctly for
     /// small and large instances of [`Z`] and structs implementing [`Into<Z>`].
@@ -700,10 +699,7 @@ mod test_from_z {
         let z_1 = Z::from(u64::MAX);
         let z_2 = Z::from(17);
 
-        assert_eq!(
-            Q::from_str(&u64::MAX.to_string()).unwrap(),
-            Q::from_int(z_1)
-        );
+        assert_eq!(Q::from(u64::MAX), Q::from_int(z_1));
         assert_eq!(Q::from(17), Q::from_int(z_2));
     }
 
@@ -714,7 +710,7 @@ mod test_from_z {
         let z_1 = Z::from(u64::MAX);
         let z_2 = Z::from(17);
 
-        assert_eq!(Q::from_str(&u64::MAX.to_string()).unwrap(), Q::from(z_1));
+        assert_eq!(Q::from(u64::MAX), Q::from(z_1));
         assert_eq!(Q::from(17), Q::from(z_2));
     }
 

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -443,7 +443,7 @@ mod test_from_int_int {
         let uint_32: u32 = 10;
         let uint_64: u64 = 10;
         let z = Z::from(10);
-        let zq = Zq::try_from((10, 20)).unwrap();
+        let zq = Zq::from((10, 20));
 
         // owned, owned the same type in numerator and denominator
         let _ = Q::from((int_8, int_8));

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -179,7 +179,7 @@ impl Q {
         let shift = match exponent {
             // This could be optimized with `fmpz_lshift_mpn` once it is part of flint_sys.
             e if e >= 1 => Q::from(2).pow(e).unwrap(),
-            e => Q::try_from((&1, &2)).unwrap().pow(e.abs()).unwrap(),
+            e => Q::from((1, 2)).pow(e.abs()).unwrap(),
         };
 
         sign * Z::from(mantissa) * shift
@@ -207,7 +207,7 @@ impl<IntegerNumerator: AsInteger, IntegerDenominator: AsInteger>
     /// use qfall_math::integer::Z;
     ///
     /// let a = Q::from((42, &2));
-    /// let b = Q::from((Z::from(21), 1));
+    /// let b = Q::from((Z::from(84), 4));
     ///
     /// assert_eq!(a,b);
     /// ```
@@ -773,7 +773,7 @@ mod test_from_float {
 
         let value = Q::from(numerator as f64 / denominator as f64);
 
-        let cmp = Q::try_from((&numerator, &denominator)).unwrap();
+        let cmp = Q::from((numerator, denominator));
         assert_eq!(cmp, value)
     }
 
@@ -785,7 +785,7 @@ mod test_from_float {
 
         let value = Q::from(numerator as f64 / denominator as f64);
 
-        let cmp = Q::try_from((&numerator, &denominator)).unwrap();
+        let cmp = Q::from((numerator, denominator));
         assert_eq!(cmp, value)
     }
 

--- a/src/rational/q/get.rs
+++ b/src/rational/q/get.rs
@@ -20,7 +20,7 @@ impl Q {
     /// use qfall_math::rational::Q;
     /// use qfall_math::integer::Z;
     ///
-    /// let value = Q::try_from((&2,&20)).unwrap();
+    /// let value = Q::from((2, 20));
     ///
     /// let den = value.get_denominator();
     ///
@@ -39,7 +39,7 @@ impl Q {
     /// use qfall_math::rational::Q;
     /// use qfall_math::integer::Z;
     ///
-    /// let value = Q::try_from((&2,&20)).unwrap();
+    /// let value = Q::from((2, 20));
     ///
     /// let num = value.get_numerator();
     ///
@@ -59,7 +59,7 @@ mod test_get_denominator {
     /// get a small denominator
     #[test]
     fn get_small() {
-        let value = Q::try_from((&2, &20)).unwrap();
+        let value = Q::from((2, 20));
         let den = value.get_denominator();
         assert_eq!(den, Z::from(10));
     }
@@ -67,7 +67,7 @@ mod test_get_denominator {
     /// get a large denominator (uses FLINT's pointer representation)
     #[test]
     fn get_large() {
-        let value = Q::try_from((&1, &i64::MAX)).unwrap();
+        let value = Q::from((1, i64::MAX));
         let den = value.get_denominator();
         assert_eq!(den, Z::from(i64::MAX));
     }
@@ -80,7 +80,7 @@ mod test_get_numerator {
     /// get a small numerator
     #[test]
     fn get_small() {
-        let value = Q::try_from((&2, &20)).unwrap();
+        let value = Q::from((2, 20));
         let num = value.get_numerator();
         assert_eq!(num, Z::from(1));
     }
@@ -88,7 +88,7 @@ mod test_get_numerator {
     /// get a large numerator (uses FLINT's pointer representation)
     #[test]
     fn get_large() {
-        let value = Q::try_from((&i64::MAX, &1)).unwrap();
+        let value = Q::from(i64::MAX);
         let num = value.get_numerator();
         assert_eq!(num, Z::from(i64::MAX));
     }

--- a/src/rational/q/ownership.rs
+++ b/src/rational/q/ownership.rs
@@ -23,7 +23,7 @@ impl Clone for Q {
     /// use qfall_math::rational::Q;
     /// use std::str::FromStr;
     ///
-    /// let a = Q::from_str("3/4").unwrap();
+    /// let a = Q::from((3, 4));
     /// let b = a.clone();
     /// ```
     fn clone(&self) -> Self {
@@ -42,7 +42,7 @@ impl Drop for Q {
     /// use qfall_math::rational::Q;
     /// use std::str::FromStr;
     /// {
-    ///     let a = Q::from_str("3/4").unwrap();
+    ///     let a = Q::from((3, 4));
     /// } // as a's scope ends here, it get's dropped
     /// ```
     ///
@@ -50,7 +50,7 @@ impl Drop for Q {
     /// use qfall_math::rational::Q;
     /// use std::str::FromStr;
     ///
-    /// let a = Q::from_str("3/4").unwrap();
+    /// let a = Q::from((3, 4));
     /// drop(a); // explicitly drops a's value
     /// ```
     fn drop(&mut self) {
@@ -139,10 +139,10 @@ mod test_clone {
     fn keep_alive() {
         let a: Q;
         {
-            let b = Q::from_str("5/1").unwrap();
+            let b = Q::from((5, 1));
             a = b.clone();
         }
-        assert_eq!(a, Q::from_str("5/1").unwrap());
+        assert_eq!(a, Q::from((5, 1)));
     }
 }
 

--- a/src/rational/q/ownership.rs
+++ b/src/rational/q/ownership.rs
@@ -139,10 +139,10 @@ mod test_clone {
     fn keep_alive() {
         let a: Q;
         {
-            let b = Q::from((5, 1));
+            let b = Q::from(5);
             a = b.clone();
         }
-        assert_eq!(a, Q::from((5, 1)));
+        assert_eq!(a, Q::from(5));
     }
 }
 

--- a/src/rational/q/properties.rs
+++ b/src/rational/q/properties.rs
@@ -41,7 +41,7 @@ impl Q {
     ///
     /// let inverse = value.inverse().unwrap();
     ///
-    /// assert_eq!(Q::try_from((&1, &4)).unwrap(), inverse);
+    /// assert_eq!(Q::from((1, 4)), inverse);
     /// ```
     pub fn inverse(&self) -> Option<Q> {
         if self == &Q::ZERO {
@@ -104,13 +104,10 @@ mod test_abs {
     #[test]
     fn large_values() {
         let pos = Q::from(i64::MAX);
-        let neg = Q::try_from((&1, &i64::MIN)).unwrap();
+        let neg = Q::from((1, i64::MIN));
 
         assert_eq!(Q::from(i64::MAX), pos.abs());
-        assert_eq!(
-            Q::try_from((&1, &i64::MIN)).unwrap() * Q::from(-1),
-            neg.abs()
-        );
+        assert_eq!(Q::from((-1, i64::MIN)), neg.abs());
     }
 }
 
@@ -122,26 +119,26 @@ mod test_inv {
     #[test]
     fn small_values() {
         let val_0 = Q::from(4);
-        let val_1 = Q::try_from((&2, &-7)).unwrap();
+        let val_1 = Q::from((2, -7));
 
         let inv_0 = val_0.inverse().unwrap();
         let inv_1 = val_1.inverse().unwrap();
 
-        assert_eq!(Q::try_from((&1, &4)).unwrap(), inv_0);
-        assert_eq!(Q::try_from((&-7, &2)).unwrap(), inv_1);
+        assert_eq!(Q::from((1, 4)), inv_0);
+        assert_eq!(Q::from((-7, 2)), inv_1);
     }
 
     /// Checks whether the inverse is correctly computed for large values.
     #[test]
     fn large_values() {
-        let val_0 = Q::try_from((&1, &i64::MAX)).unwrap();
+        let val_0 = Q::from((1, i64::MAX));
         let val_1 = Q::from(i64::MIN);
 
         let inv_0 = val_0.inverse().unwrap();
         let inv_1 = val_1.inverse().unwrap();
 
         assert_eq!(Q::from(i64::MAX), inv_0);
-        assert_eq!(Q::try_from((&1, &i64::MIN)).unwrap(), inv_1);
+        assert_eq!(Q::from((1, i64::MIN)), inv_1);
     }
 
     /// Checks whether the inverse of `0` returns `None`.
@@ -163,7 +160,7 @@ mod test_is_zero {
     /// Ensure that is_zero returns `true` for `0`.
     #[test]
     fn zero_detection() {
-        let zero = Q::from(0);
+        let zero = Q::ZERO;
 
         assert!(zero.is_zero());
     }

--- a/src/rational/q/rounding.rs
+++ b/src/rational/q/rounding.rs
@@ -23,13 +23,13 @@ impl Q {
     /// use qfall_math::rational::Q;
     /// use qfall_math::integer::Z;
     ///
-    /// let value = Q::try_from((&5,&2)).unwrap();
+    /// let value = Q::from((5, 2));
     /// assert_eq!(Z::from(2), value.floor());
     ///
-    /// let value = Q::try_from((&-5,&2)).unwrap();
+    /// let value = Q::from((-5, 2));
     /// assert_eq!(Z::from(-3), value.floor());
     ///
-    /// let value = Q::try_from((&2,&1)).unwrap();
+    /// let value = Q::from(2);
     /// assert_eq!(Z::from(2), value.floor());
     /// ```
     pub fn floor(&self) -> Z {
@@ -45,13 +45,13 @@ impl Q {
     /// use qfall_math::rational::Q;
     /// use qfall_math::integer::Z;
     ///
-    /// let value = Q::try_from((&5,&2)).unwrap();
+    /// let value = Q::from((5, 2));
     /// assert_eq!(Z::from(3), value.ceil());
     ///
-    /// let value = Q::try_from((&-5,&2)).unwrap();
+    /// let value = Q::from((-5, 2));
     /// assert_eq!(Z::from(-2), value.ceil());
     ///
-    /// let value = Q::try_from((&2,&1)).unwrap();
+    /// let value = Q::from(2);
     /// assert_eq!(Z::from(2), value.ceil());
     /// ```
     pub fn ceil(&self) -> Z {
@@ -68,13 +68,13 @@ impl Q {
     /// use qfall_math::rational::Q;
     /// use qfall_math::integer::Z;
     ///
-    /// let value = Q::try_from((&5,&2)).unwrap();
+    /// let value = Q::from((5, 2));
     /// assert_eq!(Z::from(3), value.round());
     ///
-    /// let value = Q::try_from((&-5,&2)).unwrap();
+    /// let value = Q::from((-5, 2));
     /// assert_eq!(Z::from(-2), value.round());
     ///
-    /// let value = Q::try_from((&2,&1)).unwrap();
+    /// let value = Q::from(2);
     /// assert_eq!(Z::from(2), value.round());
     /// ```
     pub fn round(&self) -> Z {
@@ -98,18 +98,18 @@ impl Q {
     /// ```
     /// use qfall_math::rational::Q;
     ///
-    /// let value = Q::try_from((&17, &20)).unwrap();
-    /// let precision = Q::try_from((&1, &20)).unwrap();
+    /// let value = Q::from((17, 20));
+    /// let precision = Q::from((1, 20));
     ///
-    /// let simplified = Q::try_from((&4, &5)).unwrap();
+    /// let simplified = Q::from((4, 5));
     /// assert_eq!(simplified, value.simplify(&precision));
     /// ```
     ///
     /// ```
     /// use qfall_math::rational::Q;
     ///
-    /// let value = Q::try_from((&3, &2)).unwrap();
-    /// let precision = Q::try_from((&1, &2)).unwrap();
+    /// let value = Q::from((3, 2));
+    /// let precision = Q::from((1, 2));
     ///
     /// assert_eq!(Q::ONE, value.simplify(&precision));
     /// ```
@@ -129,8 +129,8 @@ mod test_floor {
     // Ensure that positive rationals are rounded correctly
     #[test]
     fn positive() {
-        let val_1 = Q::try_from((&i64::MAX, &2)).unwrap();
-        let val_2 = Q::try_from((&1, &u64::MAX)).unwrap();
+        let val_1 = Q::from((i64::MAX, 2));
+        let val_2 = Q::from((1, u64::MAX));
 
         assert_eq!(Z::from((i64::MAX - 1) / 2), val_1.floor());
         assert_eq!(Z::ZERO, val_2.floor());
@@ -139,8 +139,8 @@ mod test_floor {
     // Ensure that negative rationals are rounded correctly
     #[test]
     fn negative() {
-        let val_1 = Q::try_from((&-i64::MAX, &2)).unwrap();
-        let val_2 = Q::try_from((&-1, &u64::MAX)).unwrap();
+        let val_1 = Q::from((-i64::MAX, 2));
+        let val_2 = Q::from((-1, u64::MAX));
 
         assert_eq!(Z::from((-i64::MAX - 1) / 2), val_1.floor());
         assert_eq!(Z::MINUS_ONE, val_2.floor());
@@ -154,8 +154,8 @@ mod test_ceil {
     // Ensure that positive rationals are rounded correctly
     #[test]
     fn positive() {
-        let val_1 = Q::try_from((&i64::MAX, &2)).unwrap();
-        let val_2 = Q::try_from((&1, &u64::MAX)).unwrap();
+        let val_1 = Q::from((i64::MAX, 2));
+        let val_2 = Q::from((1, u64::MAX));
 
         assert_eq!(Z::from((i64::MAX - 1) / 2 + 1), val_1.ceil());
         assert_eq!(Z::ONE, val_2.ceil());
@@ -164,8 +164,8 @@ mod test_ceil {
     // Ensure that negative rationals are rounded correctly
     #[test]
     fn negative() {
-        let val_1 = Q::try_from((&-i64::MAX, &2)).unwrap();
-        let val_2 = Q::try_from((&-1, &u64::MAX)).unwrap();
+        let val_1 = Q::from((-i64::MAX, 2));
+        let val_2 = Q::from((-1, u64::MAX));
 
         assert_eq!(Z::from((-i64::MAX - 1) / 2 + 1), val_1.ceil());
         assert_eq!(Z::ZERO, val_2.ceil());
@@ -179,8 +179,8 @@ mod test_round {
     // Ensure that positive rationals are rounded correctly
     #[test]
     fn positive() {
-        let val_1 = Q::try_from((&i64::MAX, &2)).unwrap();
-        let val_2 = Q::try_from((&1, &u64::MAX)).unwrap();
+        let val_1 = Q::from((i64::MAX, 2));
+        let val_2 = Q::from((1, u64::MAX));
 
         assert_eq!(Z::from((i64::MAX - 1) / 2 + 1), val_1.round());
         assert_eq!(Z::ZERO, val_2.round());
@@ -189,8 +189,8 @@ mod test_round {
     // Ensure that negative rationals are rounded correctly
     #[test]
     fn negative() {
-        let val_1 = Q::try_from((&-i64::MAX, &2)).unwrap();
-        let val_2 = Q::try_from((&-1, &u64::MAX)).unwrap();
+        let val_1 = Q::from((-i64::MAX, 2));
+        let val_2 = Q::from((-1, u64::MAX));
 
         assert_eq!(Z::from((-i64::MAX - 1) / 2 + 1), val_1.round());
         assert_eq!(Z::ZERO, val_2.round());
@@ -204,12 +204,12 @@ mod test_simplify {
     /// Ensure that negative precision works as expected
     #[test]
     fn precision_absolute_value() {
-        let value_1 = Q::try_from((&17, &20)).unwrap();
-        let value_2 = Q::try_from((&-17, &20)).unwrap();
-        let precision = Q::try_from((&-1, &20)).unwrap();
+        let value_1 = Q::from((17, 20));
+        let value_2 = Q::from((-17, 20));
+        let precision = Q::from((-1, 20));
 
-        let simplified_1 = Q::try_from((&4, &5)).unwrap();
-        let simplified_2 = Q::try_from((&-4, &5)).unwrap();
+        let simplified_1 = Q::from((4, 5));
+        let simplified_2 = Q::from((-4, 5));
         assert_eq!(simplified_1, value_1.simplify(&precision));
         assert_eq!(simplified_2, value_2.simplify(&precision));
     }
@@ -217,8 +217,8 @@ mod test_simplify {
     /// Ensure that large values with pointer representations are reduced
     #[test]
     fn large_pointer_representation() {
-        let value = Q::try_from((&(u64::MAX - 1), &u64::MAX)).unwrap();
-        let precision = Q::try_from((&1, &u64::MAX)).unwrap();
+        let value = Q::from((u64::MAX - 1, u64::MAX));
+        let precision = Q::from((1, u64::MAX));
 
         assert_eq!(Q::ONE, value.simplify(&precision));
     }
@@ -226,21 +226,18 @@ mod test_simplify {
     /// Ensure that the simplified value stays in range
     #[test]
     fn stay_in_precision() {
-        let value = Q::try_from((&(i64::MAX - 1), &i64::MAX)).unwrap();
-        let precision = Q::try_from((&1, &(u64::MAX - 1))).unwrap();
+        let value = Q::from((i64::MAX - 1, i64::MAX));
+        let precision = Q::from((1, u64::MAX - 1));
 
         let simplified = value.simplify(&precision);
         assert!(&value - &precision <= simplified && simplified <= &value + &precision);
-        assert!(
-            Q::try_from((&(i64::MAX - 2), &i64::MAX)).unwrap() <= simplified
-                && simplified <= 1.into()
-        );
+        assert!(Q::from((i64::MAX - 2, i64::MAX)) <= simplified && simplified <= 1.into());
     }
 
     /// Ensure that a value which can not be simplified is not changed
     #[test]
     fn no_change() {
-        let precision = Q::try_from((&1, &(u64::MAX - 1))).unwrap();
+        let precision = Q::from((1, u64::MAX - 1));
 
         assert_eq!(Q::ONE, Q::ONE.simplify(&precision));
         assert_eq!(Q::MINUS_ONE, Q::MINUS_ONE.simplify(&precision));

--- a/src/rational/q/serialize.rs
+++ b/src/rational/q/serialize.rs
@@ -32,7 +32,7 @@ mod test_serialize {
     /// Tests whether the serialization of a positive [`Q`] works.
     #[test]
     fn serialize_output_positive() {
-        let q = Q::from_str("17/3").unwrap();
+        let q = Q::from((17, 3));
         let cmp_string = "{\"value\":\"17/3\"}";
 
         assert_eq!(cmp_string, serde_json::to_string(&q).unwrap())
@@ -41,7 +41,7 @@ mod test_serialize {
     /// Tests whether the serialization of a negative [`Q`] works.
     #[test]
     fn serialize_output_negative() {
-        let q = Q::from_str("-17/3").unwrap();
+        let q = Q::from((-17, 3));
         let cmp_string = "{\"value\":\"-17/3\"}";
 
         assert_eq!(cmp_string, serde_json::to_string(&q).unwrap())
@@ -77,20 +77,14 @@ mod test_deserialize {
     #[test]
     fn deserialize_positive() {
         let q_string = "{\"value\":\"17/3\"}";
-        assert_eq!(
-            Q::from_str("17/3").unwrap(),
-            serde_json::from_str(q_string).unwrap()
-        )
+        assert_eq!(Q::from((17, 3)), serde_json::from_str(q_string).unwrap())
     }
 
     /// Tests whether the deserialization of a negative [`Q`] works.
     #[test]
     fn deserialize_negative() {
         let q_string = "{\"value\":\"-17/3\"}";
-        assert_eq!(
-            Q::from_str("-17/3").unwrap(),
-            serde_json::from_str(q_string).unwrap()
-        )
+        assert_eq!(Q::from((-17, 3)), serde_json::from_str(q_string).unwrap())
     }
 
     /// Tests whether the deserialization of a positive large [`Q`] works.

--- a/src/rational/q/to_string.rs
+++ b/src/rational/q/to_string.rs
@@ -28,7 +28,7 @@ impl fmt::Display for Q {
     /// use qfall_math::rational::Q;
     /// use core::fmt;
     ///
-    /// let rational = Q::from_str("-1/235").unwrap();
+    /// let rational = Q::from((-1, 235));
     /// println!("{}", rational);
     /// ```
     ///
@@ -37,7 +37,7 @@ impl fmt::Display for Q {
     /// use qfall_math::rational::Q;
     /// use core::fmt;
     ///
-    /// let rational = Q::from_str("-1/235").unwrap();
+    /// let rational = Q::from((-1, 235));
     /// let integer_string = rational.to_string();
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -67,7 +67,7 @@ mod test_to_string {
     /// Tests whether a large positive rational works in a roundtrip
     #[test]
     fn working_large_positive_nom() {
-        let cmp = Q::from_str(&u64::MAX.to_string()).unwrap();
+        let cmp = Q::from(u64::MAX);
 
         assert_eq!(u64::MAX.to_string(), cmp.to_string())
     }
@@ -99,7 +99,7 @@ mod test_to_string {
     /// Tests whether a positive rational works in a roundtrip
     #[test]
     fn working_positive() {
-        let cmp = Q::from_str("42/235").unwrap();
+        let cmp = Q::from((42, 235));
 
         assert_eq!("42/235", cmp.to_string())
     }
@@ -107,7 +107,7 @@ mod test_to_string {
     /// Tests whether a negative rational works in a roundtrip
     #[test]
     fn working_negative() {
-        let cmp = Q::from_str("-42/235").unwrap();
+        let cmp = Q::from((-42, 235));
 
         assert_eq!("-42/235", cmp.to_string())
     }
@@ -116,7 +116,7 @@ mod test_to_string {
     /// string that can be used to create a [`Q`]
     #[test]
     fn working_use_result_of_to_string_as_input() {
-        let cmp = Q::from_str("42/235").unwrap();
+        let cmp = Q::from((42, 235));
 
         let cmp_string2 = cmp.to_string();
 

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -85,9 +85,7 @@ pub(crate) fn sample_z(n: &Z, center: &Q, s: &Q) -> Result<Z, MathError> {
     // this eprint version explains in more detail how sample_z works
     let rng = get_rng();
     // TODO: Change to Q::from_f64 once it works appropriately for large scale
-    while gaussian_function(&sample, center, s)
-        <= Q::try_from((&rng.next_u64(), &u64::MAX)).unwrap()
-    {
+    while gaussian_function(&sample, center, s) <= Q::from((rng.next_u64(), u64::MAX)) {
         sample = &lower_bound + sample_uniform_rejection(&interval_size).unwrap();
     }
 
@@ -247,7 +245,7 @@ mod test_sample_z {
     fn small_interval() {
         let n = Z::from(1024);
         let center = Q::from(15);
-        let gaussian_parameter = Q::try_from((&1, &2)).unwrap();
+        let gaussian_parameter = Q::from((1, 2));
 
         for _ in 0..64 {
             let sample = sample_z(&n, &center, &gaussian_parameter).unwrap();
@@ -280,7 +278,7 @@ mod test_sample_z {
 
         assert!(sample_z(&n, &center, &Q::ZERO).is_err());
         assert!(sample_z(&n, &center, &Q::MINUS_ONE).is_err());
-        assert!(sample_z(&n, &center, &Q::try_from((&i64::MIN, &1)).unwrap()).is_err());
+        assert!(sample_z(&n, &center, &Q::from(i64::MIN)).is_err());
     }
 
     /// Checks whether `sample_z` returns an error if `n <= 1`
@@ -308,11 +306,11 @@ mod test_gaussian_function {
         let center = Q::ZERO;
         let gaussian_parameter = Q::ONE;
         // result roughly 0.0432139 computed via WolframAlpha
-        let cmp = Q::try_from((&43214, &1_000_000)).unwrap();
+        let cmp = Q::from((43214, 1_000_000));
 
         let value = gaussian_function(&sample, &center, &gaussian_parameter);
 
-        assert!(cmp.distance(&value) < Q::try_from((&1, &1_000_000)).unwrap());
+        assert!(cmp.distance(&value) < Q::from((1, 1_000_000)));
     }
 
     /// Checks whether the values for small values are computed appropriately
@@ -322,20 +320,20 @@ mod test_gaussian_function {
         let sample_0 = Z::ZERO;
         let sample_1 = Z::MINUS_ONE;
         let center = Q::MINUS_ONE;
-        let gaussian_parameter_0 = Q::try_from((&1, &2)).unwrap();
-        let gaussian_parameter_1 = Q::try_from((&3, &2)).unwrap();
+        let gaussian_parameter_0 = Q::from((1, 2));
+        let gaussian_parameter_1 = Q::from((3, 2));
         // result roughly 0.00000348734 computed via WolframAlpha
-        let cmp_0 = Q::try_from((&349, &100_000_000)).unwrap();
+        let cmp_0 = Q::from((349, 100_000_000));
         // result 0.247520 computed via WolframAlpha
-        let cmp_1 = Q::try_from((&24752, &100_000)).unwrap();
+        let cmp_1 = Q::from((24752, 100_000));
 
         let res_0 = gaussian_function(&sample_0, &center, &gaussian_parameter_0);
         let res_1 = gaussian_function(&sample_0, &center, &gaussian_parameter_1);
         let res_2 = gaussian_function(&sample_1, &center, &gaussian_parameter_0);
         let res_3 = gaussian_function(&sample_1, &center, &gaussian_parameter_1);
 
-        assert!(cmp_0.distance(&res_0) < Q::try_from((&3, &1_000_000_000)).unwrap());
-        assert!(cmp_1.distance(&res_1) < Q::try_from((&1, &1_000_000)).unwrap());
+        assert!(cmp_0.distance(&res_0) < Q::from((3, 1_000_000_000)));
+        assert!(cmp_1.distance(&res_1) < Q::from((1, 1_000_000)));
         assert_eq!(Q::ONE, res_2);
         assert_eq!(Q::ONE, res_3);
     }
@@ -346,13 +344,13 @@ mod test_gaussian_function {
     fn large_values() {
         let sample = Z::from(i64::MAX);
         let center = Q::from(i64::MAX as u64 + 1);
-        let gaussian_parameter = Q::try_from((&1, &2)).unwrap();
+        let gaussian_parameter = Q::from((1, 2));
         // result roughly 0.00000348734 computed via WolframAlpha
-        let cmp = Q::try_from((&349, &100_000_000)).unwrap();
+        let cmp = Q::from((349, 100_000_000));
 
         let res = gaussian_function(&sample, &center, &gaussian_parameter);
 
-        assert!(cmp.distance(&res) < Q::try_from((&3, &1_000_000_000)).unwrap());
+        assert!(cmp.distance(&res) < Q::from((3, 1_000_000_000)));
     }
 
     /// Checks whether `s = 0` results in a panic
@@ -460,7 +458,7 @@ mod test_sample_d {
 
         assert!(sample_d(&basis, &n, &center, &Q::ZERO).is_err());
         assert!(sample_d(&basis, &n, &center, &Q::MINUS_ONE).is_err());
-        assert!(sample_d(&basis, &n, &center, &Q::try_from((&i64::MIN, &1)).unwrap()).is_err());
+        assert!(sample_d(&basis, &n, &center, &Q::from(i64::MIN)).is_err());
     }
 
     /// Checks whether `sample_d` returns an error if `n <= 1`


### PR DESCRIPTION
**Description**

This PR implements...
- [x] Rename `BITPRIME64` to something like `PRIME_64_BIT` or `LARGE_PRIME`.
- [x] Modulus try_from, from_str and try_from_z to modulus::form(integer), Panics now in documentation
- [x] Zq::try_from => Zq::from, maybe change return type of functions accordingly, Panics now in documentation
- [x] use from methods instead of from_*
- [x] Zq::sample_discrete_gauss, change parameter types, remove Clone, into<Modulus> etc.
- [x] Ensure that Panics are documented in `# Panics ...` start next line with `- if` and end with a dot.


**Testing**

I used regex search and hope that I found everything.
