### PR TITLE
SampleD Ring-Variant

### DIFF
--- a/src/integer/mat_poly_over_z.rs
+++ b/src/integer/mat_poly_over_z.rs
@@ -21,6 +21,7 @@ mod from;
 mod get;
 mod ownership;
 mod properties;
+mod sample;
 mod serialize;
 mod set;
 mod to_string;

--- a/src/integer/mat_poly_over_z/sample.rs
+++ b/src/integer/mat_poly_over_z/sample.rs
@@ -1,0 +1,11 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains sampling algorithms for different distributions.
+
+mod discrete_gauss;

--- a/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
@@ -15,7 +15,6 @@ use crate::{
     traits::{GetCoefficient, GetEntry, GetNumColumns, GetNumRows, SetCoefficient, SetEntry},
     utils::sample::discrete_gauss::sample_d,
 };
-use std::cmp::max;
 
 impl MatPolyOverZ {
     /// SampleD samples a discrete Gaussian from the lattice with a provided `basis`.
@@ -25,6 +24,7 @@ impl MatPolyOverZ {
     ///
     /// Parameters:
     /// - `basis`: specifies a basis for the lattice from which is sampled
+    /// - `k`: the maximal length the polynomial can have
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
@@ -51,6 +51,7 @@ impl MatPolyOverZ {
     /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
     pub fn sample_d(
         basis: &Self,
+        k: i64,
         n: impl Into<Z>,
         center: &PolyOverQ,
         s: impl Into<Q>,
@@ -58,9 +59,8 @@ impl MatPolyOverZ {
         let n: Z = n.into();
         let s: Q = s.into();
 
-        let basis = polyz_vector_to_matz(basis)?;
-        // TODO: center might have smaller degree
-        let center = polyq_to_matq_vector(center)?;
+        let basis = polyz_vector_to_matz(basis, k)?;
+        let center = polyq_to_matq_vector(center, k)?;
 
         let sample = sample_d(&basis, &n, &center, &s)?;
 
@@ -68,7 +68,7 @@ impl MatPolyOverZ {
     }
 }
 
-fn polyz_vector_to_matz(poly_vec: &MatPolyOverZ) -> Result<MatZ, MathError> {
+fn polyz_vector_to_matz(poly_vec: &MatPolyOverZ, k: i64) -> Result<MatZ, MathError> {
     if !poly_vec.is_row_vector() {
         return Err(MathError::VectorFunctionCalledOnNonVector(
             String::from("polyz_vector_to_matz"),
@@ -78,16 +78,15 @@ fn polyz_vector_to_matz(poly_vec: &MatPolyOverZ) -> Result<MatZ, MathError> {
     }
 
     let mut poly: Vec<PolyOverZ> = Vec::new();
-    let mut length = 0;
     for i in 0..poly_vec.get_num_columns() {
         let entry = poly_vec.get_entry(0, i).unwrap();
-        length = max(length, entry.get_degree() + 1);
+        assert!(entry.get_degree() < k);
         poly.push(entry);
     }
-    let mut out = MatZ::new(poly.len(), length);
+    let mut out = MatZ::new(poly.len(), k);
 
     for (i, entry) in poly.iter().enumerate() {
-        for j in 0..length {
+        for j in 0..k {
             match entry.get_coeff(j) {
                 Ok(value) => out.set_entry(i, j, &value)?,
                 Err(_) => break,
@@ -98,10 +97,10 @@ fn polyz_vector_to_matz(poly_vec: &MatPolyOverZ) -> Result<MatZ, MathError> {
     Ok(out)
 }
 
-fn polyq_to_matq_vector(polyq: &PolyOverQ) -> Result<MatQ, MathError> {
-    let length = polyq.get_degree() + 1;
-    let mut out = MatQ::new(length, 1);
-    for j in 0..length {
+fn polyq_to_matq_vector(polyq: &PolyOverQ, k: i64) -> Result<MatQ, MathError> {
+    assert!(polyq.get_degree() < k);
+    let mut out = MatQ::new(k, 1);
+    for j in 0..k {
         match polyq.get_coeff(j) {
             Ok(value) => out.set_entry(j, 0, &value)?,
             Err(_) => break,
@@ -140,7 +139,7 @@ mod test_helper_conversions {
     #[test]
     fn standard_basis() {
         let standard_basis = MatPolyOverZ::from_str("[[1  1, 2  0 1]]").unwrap();
-        let basis = polyz_vector_to_matz(&standard_basis).unwrap();
+        let basis = polyz_vector_to_matz(&standard_basis, 2).unwrap();
 
         assert_eq!(MatZ::identity(2, 2), basis)
     }
@@ -148,7 +147,7 @@ mod test_helper_conversions {
     #[test]
     fn convert_center() {
         let poly = PolyOverQ::from_str("3  1/2 5 17/3").unwrap();
-        let center = polyq_to_matq_vector(&poly).unwrap();
+        let center = polyq_to_matq_vector(&poly, 3).unwrap();
 
         let cmp_center = MatQ::from_str("[[1/2],[5],[17/3]]").unwrap();
         assert_eq!(cmp_center, center)

--- a/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
@@ -33,7 +33,16 @@ impl MatPolyOverZ {
     ///
     /// # Example
     /// ```
-    /// todo!()
+    /// use qfall_math::{
+    ///     integer::MatPolyOverZ,
+    ///     rational::PolyOverQ,
+    /// };
+    /// use std::str::FromStr;
+    ///
+    /// let base = MatPolyOverZ::from_str("[[1  1, 3  0 1 -1, 2  2 2]]").unwrap();
+    /// let center = PolyOverQ::default();
+    ///
+    /// let sample = MatPolyOverZ::sample_d(&base, 3, 100, &center, 10.5_f64).unwrap();
     /// ```
     ///
     /// # Errors and Failures
@@ -52,7 +61,7 @@ impl MatPolyOverZ {
     /// # Panics ...
     /// - if the polynomials have higher length than the provided upper bound `k`
     pub fn sample_d(
-        basis: &Self,
+        base: &Self,
         k: impl Into<i64>,
         n: impl Into<Z>,
         center: &PolyOverQ,
@@ -60,11 +69,61 @@ impl MatPolyOverZ {
     ) -> Result<PolyOverZ, MathError> {
         let k = k.into();
         // use coefficient embedding and then call sampleD for the matrix representation
-        let basis = basis.into_coefficient_embedding(k);
+        let basis = base.into_coefficient_embedding(k);
         let center = center.into_coefficient_embedding(k);
         let sample = MatZ::sample_d(&basis, n, &center, s)?;
 
         // convert sample back to a polynomial using the coefficient embedding
         Ok(PolyOverZ::from_coefficient_embedding(&sample))
+    }
+}
+
+#[cfg(test)]
+mod test_sample_d {
+    use crate::{
+        integer::{MatPolyOverZ, MatZ, Z},
+        rational::{PolyOverQ, Q},
+        traits::IntoCoefficientEmbedding,
+    };
+    use std::str::FromStr;
+
+    /// Ensure that the sample is from the base.
+    #[test]
+    fn ensure_sampled_from_base() {
+        let base = MatPolyOverZ::from_str("[[1  1, 3  0 1 -1]]").unwrap();
+        let center = PolyOverQ::default();
+
+        for _ in 0..10 {
+            let sample = MatPolyOverZ::sample_d(&base, 3, 100, &center, 10.5_f64).unwrap();
+            let sample_vec = sample.into_coefficient_embedding(3);
+            let orthogonal = MatZ::from_str("[[0],[1],[1]]").unwrap();
+
+            assert_eq!(Z::ZERO, sample_vec.dot_product(&orthogonal).unwrap())
+        }
+    }
+
+    /// Checks whether `sample_d` is available for all types
+    /// implementing [`Into<Z>`], i.e. u8, u16, u32, u64, i8, ...
+    /// or [`Into<Q>`], i.e. u8, i16, f32, Z, Q, ...
+    #[test]
+    fn availability() {
+        let basis = MatPolyOverZ::from_str("[[1  1, 2  0 1, 3  0 0 1]]").unwrap();
+        let center = PolyOverQ::default();
+        let n = Z::from(1024);
+        let s = Q::ONE;
+
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 16u16, &center, 1u16);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2u32, &center, 1u8);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2u64, &center, 1u32);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2i8, &center, 1u64);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2i16, &center, 1i64);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2i32, &center, 1i32);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2i64, &center, 1i16);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, &n, &center, 1i8);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2u8, &center, 1i64);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2, &center, &n);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2, &center, &s);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2, &center, 1.25f64);
+        let _ = MatPolyOverZ::sample_d(&basis, 3, 2, &center, 15.75f32);
     }
 }

--- a/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
@@ -83,12 +83,12 @@ fn polyz_vector_to_matz(poly_vec: &MatPolyOverZ, k: i64) -> Result<MatZ, MathErr
         assert!(entry.get_degree() < k);
         poly.push(entry);
     }
-    let mut out = MatZ::new(poly.len(), k);
+    let mut out = MatZ::new(k, poly.len());
 
     for (i, entry) in poly.iter().enumerate() {
         for j in 0..k {
             match entry.get_coeff(j) {
-                Ok(value) => out.set_entry(i, j, &value)?,
+                Ok(value) => out.set_entry(j, i, &value)?,
                 Err(_) => break,
             }
         }
@@ -139,9 +139,9 @@ mod test_helper_conversions {
     #[test]
     fn standard_basis() {
         let standard_basis = MatPolyOverZ::from_str("[[1  1, 2  0 1]]").unwrap();
-        let basis = polyz_vector_to_matz(&standard_basis, 2).unwrap();
+        let basis = polyz_vector_to_matz(&standard_basis, 3).unwrap();
 
-        assert_eq!(MatZ::identity(2, 2), basis)
+        assert_eq!(MatZ::identity(3, 2), basis)
     }
 
     #[test]

--- a/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
@@ -1,0 +1,165 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains algorithms for sampling according to the discrete Gaussian distribution.
+
+use crate::{
+    error::MathError,
+    integer::{MatPolyOverZ, MatZ, PolyOverZ, Z},
+    rational::{MatQ, PolyOverQ, Q},
+    traits::{GetCoefficient, GetEntry, GetNumColumns, GetNumRows, SetCoefficient, SetEntry},
+    utils::sample::discrete_gauss::sample_d,
+};
+use std::cmp::max;
+
+impl MatPolyOverZ {
+    /// SampleD samples a discrete Gaussian from the lattice with a provided `basis`.
+    ///
+    /// We do not check whether `basis` is actually a basis. Hence, the callee is
+    /// responsible for making sure that `basis` provides a suitable basis.
+    ///
+    /// Parameters:
+    /// - `basis`: specifies a basis for the lattice from which is sampled
+    /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
+    /// - `center`: specifies the positions of the center with peak probability
+    /// - `s`: specifies the Gaussian parameter, which is proportional
+    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///
+    /// Returns a polynomial sampled according to the discrete Gaussian distribution.
+    ///
+    /// # Example
+    /// ```
+    /// todo!()
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`VectorFunctionCalledOnNonVector`](MathError::VectorFunctionCalledOnNonVector), if the basis is not a row vector
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
+    /// if the `n <= 1` or `s <= 0`.
+    /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    /// if the number of rows of the `basis` and `center` differ.
+    ///
+    /// This function implements SampleD according to:
+    /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
+    /// Trapdoors for hard lattices and new cryptographic constructions.
+    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    pub fn sample_d(
+        basis: &Self,
+        n: impl Into<Z>,
+        center: &PolyOverQ,
+        s: impl Into<Q>,
+    ) -> Result<PolyOverZ, MathError> {
+        let n: Z = n.into();
+        let s: Q = s.into();
+
+        let basis = polyz_vector_to_matz(basis)?;
+        // TODO: center might have smaller degree
+        let center = polyq_to_matq_vector(center)?;
+
+        let sample = sample_d(&basis, &n, &center, &s)?;
+
+        matz_vector_to_polyz(&sample)
+    }
+}
+
+fn polyz_vector_to_matz(poly_vec: &MatPolyOverZ) -> Result<MatZ, MathError> {
+    if !poly_vec.is_row_vector() {
+        return Err(MathError::VectorFunctionCalledOnNonVector(
+            String::from("polyz_vector_to_matz"),
+            poly_vec.get_num_rows(),
+            poly_vec.get_num_columns(),
+        ));
+    }
+
+    let mut poly: Vec<PolyOverZ> = Vec::new();
+    let mut length = 0;
+    for i in 0..poly_vec.get_num_columns() {
+        let entry = poly_vec.get_entry(0, i).unwrap();
+        length = max(length, entry.get_degree() + 1);
+        poly.push(entry);
+    }
+    let mut out = MatZ::new(poly.len(), length);
+
+    for (i, entry) in poly.iter().enumerate() {
+        for j in 0..length {
+            match entry.get_coeff(j) {
+                Ok(value) => out.set_entry(i, j, &value)?,
+                Err(_) => break,
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+fn polyq_to_matq_vector(polyq: &PolyOverQ) -> Result<MatQ, MathError> {
+    let length = polyq.get_degree() + 1;
+    let mut out = MatQ::new(length, 1);
+    for j in 0..length {
+        match polyq.get_coeff(j) {
+            Ok(value) => out.set_entry(j, 0, &value)?,
+            Err(_) => break,
+        }
+    }
+    Ok(out)
+}
+
+fn matz_vector_to_polyz(matz_vector: &MatZ) -> Result<PolyOverZ, MathError> {
+    if !matz_vector.is_column_vector() {
+        return Err(MathError::VectorFunctionCalledOnNonVector(
+            String::from("matz_vector_to_polyz"),
+            matz_vector.get_num_rows(),
+            matz_vector.get_num_columns(),
+        ));
+    }
+    let mut out = PolyOverZ::default();
+    for i in 0..matz_vector.get_num_rows() {
+        out.set_coeff(i, matz_vector.get_entry(i, 0)?)?
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod test_helper_conversions {
+    use super::{polyq_to_matq_vector, polyz_vector_to_matz};
+    use crate::{
+        integer::{
+            mat_poly_over_z::sample::discrete_gauss::matz_vector_to_polyz, MatPolyOverZ, MatZ,
+            PolyOverZ,
+        },
+        rational::{MatQ, PolyOverQ},
+    };
+    use std::str::FromStr;
+
+    #[test]
+    fn standard_basis() {
+        let standard_basis = MatPolyOverZ::from_str("[[1  1, 2  0 1]]").unwrap();
+        let basis = polyz_vector_to_matz(&standard_basis).unwrap();
+
+        assert_eq!(MatZ::identity(2, 2), basis)
+    }
+
+    #[test]
+    fn convert_center() {
+        let poly = PolyOverQ::from_str("3  1/2 5 17/3").unwrap();
+        let center = polyq_to_matq_vector(&poly).unwrap();
+
+        let cmp_center = MatQ::from_str("[[1/2],[5],[17/3]]").unwrap();
+        assert_eq!(cmp_center, center)
+    }
+
+    #[test]
+    fn convert_vector_to_poly() {
+        let vector = MatZ::from_str("[[17],[3],[-5]]").unwrap();
+        let poly = matz_vector_to_polyz(&vector).unwrap();
+
+        let cmp_poly = PolyOverZ::from_str("3  17 3 -5").unwrap();
+        assert_eq!(cmp_poly, poly)
+    }
+}

--- a/src/integer_mod_q/mat_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq.rs
@@ -19,6 +19,7 @@ mod default;
 mod from;
 mod get;
 mod reduce;
+mod sample;
 mod set;
 mod transpose;
 mod vector;

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample.rs
@@ -1,0 +1,11 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains sampling algorithms for different distributions.
+
+mod discrete_gauss;

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
@@ -1,0 +1,28 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains algorithms for sampling according to the discrete Gaussian distribution.
+
+use crate::{
+    error::MathError,
+    integer::{MatPolyOverZ, Z},
+    integer_mod_q::{MatPolynomialRingZq, PolynomialRingZq},
+    rational::{PolyOverQ, Q},
+};
+
+impl MatPolynomialRingZq {
+    pub fn sample_d(
+        basis: &Self,
+        n: impl Into<Z>,
+        center: &PolyOverQ,
+        s: impl Into<Q>,
+    ) -> Result<PolynomialRingZq, MathError> {
+        let sample = MatPolyOverZ::sample_d(&basis.matrix, n, center, s)?;
+        Ok(PolynomialRingZq::from((&sample, &basis.get_mod())))
+    }
+}

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
@@ -18,11 +18,12 @@ use crate::{
 impl MatPolynomialRingZq {
     pub fn sample_d(
         basis: &Self,
+        k: i64,
         n: impl Into<Z>,
         center: &PolyOverQ,
         s: impl Into<Q>,
     ) -> Result<PolynomialRingZq, MathError> {
-        let sample = MatPolyOverZ::sample_d(&basis.matrix, n, center, s)?;
+        let sample = MatPolyOverZ::sample_d(&basis.matrix, k, n, center, s)?;
         Ok(PolynomialRingZq::from((&sample, &basis.get_mod())))
     }
 }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
@@ -16,14 +16,127 @@ use crate::{
 };
 
 impl MatPolynomialRingZq {
+    /// SampleD samples a discrete Gaussian from the lattice with a provided `basis`.
+    ///
+    /// We do not check whether `basis` is actually a basis. Hence, the callee is
+    /// responsible for making sure that `basis` provides a suitable basis.
+    ///
+    /// Parameters:
+    /// - `basis`: specifies a basis for the lattice from which is sampled
+    /// - `k`: the maximal length the polynomial can have
+    /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
+    /// - `center`: specifies the positions of the center with peak probability
+    /// - `s`: specifies the Gaussian parameter, which is proportional
+    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///
+    /// Returns a polynomial sampled according to the discrete Gaussian distribution.
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_math::{
+    ///     integer::{MatPolyOverZ, Z},
+    ///     integer_mod_q::{
+    ///         MatPolynomialRingZq,
+    ///         ModulusPolynomialRingZq,
+    ///     },
+    ///     rational::{PolyOverQ, Q},
+    /// };
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+    /// let poly_mat = MatPolyOverZ::from_str("[[1  1, 3  0 0 1, 2  0 1]]").unwrap();
+    /// let basis = MatPolynomialRingZq::from((&poly_mat, &modulus));
+    /// let center = PolyOverQ::default();
+    /// let n = Z::from(1024);
+    /// let s = Q::from(8);
+    ///
+    /// let sample = MatPolynomialRingZq::sample_d(&basis, 3, 16, &center, s);
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`VectorFunctionCalledOnNonVector`](MathError::VectorFunctionCalledOnNonVector), if the basis is not a row vector
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
+    /// if the `n <= 1` or `s <= 0`.
+    /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    /// if the number of rows of the `basis` and `center` differ.
+    ///
+    /// This function implements SampleD according to:
+    /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
+    /// Trapdoors for hard lattices and new cryptographic constructions.
+    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    ///
+    /// # Panics ...
+    /// - if the polynomials have higher length than the provided upper bound `k`
     pub fn sample_d(
         basis: &Self,
-        k: i64,
+        k: impl Into<i64>,
         n: impl Into<Z>,
         center: &PolyOverQ,
         s: impl Into<Q>,
     ) -> Result<PolynomialRingZq, MathError> {
         let sample = MatPolyOverZ::sample_d(&basis.matrix, k, n, center, s)?;
         Ok(PolynomialRingZq::from((&sample, &basis.get_mod())))
+    }
+}
+
+#[cfg(test)]
+mod test_sample_d {
+    use crate::{
+        integer::{MatPolyOverZ, Z},
+        integer_mod_q::{MatPolynomialRingZq, MatZq, Modulus, ModulusPolynomialRingZq, Zq},
+        rational::{PolyOverQ, Q},
+        traits::IntoCoefficientEmbedding,
+    };
+    use std::str::FromStr;
+
+    /// Ensure that the sample is from the base.
+    #[test]
+    fn ensure_sampled_from_base() {
+        let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+        let poly_mat = MatPolyOverZ::from_str("[[1  1, 3  0 1 -1]]").unwrap();
+        let base = MatPolynomialRingZq::from((&poly_mat, &modulus));
+        let center = PolyOverQ::default();
+
+        for _ in 0..10 {
+            let sample = MatPolynomialRingZq::sample_d(&base, 3, 100, &center, 20.5_f64).unwrap();
+            let sample_vec = MatZq::from((
+                &sample.get_poly().into_coefficient_embedding(3),
+                &Modulus::from(17),
+            ));
+            let orthogonal = MatZq::from_str("[[0],[1],[1]] mod 17").unwrap();
+
+            assert_eq!(
+                Zq::from((0, 17)),
+                sample_vec.dot_product(&orthogonal).unwrap()
+            )
+        }
+    }
+
+    /// Checks whether `sample_d` is available for all types
+    /// implementing [`Into<Z>`], i.e. u8, u16, u32, u64, i8, ...
+    /// or [`Into<Q>`], i.e. u8, i16, f32, Z, Q, ...
+    #[test]
+    fn availability() {
+        let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+        let poly_mat = MatPolyOverZ::from_str("[[1  1, 3  0 0 1, 2  0 1]]").unwrap();
+        let basis = MatPolynomialRingZq::from((&poly_mat, &modulus));
+        let center = PolyOverQ::default();
+        let n = Z::from(1024);
+        let s = Q::from(8);
+
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 16u16, &center, 1u16);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2u32, &center, 1u8);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2u64, &center, 1u32);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2i8, &center, 1u64);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2i16, &center, 1i64);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2i32, &center, 1i32);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2i64, &center, 1i16);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, &n, &center, 1i8);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2u8, &center, 1i64);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2, &center, &n);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2, &center, &s);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2, &center, 1.25f64);
+        let _ = MatPolynomialRingZq::sample_d(&basis, 3, 2, &center, 15.75f32);
     }
 }

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -196,7 +196,7 @@ pub(crate) fn sample_d(basis: &MatZ, n: &Z, center: &MatQ, s: &Q) -> Result<MatZ
     // to the euclidean norm.
     let basis_gso = MatQ::from_mat_z(&basis).gso();
 
-    let mut out = MatZ::new(basis_gso.get_num_columns(), 1);
+    let mut out = MatZ::new(basis_gso.get_num_rows(), 1);
 
     for i in (0..basis_gso.get_num_columns()).rev() {
         // basisvector_i = b_tilde[i]


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

In order to sample from a discrete Gaussian in the ring-setting, we require the sampleD to be implemented for the ring variants.
This is done via the coefficient embedding, i.e. every polynomial is interpreted as a vector and then one can simply use the previously implemented SampleD algorithm.

This PR implements...
- [x] helper functions that convert the input using the coefficient embedding
  - [x] find a suitable place for these functions
- [x] implement sampleD for `MatPolynomialRingZq` and `MatPolyOverZ`

for/ of `Component`.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
