### PR TITLE
Format doc comment function calls

### DIFF
--- a/src/integer/mat_poly_over_z/cmp.rs
+++ b/src/integer/mat_poly_over_z/cmp.rs
@@ -36,7 +36,7 @@ impl PartialEq for MatPolyOverZ {
     /// # assert!(!compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (MatPolyOverZ::eq(&a,&b));
+    /// let compared: bool = (MatPolyOverZ::eq(&a, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -104,7 +104,7 @@ impl From<&MatZ> for MatPolyOverZ {
     /// ```
     /// use qfall_math::integer::{MatZ, MatPolyOverZ};
     ///
-    /// let mat_z = MatZ::identity(10,10);
+    /// let mat_z = MatZ::identity(10, 10);
     /// let mat_poly = MatPolyOverZ::from(&mat_z);
     /// ```
     fn from(matrix: &MatZ) -> Self {

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -29,7 +29,7 @@ impl GetNumRows for MatPolyOverZ {
     /// use qfall_math::integer::MatPolyOverZ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatPolyOverZ::new(5,6);
+    /// let matrix = MatPolyOverZ::new(5, 6);
     /// let rows = matrix.get_num_rows();
     /// ```
     fn get_num_rows(&self) -> i64 {
@@ -45,7 +45,7 @@ impl GetNumColumns for MatPolyOverZ {
     /// use qfall_math::integer::MatPolyOverZ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatPolyOverZ::new(5,6);
+    /// let matrix = MatPolyOverZ::new(5, 6);
     /// let columns = matrix.get_num_columns();
     /// ```
     fn get_num_columns(&self) -> i64 {

--- a/src/integer/mat_z/cmp.rs
+++ b/src/integer/mat_z/cmp.rs
@@ -34,7 +34,7 @@ impl PartialEq for MatZ {
     /// # assert!(!compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (MatZ::eq(&a,&b));
+    /// let compared: bool = (MatZ::eq(&a, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -29,7 +29,7 @@ impl GetNumRows for MatZ {
     /// use qfall_math::integer::MatZ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatZ::new(5,6);
+    /// let matrix = MatZ::new(5, 6);
     /// let rows = matrix.get_num_rows();
     /// ```
     fn get_num_rows(&self) -> i64 {
@@ -45,7 +45,7 @@ impl GetNumColumns for MatZ {
     /// use qfall_math::integer::MatZ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatZ::new(5,6);
+    /// let matrix = MatZ::new(5, 6);
     /// let columns = matrix.get_num_columns();
     /// ```
     fn get_num_columns(&self) -> i64 {

--- a/src/integer/poly_over_z/cmp.rs
+++ b/src/integer/poly_over_z/cmp.rs
@@ -35,7 +35,7 @@ impl PartialEq for PolyOverZ {
     /// # assert!(!compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (PolyOverZ::eq(&a,&b));
+    /// let compared: bool = (PolyOverZ::eq(&a, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {

--- a/src/integer/poly_over_z/evaluate.rs
+++ b/src/integer/poly_over_z/evaluate.rs
@@ -65,7 +65,7 @@ impl Evaluate<&Q, Q> for PolyOverZ {
     /// use std::str::FromStr;
     ///
     /// let poly = PolyOverZ::from_str("5  0 1 2 -3 1").unwrap();
-    /// let value = Q::from((3,2));
+    /// let value = Q::from((3, 2));
     /// let res = poly.evaluate(&value);
     /// ```
     fn evaluate(&self, value: &Q) -> Q {

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -77,7 +77,7 @@ impl Add<&Q> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(-42);
-    /// let b: Q = Q::from((42,19));
+    /// let b: Q = Q::from((42, 19));
     ///
     /// let c: Q = &a + &b;
     /// let d: Q = a + b;
@@ -113,7 +113,7 @@ impl Add<&Zq> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(42);
-    /// let b: Zq = Zq::from((42,19));
+    /// let b: Zq = Zq::from((42, 19));
     ///
     /// let c: Zq = &a + &b;
     /// let d: Zq = a + b;

--- a/src/integer/z/arithmetic/div.rs
+++ b/src/integer/z/arithmetic/div.rs
@@ -229,7 +229,7 @@ impl Div<&Q> for &Z {
     /// use std::str::FromStr;
     ///
     /// let a: Z = Z::from(-42);
-    /// let b: Q = Q::from((42,19));
+    /// let b: Q = Q::from((42, 19));
     ///
     /// let c: Q = &a / &b;
     /// let d: Q = a / b;

--- a/src/integer/z/cmp.rs
+++ b/src/integer/z/cmp.rs
@@ -34,7 +34,7 @@ impl PartialEq for Z {
     /// # assert!(!compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (Z::eq(&a,&b));
+    /// let compared: bool = (Z::eq(&a, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {

--- a/src/integer/z/distance.rs
+++ b/src/integer/z/distance.rs
@@ -55,7 +55,7 @@ mod test_distance {
     use super::{Distance, Modulus, Z};
 
     /// Checks if distance is correctly computed for small [`Z`] values
-    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    /// and whether distance(a, b) == distance(b, a), distance(a, a) == 0
     #[test]
     fn small_values() {
         let a = Z::ONE;
@@ -72,7 +72,7 @@ mod test_distance {
     }
 
     /// Checks if distance is correctly computed for large [`Z`] values
-    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    /// and whether distance(a, b) == distance(b, a), distance(a, a) == 0
     #[test]
     fn large_values() {
         let a = Z::from(i64::MAX);

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -340,7 +340,7 @@ mod test_distance {
     use flint_sys::fmpz::fmpz;
 
     /// Checks if distance is correctly output for small [`Z`] values
-    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    /// and whether distance(a, b) == distance(b, a), distance(a, a) == 0
     #[test]
     fn small_values() {
         let a = fmpz(1);
@@ -359,7 +359,7 @@ mod test_distance {
     }
 
     /// Checks if distance is correctly output for large [`Z`] values
-    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    /// and whether distance(a, b) == distance(b, a), distance(a, a) == 0
     #[test]
     fn large_values() {
         let a = Z::from(i64::MAX);

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -44,7 +44,7 @@ impl Z {
     /// ```
     /// ```compile_fail
     /// use qfall_math::integer::Z;
-    /// use flint_sys::fmpz::{fmpz,fmpz_clear};
+    /// use flint_sys::fmpz::{fmpz, fmpz_clear};
     ///
     /// let value = fmpz(0);
     ///

--- a/src/integer/z/gcd.rs
+++ b/src/integer/z/gcd.rs
@@ -20,7 +20,7 @@ impl Gcd<&Z> for Z {
     type Output = Z;
 
     /// Outputs the greatest common divisor (gcd) of the two given values
-    /// with `gcd(a,0) = |a|`.
+    /// with `gcd(a, 0) = |a|`.
     ///
     /// Paramters:
     /// - `other`: specifies one of the values of which the gcd is computed
@@ -54,13 +54,13 @@ impl Xgcd<&Z> for Z {
     type Output = (Z, Z, Z);
 
     /// Outputs the extended greatest common divisor (xgcd) of the two given values,
-    /// i.e. a triple `(gcd(a,b), x, y)`, where `a*x + b*y = gcd(a,b)*`.
+    /// i.e. a triple `(gcd(a, b), x, y)`, where `a*x + b*y = gcd(a, b)*`.
     ///
     /// Paramters:
     /// - `other`: specifies one of the values of which the gcd is computed
     ///
-    /// Returns a triple `(gcd(a,b), x, y)` containing the greatest common divisor,
-    /// `x`, and `y` s.t. `gcd(a,b) = a*x + b*y`.
+    /// Returns a triple `(gcd(a, b), x, y)` containing the greatest common divisor,
+    /// `x`, and `y` s.t. `gcd(a, b) = a*x + b*y`.
     ///
     /// # Examples
     /// ```
@@ -101,7 +101,7 @@ mod test_gcd {
     use super::{Gcd, Z};
 
     /// Ensures that the gcd is correctly computed for small [`Z`] instances
-    /// and ensures properties: `gcd(a,b) == gcd(b,a)` and `gcd(a,a) == a`
+    /// and ensures properties: `gcd(a, b) == gcd(b, a)` and `gcd(a, a) == a`
     #[test]
     fn small() {
         let pos_1 = Z::from(10);
@@ -129,8 +129,8 @@ mod test_gcd {
     }
 
     /// Ensures that the gcd is correctly computed for small [`Z`] instances
-    /// and ensures properties: `gcd(a,b) == gcd(b,a)`, `gcd(a,a) == a`, and
-    /// `gcd(a,0) == a`
+    /// and ensures properties: `gcd(a, b) == gcd(b, a)`, `gcd(a, a) == a`, and
+    /// `gcd(a, 0) == a`
     #[test]
     fn large() {
         let pos = Z::from(i64::MAX);
@@ -173,7 +173,7 @@ mod test_xgcd {
     use super::{Xgcd, Z};
 
     /// Ensures that the gcd is correctly computed for small [`Z`] instances
-    /// and ensures properties: `gcd(a,b) == gcd(b,a)` and `gcd(a,a) == a`
+    /// and ensures properties: `gcd(a, b) == gcd(b, a)` and `gcd(a, a) == a`
     #[test]
     fn gcd_small() {
         let pos_1 = Z::from(10);
@@ -201,8 +201,8 @@ mod test_xgcd {
     }
 
     /// Ensures that the gcd is correctly computed for small [`Z`] instances
-    /// and ensures properties: `gcd(a,b) == gcd(b,a)`, `gcd(a,a) == a`, and
-    /// `gcd(a,0) == a`
+    /// and ensures properties: `gcd(a, b) == gcd(b, a)`, `gcd(a, a) == a`, and
+    /// `gcd(a, 0) == a`
     #[test]
     fn gcd_large() {
         let pos = Z::from(i64::MAX);
@@ -224,7 +224,7 @@ mod test_xgcd {
     }
 
     /// Ensures that the computation of `x` and `y` works correctly
-    /// s.t. `a*x + b*y = gcd(a,b)` for small values
+    /// s.t. `a*x + b*y = gcd(a, b)` for small values
     #[test]
     fn xy_small() {
         let pos_1 = Z::from(10);
@@ -277,7 +277,7 @@ mod test_xgcd {
     }
 
     /// Ensures that the computation of `x` and `y` works correctly
-    /// s.t. `a*x + b*y = gcd(a,b)` for large values
+    /// s.t. `a*x + b*y = gcd(a, b)` for large values
     #[test]
     fn xy_large() {
         let pos = Z::from(i64::MAX);
@@ -290,7 +290,7 @@ mod test_xgcd {
         let xgcd_4 = neg.xgcd(&neg);
         let xgcd_5 = pos.xgcd(&neg);
 
-        // check that `gcd(a,b) == a * x + b * y`
+        // check that `gcd(a, b) == a * x + b * y`
         assert_eq!(xgcd_1.0, &pos * &xgcd_1.1 + &zero * &xgcd_1.2);
         assert_eq!(xgcd_2.0, &pos * &xgcd_2.1 + &pos * &xgcd_2.2);
         assert_eq!(xgcd_3.0, &neg * &xgcd_3.1 + &zero * &xgcd_3.2);

--- a/src/integer/z/lcm.rs
+++ b/src/integer/z/lcm.rs
@@ -54,7 +54,7 @@ mod test_lcm {
     use super::{Lcm, Z};
 
     /// Ensures that the lcm is correctly computed for small [`Z`] instances
-    /// and ensures properties: `lcm(a,b) == lcm(b,a)` and `lcm(a,a) == a`
+    /// and ensures properties: `lcm(a, b) == lcm(b, a)` and `lcm(a, a) == a`
     #[test]
     fn small() {
         let pos_1 = Z::from(10);
@@ -82,8 +82,8 @@ mod test_lcm {
     }
 
     /// Ensures that the lcm is correctly computed for small [`Z`] instances
-    /// and ensures properties: `lcm(a,b) == lcm(b,a)`, `lcm(a,a) == a`, and
-    /// `lcm(a,0) == 0`
+    /// and ensures properties: `lcm(a, b) == lcm(b, a)`, `lcm(a, a) == a`, and
+    /// `lcm(a, 0) == 0`
     #[test]
     fn large() {
         let pos = Z::from(i64::MAX);

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -102,7 +102,7 @@ impl GetEntry<PolyOverZ> for MatPolynomialRingZq {
     /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
     /// let poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
     ///
-    /// let entry: PolyOverZ = poly_ring_mat.get_entry(1,0).unwrap();
+    /// let entry: PolyOverZ = poly_ring_mat.get_entry(1, 0).unwrap();
     /// ```
     ///
     /// # Errors and Failures
@@ -139,7 +139,7 @@ impl GetEntry<PolynomialRingZq> for MatPolynomialRingZq {
     /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
     /// let poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
     ///
-    /// let entry: PolynomialRingZq = poly_ring_mat.get_entry(1,0).unwrap();
+    /// let entry: PolynomialRingZq = poly_ring_mat.get_entry(1, 0).unwrap();
     /// ```
     ///
     /// # Errors and Failures

--- a/src/integer_mod_q/mat_zq/cmp.rs
+++ b/src/integer_mod_q/mat_zq/cmp.rs
@@ -35,7 +35,7 @@ impl PartialEq for MatZq {
     /// # assert!(!compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (MatZq::eq(&a,&b));
+    /// let compared: bool = (MatZq::eq(&a, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
@@ -38,7 +38,7 @@ impl PartialEq for ModulusPolynomialRingZq {
     /// # assert!(!compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (ModulusPolynomialRingZq::eq(&a,&b));
+    /// let compared: bool = (ModulusPolynomialRingZq::eq(&a, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {

--- a/src/integer_mod_q/poly_over_zq/cmp.rs
+++ b/src/integer_mod_q/poly_over_zq/cmp.rs
@@ -37,7 +37,7 @@ impl PartialEq for PolyOverZq {
     /// # assert!(!compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (PolyOverZq::eq(&a,&b));
+    /// let compared: bool = (PolyOverZq::eq(&a, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {

--- a/src/integer_mod_q/poly_over_zq/set.rs
+++ b/src/integer_mod_q/poly_over_zq/set.rs
@@ -96,7 +96,7 @@ impl SetCoefficient<&Zq> for PolyOverZq {
     /// use std::str::FromStr;
     ///
     /// let mut poly = PolyOverZq::from_str("4  0 1 2 3 mod 17").unwrap();
-    /// let value = Zq::from((1000,17));
+    /// let value = Zq::from((1000, 17));
     ///
     /// assert!(poly.set_coeff(4, &value).is_ok());
     /// ```

--- a/src/integer_mod_q/z_q/distance.rs
+++ b/src/integer_mod_q/z_q/distance.rs
@@ -148,7 +148,7 @@ mod test_distance_safe {
     use super::{Zq, Z};
 
     /// Checks if distance_safe is correctly computed for small [`Zq`] values
-    /// and whether distance(a,b) == distance(b,a) and distance(a,a) == 0
+    /// and whether distance(a, b) == distance(b, a) and distance(a, a) == 0
     #[test]
     fn small_values() {
         let a = Zq::from((1, 29));
@@ -177,7 +177,7 @@ mod test_distance_safe {
     }
 
     /// Checks if distance_safe is correctly computed for large [`Zq`] values
-    /// and whether distance(a,b) == distance(b,a), and distance(a,a) == 0
+    /// and whether distance(a, b) == distance(b, a), and distance(a, a) == 0
     #[test]
     fn large_values() {
         let a = Zq::from((i64::MAX, u64::MAX));

--- a/src/integer_mod_q/z_q/properties.rs
+++ b/src/integer_mod_q/z_q/properties.rs
@@ -37,7 +37,7 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let value = Zq::from((0,7));
+    /// let value = Zq::from((0, 7));
     /// assert!(value.is_zero());
     /// ```
     pub fn is_zero(&self) -> bool {
@@ -52,7 +52,7 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let value = Zq::from((1,7));
+    /// let value = Zq::from((1, 7));
     /// assert!(value.is_one());
     /// ```
     pub fn is_one(&self) -> bool {

--- a/src/rational/mat_q/cmp.rs
+++ b/src/rational/mat_q/cmp.rs
@@ -37,7 +37,7 @@ impl PartialEq for MatQ {
     /// # assert!(!compared);
     /// let compared: bool = (a1.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (MatQ::eq(&a1,&b));
+    /// let compared: bool = (MatQ::eq(&a1, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -26,7 +26,7 @@ impl GetNumRows for MatQ {
     /// use qfall_math::rational::MatQ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatQ::new(5,6);
+    /// let matrix = MatQ::new(5, 6);
     /// let rows = matrix.get_num_rows();
     /// ```
     fn get_num_rows(&self) -> i64 {
@@ -42,7 +42,7 @@ impl GetNumColumns for MatQ {
     /// use qfall_math::rational::MatQ;
     /// use qfall_math::traits::*;
     ///
-    /// let matrix = MatQ::new(5,6);
+    /// let matrix = MatQ::new(5, 6);
     /// let columns = matrix.get_num_columns();
     /// ```
     fn get_num_columns(&self) -> i64 {

--- a/src/rational/poly_over_q/cmp.rs
+++ b/src/rational/poly_over_q/cmp.rs
@@ -35,7 +35,7 @@ impl PartialEq for PolyOverQ {
     /// # assert!(!compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (PolyOverQ::eq(&a,&b));
+    /// let compared: bool = (PolyOverQ::eq(&a, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {

--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -124,10 +124,10 @@ impl<T: Into<Q>> From<T> for PolyOverQ {
     /// use qfall_math::{rational::*, traits::GetCoefficient};
     ///
     /// let one = PolyOverQ::from(1);
-    /// let three_quarter = PolyOverQ::from(Q::from((3,4)));
-    /// let one_half = PolyOverQ::from((1,2));
+    /// let three_quarter = PolyOverQ::from(Q::from((3, 4)));
+    /// let one_half = PolyOverQ::from((1, 2));
     ///
-    /// assert_eq!(one_half.get_coeff(0).unwrap(), Q::from((1,2)));
+    /// assert_eq!(one_half.get_coeff(0).unwrap(), Q::from((1, 2)));
     /// assert_eq!(one_half.get_degree(), 0);
     /// ```
     ///

--- a/src/rational/q/arithmetic/root.rs
+++ b/src/rational/q/arithmetic/root.rs
@@ -35,10 +35,10 @@ impl Q {
     /// ```
     /// use qfall_math::rational::Q;
     ///
-    /// let value = Q::from((9,4));
+    /// let value = Q::from((9, 4));
     /// let root = value.sqrt();
     ///
-    /// assert_eq!(&root, &Q::from((3,2)));
+    /// assert_eq!(&root, &Q::from((3, 2)));
     /// ```
     ///
     /// # Panics ...
@@ -52,7 +52,7 @@ impl Q {
 
     /// Calculate the square root with a specified minimum precision.
     ///
-    /// Given `Q::sqrt_precision(x/y,precision) = a/b` the maximum error to
+    /// Given `Q::sqrt_precision(x/y, precision) = a/b` the maximum error to
     /// the true square root result is `a/b * (b + 1) * p/(b-p)`
     /// with `p = 1/(2*precision)`.
     /// The actual result may be more accurate.
@@ -67,11 +67,11 @@ impl Q {
     /// use qfall_math::rational::Q;
     ///
     /// let precision = Z::from(1000);
-    /// let value = Q::from((9,4));
+    /// let value = Q::from((9, 4));
     ///
     /// let root = value.sqrt_precision(&precision).unwrap();
     ///
-    /// assert_eq!(&root, &Q::from((3,2)));
+    /// assert_eq!(&root, &Q::from((3, 2)));
     /// ```
     ///
     /// # Errors and Failures

--- a/src/rational/q/cmp.rs
+++ b/src/rational/q/cmp.rs
@@ -35,7 +35,7 @@ impl PartialEq for Q {
     /// # assert!(!compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(!compared);
-    /// let compared: bool = (Q::eq(&a,&b));
+    /// let compared: bool = (Q::eq(&a, &b));
     /// # assert!(!compared);
     /// ```
     fn eq(&self, other: &Self) -> bool {
@@ -61,8 +61,8 @@ impl PartialOrd for Q {
     /// # use qfall_math::error::MathError;
     /// use qfall_math::rational::Q;
     ///
-    /// let a: Q = Q::from((1,10));
-    /// let b: Q = Q::from((2,10));
+    /// let a: Q = Q::from((1, 10));
+    /// let b: Q = Q::from((2, 10));
     ///
     /// assert!(a < b);
     /// assert!(a <= b);

--- a/src/rational/q/distance.rs
+++ b/src/rational/q/distance.rs
@@ -53,7 +53,7 @@ mod test_distance {
     use super::{Distance, Q};
 
     /// Checks if distance is correctly computed for small [`Q`] values
-    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    /// and whether distance(a, b) == distance(b, a), distance(a, a) == 0
     #[test]
     fn small_values() {
         let a = Q::ONE;
@@ -70,7 +70,7 @@ mod test_distance {
     }
 
     /// Checks if distance is correctly computed for large [`Q`] values
-    /// and whether distance(a,b) == distance(b,a), distance(a,a) == 0
+    /// and whether distance(a, b) == distance(b, a), distance(a, a) == 0
     #[test]
     fn large_values() {
         let a = Q::from(i64::MAX);

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -209,7 +209,7 @@ impl<IntegerNumerator: AsInteger, IntegerDenominator: AsInteger>
     /// let a = Q::from((42, &2));
     /// let b = Q::from((Z::from(84), 4));
     ///
-    /// assert_eq!(a,b);
+    /// assert_eq!(a, b);
     /// ```
     ///
     /// # Panics ...

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -181,7 +181,7 @@ pub trait Gcd<T = Self> {
     type Output;
 
     /// Outputs the greatest common divisor (gcd) of the two given values
-    /// with `gcd(a,0) = |a|`.
+    /// with `gcd(a, 0) = |a|`.
     ///
     /// Paramters:
     /// - `other`: specifies one of the values of which the gcd is computed
@@ -196,13 +196,13 @@ pub trait Xgcd<T = Self> {
     type Output;
 
     /// Outputs the extended greatest common divisor (xgcd) of the two given values,
-    /// i.e. a triple `(gcd(a,b), x, y)`, where `a*x + b*y = gcd(a,b)*`.
+    /// i.e. a triple `(gcd(a, b), x, y)`, where `a*x + b*y = gcd(a, b)*`.
     ///
     /// Paramters:
     /// - `other`: specifies one of the values of which the gcd is computed
     ///
-    /// Returns a triple `(gcd(a,b), x, y)` containing the greatest common divisor,
-    /// `x`, and `y` s.t. `gcd(a,b) = a*x + b*y`.
+    /// Returns a triple `(gcd(a, b), x, y)` containing the greatest common divisor,
+    /// `x`, and `y` s.t. `gcd(a, b) = a*x + b*y`.
     fn xgcd(&self, other: T) -> Self::Output;
 }
 


### PR DESCRIPTION
Doc comments are not formatted by cargo fmt.
Now, a comma is followed by a space in the parameters.