### PR TITLE
Exponential function optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = {version="1.0", features=["derive"]}
 serde_json = "1.0"
 string-builder = "0.2.0"
 thiserror = "1.0"
+lazy_static = "1.4"
 
 [profile.bench]
 debug = true

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -12,5 +12,6 @@ use criterion::criterion_main;
 
 pub mod classic_crypto;
 pub mod integer;
+pub mod sampling;
 
-criterion_main! {integer::benches, classic_crypto::benches}
+criterion_main! {integer::benches, classic_crypto::benches, sampling::benches}

--- a/benches/sampling.rs
+++ b/benches/sampling.rs
@@ -13,8 +13,8 @@ pub fn sample_d() {
 }
 
 /// benchmark [sample_d]
-pub fn bench_sample_z(c: &mut Criterion) {
+pub fn bench_sample_d(c: &mut Criterion) {
     c.bench_function("sample_d", |b| b.iter(sample_d));
 }
 
-criterion_group!(benches, bench_sample_z);
+criterion_group!(benches, bench_sample_d);

--- a/benches/sampling.rs
+++ b/benches/sampling.rs
@@ -1,0 +1,20 @@
+use criterion::*;
+use qfall_math::{integer::*, rational::*};
+
+/// Basically the test [`qfall_math::utils::sample::discrete_gauss::test_sample_d::doc_test`]
+/// Sample a [`MatZ`] with `sample_d`.
+pub fn sample_d() {
+    let basis = MatZ::identity(5, 5);
+    let n = Z::from(1024);
+    let center = MatQ::new(5, 1);
+    let gaussian_parameter = Q::ONE;
+
+    let _ = MatZ::sample_d(&basis, &n, &center, &gaussian_parameter).unwrap();
+}
+
+/// benchmark [sample_d]
+pub fn bench_sample_z(c: &mut Criterion) {
+    c.bench_function("sample_d", |b| b.iter(sample_d));
+}
+
+criterion_group!(benches, bench_sample_z);

--- a/src/rational/poly_over_q/ownership.rs
+++ b/src/rational/poly_over_q/ownership.rs
@@ -15,9 +15,11 @@ use super::PolyOverQ;
 use flint_sys::fmpq_poly::{fmpq_poly_clear, fmpq_poly_init, fmpq_poly_set};
 use std::mem::MaybeUninit;
 
-// The use of [`PolyOverQ`] should be thread safe because we relay on FLINT.
-// Since FLINT supports multithreading, FLINT's data types are probably also thread safe.
-// FLINT itself uses GMP which usually thread safe conditions <https://gmplib.org/manual/Reentrancy>.
+// The use of [`PolyOverQ`] should be thread safe because
+// a) just mutable objects/references can manipulate the data in memory.
+// b) [`PolyOverQ`] just wraps a FLINT data type. These are probably
+//    thread safe, because FLINT supports multithreading. Additionally, FLINT
+//    relays on GMP which is thread safe in most conditions <https://gmplib.org/manual/Reentrancy>.
 unsafe impl Send for PolyOverQ {}
 unsafe impl Sync for PolyOverQ {}
 

--- a/src/rational/poly_over_q/ownership.rs
+++ b/src/rational/poly_over_q/ownership.rs
@@ -15,6 +15,12 @@ use super::PolyOverQ;
 use flint_sys::fmpq_poly::{fmpq_poly_clear, fmpq_poly_init, fmpq_poly_set};
 use std::mem::MaybeUninit;
 
+// The use of [`PolyOverQ`] should be thread safe because we relay on FLINT.
+// Since FLINT supports multithreading, FLINT's data types are probably also thread safe.
+// FLINT itself uses GMP which usually thread safe conditions <https://gmplib.org/manual/Reentrancy>.
+unsafe impl Send for PolyOverQ {}
+unsafe impl Sync for PolyOverQ {}
+
 impl Clone for PolyOverQ {
     /// Clones the given [`PolyOverQ`] element by returning a deep clone,
     /// storing two separately stored [fmpz](flint_sys::fmpz::fmpz) values

--- a/src/rational/q/arithmetic/exp.rs
+++ b/src/rational/q/arithmetic/exp.rs
@@ -14,6 +14,25 @@ use crate::{
 };
 
 impl Q {
+    /// Computes `e^self`. This is done by first converting the value to a [`f64`],
+    /// evaluating the exponential function and converting the float back to [`Q`].
+    /// As a result, the precision is limited to the precision of [`f64`].
+    /// More concrete, values smaller than `e^-745` are rounded to `0` and values
+    /// larger than `e^709` are all mapped to the [`Q`] representation of [`f64::INFINITY`].
+    ///
+    /// Returns e^self.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///
+    /// let evaluation = Q::from((17, 3)).exp();
+    /// let e = Q::ONE.exp();
+    /// ```
+    pub fn exp(&self) -> Self {
+        Q::from(f64::from(self).exp())
+    }
+
     /// Computes e^self using taylor series approximation of the exponential function.
     ///
     /// Parameters:
@@ -38,6 +57,25 @@ impl Q {
 
 #[cfg(test)]
 mod test_exp {
+    use super::*;
+
+    /// Ensure that `e^0 = 1`.
+    #[test]
+    fn zero() {
+        assert_eq!(Q::ONE, Q::ZERO.exp())
+    }
+
+    /// Ensure that `e^1 = e`.
+    #[test]
+    fn one() {
+        let e = Q::ONE.exp();
+
+        assert_eq!(e, Q::from(1.0f64.exp()))
+    }
+}
+
+#[cfg(test)]
+mod test_exp_taylor {
     use crate::rational::Q;
 
     /// Ensure that `0` is returned if the length `0` is provided

--- a/src/rational/q/arithmetic/exp.rs
+++ b/src/rational/q/arithmetic/exp.rs
@@ -106,8 +106,6 @@ mod test_exp {
         let small_2 = Q::from((-7451, 10)).exp();
         let zero = Q::from((-7452, 10)).exp();
 
-        println!("{}", &small);
-
         assert_ne!(small, Q::ZERO);
         assert_eq!(small, small_2);
         assert_eq!(zero, Q::ZERO);
@@ -162,12 +160,10 @@ mod test_exp {
         let mut value_prime = unsafe { fmpz_get_d_2exp(&mut exponent, &large.value.num) };
         value_prime = value_prime * 2f64.powi((exponent - 6196328016) as i32);
 
-        println!("{}, {}", value_prime, exponent);
-
         // Allow 6% Error (Error Bound chosen based on calculation result)
         let upper_bound = 1.06 * 2.42298514666;
         let lower_bound = 0.94 * 2.42298514666;
-        // let upper_bound =
+
         assert!(lower_bound < value_prime);
         assert!(upper_bound > value_prime);
     }

--- a/src/rational/q/arithmetic/exp.rs
+++ b/src/rational/q/arithmetic/exp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright © 2023 Marvin Beckmann and Sven Moog
 //
 // This file is part of qFALL-math.
 //
@@ -12,20 +12,17 @@ use crate::{
     rational::{PolyOverQ, Q},
     traits::Evaluate,
 };
-
-// Initialize the taylor expansion just once and not every time we call exp.
-lazy_static::lazy_static! {
-    /// The taylor expansion of the exponential function used when [`f64.exp`]
-    /// can no longer be used.
-    pub static ref EXP_TAYLOR_POLY: PolyOverQ = PolyOverQ::exp_function_taylor(100u32);
-}
+use flint_sys::fmpq::fmpq_mul_2exp;
 
 impl Q {
-    /// Computes `e^self`. This is done by first converting the value to a [`f64`],
-    /// evaluating the exponential function and converting the float back to [`Q`].
+    /// Computes `e^self`.
+    ///
+    /// For exponents below 709, the value is converted to [`f64`] for the calculation.
     /// As a result, the precision is limited to the precision of [`f64`].
-    /// More concrete, values smaller than `e^-745` are rounded to `0`.
-    /// For exponents above 709, a taylor series with 100 coefficients is used.
+    /// This means that values smaller than `e^-745` are rounded to `0`.
+    /// The [`f64`] calculation is relatively fast.
+    /// For exponents above 709, a different algorithm is used.
+    /// Its error bound is not calculated at this point, but probably below 10%.
     ///
     /// Returns e^self.
     ///
@@ -36,11 +33,28 @@ impl Q {
     /// let evaluation = Q::from((17, 3)).exp();
     /// let e = Q::ONE.exp();
     /// ```
+    ///
+    /// # Panics ...
+    /// - if the exponent is too large (exponent*log_2(e)) >= 2^36.
+    ///   This would use up more than 64 GB of RAM.
     pub fn exp(&self) -> Self {
-        if self < &Q::from(709) {
+        // f64::exp starts mapping to f64::INFINITY between 709.7 and 709.8.
+        if self <= &Q::from(709) {
             Q::from(f64::from(self).exp())
         } else {
-            EXP_TAYLOR_POLY.evaluate(self)
+            // e^x = 2^(log_2(e^x)) = 2^(x*log_2(e))
+            let log_2_of_e = Q::from(f64::log2(1f64.exp()));
+
+            let base_2_exponent = self * log_2_of_e;
+            let base_2_int_exponent: i64 = (&base_2_exponent.floor()).try_into().unwrap();
+            let base_2_remainder_exponent = base_2_exponent - base_2_int_exponent;
+
+            // Divide x*log_2(e) into an integer part i and the remainder r.
+            // 2^(i+r) = 2^i * 2^r
+            // 2^r ~= r+1 for r in [0,1]
+            let mut out: Q = base_2_remainder_exponent + 1;
+            unsafe { fmpq_mul_2exp(&mut out.value, &out.value, base_2_int_exponent as u64) }
+            out
         }
     }
 
@@ -69,6 +83,7 @@ impl Q {
 #[cfg(test)]
 mod test_exp {
     use super::*;
+    use flint_sys::fmpz::fmpz_get_d_2exp;
 
     /// Ensure that `e^0 = 1`.
     #[test]
@@ -81,7 +96,7 @@ mod test_exp {
     fn one() {
         let e = Q::ONE.exp();
 
-        assert_eq!(e, Q::from(1.0f64.exp()))
+        assert_eq!(e, Q::from(1f64.exp()))
     }
 
     /// Show the exp behavior for large negative inputs zero e^-745, but values smaller than e^-745 do.
@@ -100,20 +115,61 @@ mod test_exp {
 
     /// Test a large input very close to where exp stops using f64 for calculation.
     /// It should not saturate f64 into infinity.
+    /// Additionally, the the greater relationship should be correct when transitioning
+    /// to the other algorithm.
     #[test]
-    fn large_float_calc() {
-        let result = (Q::from(709) - Q::from((1, u64::MAX))).exp();
+    fn algorithm_transition_correct() {
+        let result_less_than_709 = (Q::from(709) - Q::from((1, u64::MAX))).exp();
 
-        assert_ne!(f64::from(&result), f64::INFINITY);
+        let result_709 = Q::from(709).exp();
+
+        assert_ne!(f64::from(&result_less_than_709), f64::INFINITY);
+        assert!(result_less_than_709 < result_709);
+    }
+
+    /// Ensure that e^300 is the same when calculated with [`Q`] or [`f64`].
+    #[test]
+    fn medium_exponent() {
+        let a = Q::from(300).exp();
+
+        assert_eq!(a, Q::from(300f64.exp()))
     }
 
     /// Ensure that the exponential function for large values outputs different results.
     #[test]
     fn large_exponent() {
-        let large_1 = Q::from(u64::MAX).exp();
-        let large_2 = Q::from(u64::MAX - 1).exp();
+        let large_1 = Q::from(u32::MAX).exp();
+        let large_2 = Q::from(u32::MAX - 1).exp();
 
         assert!(large_1 > large_2);
+    }
+
+    /// Ensure that the exponential function for [`u32::MAX`] has an
+    /// error of at most 6%.
+    #[test]
+    fn large_exponent_error_bound() {
+        let large = Q::from(u32::MAX).exp();
+
+        // large = e^u32::MAX ~= 1.490856880... × 10^1865280596
+        // <https://www.wolframalpha.com/input?i=1%2Be%5E4294967295>
+
+        // Calculations with these large numbers takes a lot of computing time.
+        // Therefore, we norm them with 2^-6196328016 for further calculations.
+        // 1.490856880 × 10^1865280596 * 2^-6196328016 = 2.42298514666...
+        // 10^1865280596 = 2^6196328016.7006445
+        // value_prime = large * 2^-6196328016
+        let mut exponent = 0;
+        let mut value_prime = unsafe { fmpz_get_d_2exp(&mut exponent, &large.value.num) };
+        value_prime = value_prime * 2f64.powi((exponent - 6196328016) as i32);
+
+        println!("{}, {}", value_prime, exponent);
+
+        // Allow 6% Error (Error Bound chosen based on calculation result)
+        let upper_bound = 1.06 * 2.42298514666;
+        let lower_bound = 0.94 * 2.42298514666;
+        // let upper_bound =
+        assert!(lower_bound < value_prime);
+        assert!(upper_bound > value_prime);
     }
 }
 

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -122,7 +122,7 @@ fn gaussian_function(x: &Z, c: &Q, s: &Q) -> Q {
     let num = Q::MINUS_ONE * Q::PI * (Q::from(x.to_owned()) - c).pow(2).unwrap();
     let den = s.pow(2).unwrap();
     let res: Q = num / den;
-    res.exp_taylor(100u32)
+    res.exp()
 }
 
 /// SampleD samples a discrete Gaussian from the lattice with `basis` using [`sample_z`] as a subroutine.


### PR DESCRIPTION
The new exp function makes the sample_d benchmark about **140** times faster.

**Description**

This PR implements...
- [x] Adds  a benchmark for MatZ::sample_d
- [x] Adds f64 from Q
- [x] Adds Q::exp using f64 for parameters below 709. This is much faster than a taylor series. Larger parameters would map to f64::INFINITY, therefore a taylor series with 100 coefficients is used for larger parameters.
- [x] Adds Send and Sync for PolyOverQ. This indicates to the compiler that PolyOverQ is thread safe. It is also required to lazily initialize the polynomial used in exp. The lazy initialization means that it is initialized once and then reused later.


**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
