### PR TITLE
Add negative indexing for Matrix entries.

### DIFF
--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -63,22 +63,28 @@ impl GetEntry<PolyOverZ> for MatPolyOverZ {
     /// - `row`: specifies the row in which the entry is located
     /// - `column`: specifies the column in which the entry is located
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns the [`PolyOverZ`] value of the matrix at the position of the given
     /// row and column or an error, if the number of rows or columns is
-    /// greater than the matrix or negative.
+    /// greater than the matrix.
     ///
     /// # Examples
     /// ```
-    /// use qfall_math::integer::MatPolyOverZ;
+    /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
     /// use qfall_math::traits::*;
+    /// use std::str::FromStr;
     ///
-    /// let matrix = MatPolyOverZ::new(5, 10);
-    /// let entry = matrix.get_entry(0, 1).unwrap();
+    /// let matrix = MatPolyOverZ::from_str("[[1  1, 1  2],[1  3, 1  4],[0,1  6]]").unwrap();
+    ///
+    /// assert_eq!(PolyOverZ::from(2), matrix.get_entry(0, 1).unwrap());
+    /// assert_eq!(PolyOverZ::from(4), matrix.get_entry(-2, 1).unwrap());
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is greater than the matrix or negative.
+    /// if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -364,6 +370,7 @@ mod test_get_entry {
         let matrix = MatPolyOverZ::new(5, 10);
 
         assert!(matrix.get_entry(5, 1).is_err());
+        assert!(matrix.get_entry(-6, 1).is_err());
     }
 
     /// Ensure that a wrong number of columns yields an Error.
@@ -372,6 +379,18 @@ mod test_get_entry {
         let matrix = MatPolyOverZ::new(5, 10);
 
         assert!(matrix.get_entry(1, 100).is_err());
+        assert!(matrix.get_entry(1, -11).is_err());
+    }
+
+    /// Ensure that negative indices return the correct values.
+    #[test]
+    fn negative_indexing() {
+        let matrix = MatPolyOverZ::from_str("[[1  1, 1  2],[1  3, 1  4],[1  5 ,1  6]]").unwrap();
+
+        assert_eq!(PolyOverZ::from(2), matrix.get_entry(0, -1).unwrap());
+        assert_eq!(PolyOverZ::from(4), matrix.get_entry(-2, 1).unwrap());
+        assert_eq!(PolyOverZ::from(4), matrix.get_entry(-2, -1).unwrap());
+        assert_eq!(PolyOverZ::from(6), matrix.get_entry(-1, -1).unwrap());
     }
 
     /// Ensure that the entry is a deep copy and not just a clone of the reference.

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -181,13 +181,17 @@ impl MatPolyOverZ {
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
     /// a new matrix.
-    /// Note that `row1 >= row2` and `col1 >= col2` must hold. Otherwise the function will panic.
+    /// Note that `row1 >= row2` and `col1 >= col2` must hold after converting negative indices.
+    /// Otherwise the function will panic.
     ///
     /// Parameters:
     /// `row1`: The starting row of the submatrix
     /// `row2`: The ending row of the submatrix
     /// `col1`: The starting column of the submatrix
     /// `col2`: The ending column of the submatrix
+    ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
     ///
     /// Returns the submatrix from `(row1, col1)` to `(row2, col2)`(inclusively).
     ///
@@ -197,15 +201,18 @@ impl MatPolyOverZ {
     /// use std::str::FromStr;
     ///
     /// let mat = MatPolyOverZ::identity(3,3);
-    /// let sub_mat = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    ///
+    /// let sub_mat_1 = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    /// let sub_mat_2 = mat.get_submatrix(0, -1, 1, -2).unwrap();
     ///
     /// let e2 = MatPolyOverZ::from_str("[[0],[1  1],[0]]").unwrap();
-    /// assert_eq!(e2, sub_mat)
+    /// assert_eq!(e2, sub_mat_1);
+    /// assert_eq!(e2, sub_mat_2);
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if any provided row or column is greater than the matrix or negative.
+    /// if any provided row or column is greater than the matrix.
     ///
     /// # Panics ...
     /// - if `col1 > col2` or `row1 > row2`.
@@ -572,8 +579,21 @@ mod test_get_submatrix {
 
         assert!(mat.get_submatrix(0, 0, 0, 10).is_err());
         assert!(mat.get_submatrix(0, 10, 0, 0).is_err());
-        assert!(mat.get_submatrix(0, 0, -1, 0).is_err());
-        assert!(mat.get_submatrix(-1, 0, 0, 0).is_err());
+        assert!(mat.get_submatrix(0, 0, -11, 0).is_err());
+        assert!(mat.get_submatrix(-11, 0, 0, 0).is_err());
+    }
+
+    /// Ensure that negative indices return the correct submatrix.
+    #[test]
+    fn negative_indexing() {
+        let matrix = MatPolyOverZ::identity(3, 3);
+
+        assert_eq!(matrix, matrix.get_submatrix(0, -1, 0, -1).unwrap());
+        assert_eq!(matrix, matrix.get_submatrix(-3, -1, -3, -1).unwrap());
+        assert_eq!(
+            matrix.get_row(0).unwrap(),
+            matrix.get_submatrix(0, -3, -3, -1).unwrap()
+        );
     }
 
     /// Ensures that the function panics if no columns of the matrix are addressed.

--- a/src/integer/mat_poly_over_z/set.rs
+++ b/src/integer/mat_poly_over_z/set.rs
@@ -33,23 +33,30 @@ impl SetEntry<&PolyOverZ> for MatPolyOverZ {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if the specified entry is not part of the matrix.
     ///
     /// # Examples
     /// ```
-    /// use qfall_math::integer::MatPolyOverZ;
-    /// use qfall_math::integer::PolyOverZ;
+    /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
     /// use qfall_math::traits::*;
+    /// use std::str::FromStr;
     ///
-    /// let mut matrix = MatPolyOverZ::new(5, 10);
-    /// let value = PolyOverZ::default();
-    /// matrix.set_entry(1, 1, &value).unwrap();
+    /// let mut matrix = MatPolyOverZ::new(2, 2);
+    /// let value = PolyOverZ::from_str("2  1 1").unwrap();
+    ///
+    /// matrix.set_entry(0, 1, &value).unwrap();
+    /// matrix.set_entry(-1, -2, &PolyOverZ::from(2)).unwrap();
+    ///
+    /// assert_eq!("[[0, 2  1 1],[1  2, 0]]", matrix.to_string());
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows or columns is greater than the matrix or negative.
+    /// if `row` or `column` are greater than the matrix size.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,
@@ -198,6 +205,9 @@ impl MatPolyOverZ {
     /// - `row1`: specifies the row, in which the second entry is located
     /// - `col1`: specifies the column, in which the second entry is located
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if one of the specified entries is not part of the matrix.
     ///
@@ -211,7 +221,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows or columns is greater than the matrix or negative.
+    /// if row or column are greater than the matrix size.
     pub fn swap_entries(
         &mut self,
         row0: impl TryInto<i64> + Display,
@@ -463,7 +473,8 @@ mod test_setter {
         let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::default();
 
-        assert!(matrix.set_entry(5, 1, value).is_err());
+        assert!(matrix.set_entry(5, 1, &value).is_err());
+        assert!(matrix.set_entry(-6, 1, value).is_err());
     }
 
     /// Ensure that a wrong number of columns yields an Error.
@@ -472,7 +483,22 @@ mod test_setter {
         let mut matrix = MatPolyOverZ::new(5, 10);
         let value = PolyOverZ::default();
 
-        assert!(matrix.set_entry(1, 100, value).is_err());
+        assert!(matrix.set_entry(1, 100, &value).is_err());
+        assert!(matrix.set_entry(1, -11, value).is_err());
+    }
+
+    /// Ensure that negative indices return address the correct entires.
+    #[test]
+    fn negative_indexing() {
+        let mut matrix = MatPolyOverZ::new(3, 3);
+
+        matrix.set_entry(-1, -1, &PolyOverZ::from(9)).unwrap();
+        matrix.set_entry(-1, -2, &PolyOverZ::from(8)).unwrap();
+        matrix.set_entry(-3, -3, &PolyOverZ::from(1)).unwrap();
+
+        let matrix_cmp =
+            MatPolyOverZ::from_str("[[1  1, 0, 0],[0, 0, 0],[0, 1  8, 1  9]]").unwrap();
+        assert_eq!(matrix_cmp, matrix);
     }
 
     /// Ensures that setting columns works fine for small entries
@@ -700,10 +726,19 @@ mod test_swaps {
     fn entries_out_of_bounds() {
         let mut matrix = MatPolyOverZ::new(5, 2);
 
-        assert!(matrix.swap_entries(-1, 0, 0, 0).is_err());
-        assert!(matrix.swap_entries(0, -1, 0, 0).is_err());
+        assert!(matrix.swap_entries(-6, 0, 0, 0).is_err());
+        assert!(matrix.swap_entries(0, -3, 0, 0).is_err());
         assert!(matrix.swap_entries(0, 0, 5, 0).is_err());
         assert!(matrix.swap_entries(0, 5, 0, 0).is_err());
+    }
+
+    /// Ensure that `swap_entries` can properly handle negative indexing.
+    #[test]
+    fn entries_negative_indexing() {
+        let mut matrix = MatPolyOverZ::identity(2, 2);
+
+        matrix.swap_entries(-2, -2, -2, -1).unwrap();
+        assert_eq!("[[0, 1  1],[0, 1  1]]", matrix.to_string());
     }
 
     /// Ensures that swapping columns works fine for small entries

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -179,13 +179,17 @@ impl MatZ {
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
     /// a new matrix.
-    /// Note that `row1 >= row2` and `col1 >= col2` must hold. Otherwise the function will panic.
+    /// Note that `row1 >= row2` and `col1 >= col2` must hold after converting negative indices.
+    /// Otherwise the function will panic.
     ///
     /// Parameters:
     /// `row1`: The starting row of the submatrix
     /// `row2`: The ending row of the submatrix
     /// `col1`: The starting column of the submatrix
     /// `col2`: The ending column of the submatrix
+    ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
     ///
     /// Returns the submatrix from `(row1, col1)` to `(row2, col2)`(inclusively).
     ///
@@ -195,10 +199,12 @@ impl MatZ {
     /// use std::str::FromStr;
     ///
     /// let mat = MatZ::identity(3,3);
-    /// let sub_mat = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    /// let sub_mat_1 = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    /// let sub_mat_2 = mat.get_submatrix(0, -1, 1, -2).unwrap();
     ///
     /// let e2 = MatZ::from_str("[[0],[1],[0]]").unwrap();
-    /// assert_eq!(e2, sub_mat)
+    /// assert_eq!(e2, sub_mat_1);
+    /// assert_eq!(e2, sub_mat_2);
     /// ```
     ///
     /// # Errors and Failures
@@ -526,8 +532,21 @@ mod test_get_submatrix {
 
         assert!(mat.get_submatrix(0, 0, 0, 10).is_err());
         assert!(mat.get_submatrix(0, 10, 0, 0).is_err());
-        assert!(mat.get_submatrix(0, 0, -1, 0).is_err());
-        assert!(mat.get_submatrix(-1, 0, 0, 0).is_err());
+        assert!(mat.get_submatrix(0, 0, -11, 0).is_err());
+        assert!(mat.get_submatrix(-11, 0, 0, 0).is_err());
+    }
+
+    /// Ensure that negative indices return the correct submatrix.
+    #[test]
+    fn negative_indexing() {
+        let matrix = MatZ::from_str("[[1,2,3],[4,5,6],[7,8,9]]").unwrap();
+
+        assert_eq!(matrix, matrix.get_submatrix(0, -1, 0, -1).unwrap());
+        assert_eq!(matrix, matrix.get_submatrix(-3, -1, -3, -1).unwrap());
+        assert_eq!(
+            matrix.get_row(0).unwrap(),
+            matrix.get_submatrix(0, -3, -3, -1).unwrap()
+        );
     }
 
     /// Ensures that the function panics if no columns of the matrix are addressed.

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -352,6 +352,7 @@ mod test_get_entry {
         let matrix = MatZ::new(5, 10);
 
         assert!(matrix.get_entry(5, 1).is_err());
+        assert!(matrix.get_entry(-6, 1).is_err());
     }
 
     /// Ensure that a wrong number of columns yields an Error.
@@ -360,6 +361,7 @@ mod test_get_entry {
         let matrix = MatZ::new(5, 10);
 
         assert!(matrix.get_entry(1, 100).is_err());
+        assert!(matrix.get_entry(1, -11).is_err());
     }
 
     /// Ensure that negative indices return the correct values.

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -199,6 +199,7 @@ impl MatZ {
     /// use std::str::FromStr;
     ///
     /// let mat = MatZ::identity(3,3);
+    ///
     /// let sub_mat_1 = mat.get_submatrix(0, 2, 1, 1).unwrap();
     /// let sub_mat_2 = mat.get_submatrix(0, -1, 1, -2).unwrap();
     ///
@@ -209,7 +210,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if any provided row or column is greater than the matrix or negative.
+    /// if any provided row or column is greater than the matrix.
     ///
     /// # Panics ...
     /// - if `col1 > col2` or `row1 > row2`.

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -60,22 +60,29 @@ impl GetEntry<Z> for MatZ {
     /// - `row`: specifies the row in which the entry is located
     /// - `column`: specifies the column in which the entry is located
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns the [`Z`] value of the matrix at the position of the given
     /// row and column or an error, if the number of rows or columns is
-    /// greater than the matrix or negative.
+    /// greater than the matrix.
     ///
     /// # Examples
     /// ```
-    /// use qfall_math::integer::MatZ;
+    /// use qfall_math::integer::{MatZ, Z};
     /// use qfall_math::traits::GetEntry;
+    /// use std::str::FromStr;
     ///
-    /// let matrix = MatZ::new(5, 10);
-    /// let entry = matrix.get_entry(0, 1).unwrap();
+    /// let matrix = MatZ::from_str("[[1,2,3],[4,5,6],[7,8,9]]").unwrap();
+    ///
+    /// assert_eq!(matrix.get_entry(0, 2).unwrap(), Z::from(3));
+    /// assert_eq!(matrix.get_entry(2, 1).unwrap(), Z::from(8));
+    /// assert_eq!(matrix.get_entry(-1, -2).unwrap(), Z::from(8));
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is greater than the matrix or negative.
+    /// if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -353,6 +360,16 @@ mod test_get_entry {
         let matrix = MatZ::new(5, 10);
 
         assert!(matrix.get_entry(1, 100).is_err());
+    }
+
+    /// Ensure that negative indices return the correct values.
+    #[test]
+    fn negative_indexing() {
+        let matrix = MatZ::from_str("[[1,2,3],[4,5,6],[7,8,9]]").unwrap();
+
+        assert_eq!(matrix.get_entry(-1, -1).unwrap(), Z::from(9));
+        assert_eq!(matrix.get_entry(-1, -2).unwrap(), Z::from(8));
+        assert_eq!(matrix.get_entry(-3, -3).unwrap(), Z::from(1));
     }
 
     /// Ensure that the entry is a deep copy and not just a clone of the reference.

--- a/src/integer/mat_z/set.rs
+++ b/src/integer/mat_z/set.rs
@@ -46,14 +46,13 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZ {
     ///
     /// # Examples
     /// ```
-    /// use qfall_math::integer::MatZ;
-    /// use qfall_math::integer::Z;
+    /// use qfall_math::integer::{MatZ, Z};
     /// use qfall_math::traits::*;
     ///
     /// let mut matrix = MatZ::new(3, 3);
     ///
     /// matrix.set_entry(0, 1, 5).unwrap();
-    /// matrix.set_entry(-1,2, 9).unwrap();
+    /// matrix.set_entry(-1, 2, 9).unwrap();
     ///
     /// assert_eq!("[[0, 5, 0],[0, 0, 0],[0, 0, 9]]", matrix.to_string());
     /// ```

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -258,13 +258,17 @@ impl MatPolynomialRingZq {
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
     /// a new matrix.
-    /// Note that `row1 >= row2` and `col1 >= col2` must hold. Otherwise the function will panic.
+    /// Note that `row1 >= row2` and `col1 >= col2` must hold after converting negative indices.
+    /// Otherwise the function will panic.
     ///
     /// Parameters:
     /// `row1`: The starting row of the submatrix
     /// `row2`: The ending row of the submatrix
     /// `col1`: The starting column of the submatrix
     /// `col2`: The ending column of the submatrix
+    ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
     ///
     /// Returns the submatrix from `(row1, col1)` to `(row2, col2)`(inclusively).
     ///
@@ -278,16 +282,18 @@ impl MatPolynomialRingZq {
     /// let mat = MatPolyOverZ::identity(3,3);
     /// let poly_ring_mat = MatPolynomialRingZq::from((&mat, &modulus));
     ///
-    /// let sub_mat = poly_ring_mat.get_submatrix(0, 2, 1, 1).unwrap();
+    /// let sub_mat_1 = poly_ring_mat.get_submatrix(0, 2, 1, 1).unwrap();
+    /// let sub_mat_2 = poly_ring_mat.get_submatrix(0, -1, 1, -2).unwrap();
     ///
     /// let e2 = MatPolyOverZ::from_str("[[0],[1  1],[0]]").unwrap();
     /// let e2 = MatPolynomialRingZq::from((&e2, &modulus));
-    /// assert_eq!(e2, sub_mat)
+    /// assert_eq!(e2, sub_mat_1);
+    /// assert_eq!(e2, sub_mat_2)
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if any provided row or column is greater than the matrix or negative.
+    /// if any provided row or column is greater than the matrix.
     ///
     /// # Panics ...
     /// - if `col1 > col2` or `row1 > row2`.
@@ -679,8 +685,20 @@ mod test_get_submatrix {
 
         assert!(mat.get_submatrix(0, 0, 0, 10).is_err());
         assert!(mat.get_submatrix(0, 10, 0, 0).is_err());
-        assert!(mat.get_submatrix(0, 0, -1, 0).is_err());
-        assert!(mat.get_submatrix(-1, 0, 0, 0).is_err());
+        assert!(mat.get_submatrix(0, 0, -11, 0).is_err());
+        assert!(mat.get_submatrix(-11, 0, 0, 0).is_err());
+    }
+
+    /// Ensure that negative indices return the correct submatrix.
+    #[test]
+    fn negative_indexing() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let mat = MatPolyOverZ::identity(3, 3);
+        let matrix = MatPolynomialRingZq::from((&mat, &modulus));
+
+        assert_eq!(matrix, matrix.get_submatrix(0, -1, 0, -1).unwrap());
+        assert_eq!(matrix, matrix.get_submatrix(-3, -1, -3, -1).unwrap());
     }
 
     /// Ensures that the function panics if no columns of the matrix are addressed.

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -24,6 +24,9 @@ impl SetEntry<&PolyOverZ> for MatPolynomialRingZq {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if the specified entry is
     /// not part of the matrix.
@@ -36,16 +39,20 @@ impl SetEntry<&PolyOverZ> for MatPolynomialRingZq {
     /// use std::str::FromStr;
     ///
     /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
-    /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
+    /// let poly_mat = MatPolyOverZ::from_str("[[0, 1  42],[0, 2  1 2]]").unwrap();
     /// let mut poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
     /// let value = PolyOverZ::default();
     ///
-    /// poly_ring_mat.set_entry(1, 1, &value).unwrap();
+    /// poly_ring_mat.set_entry(0, 1, &value).unwrap();
+    /// poly_ring_mat.set_entry(-1, -1, &value).unwrap();
+    ///
+    /// let mat_cmp = MatPolynomialRingZq::from((&MatPolyOverZ::new(2,2), &modulus));
+    /// assert_eq!(poly_ring_mat, mat_cmp);
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows or columns is greater than the matrix or negative.
+    /// if `row` or `column` are greater than the matrix size.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,
@@ -71,6 +78,9 @@ impl SetEntry<&PolynomialRingZq> for MatPolynomialRingZq {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if the specified entry is
     /// not part of the matrix or the moduli are different.
@@ -83,16 +93,20 @@ impl SetEntry<&PolynomialRingZq> for MatPolynomialRingZq {
     /// use std::str::FromStr;
     ///
     /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
-    /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
+    /// let poly_mat = MatPolyOverZ::from_str("[[0, 1  42],[0, 2  1 2]]").unwrap();
     /// let mut poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
     /// let value = PolynomialRingZq::from((&PolyOverZ::default(), &modulus));
     ///
-    /// poly_ring_mat.set_entry(1, 1, &value).unwrap();
+    /// poly_ring_mat.set_entry(0, 1, &value).unwrap();
+    /// poly_ring_mat.set_entry(-1, -1, &value).unwrap();
+    ///
+    /// let mat_cmp = MatPolynomialRingZq::from((&MatPolyOverZ::new(2,2), &modulus));
+    /// assert_eq!(poly_ring_mat, mat_cmp);
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows or columns is greater than the matrix or negative.
+    /// if `row` or `column` are greater than the matrix size.
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`]
     /// if the moduli are different.
     fn set_entry(
@@ -236,7 +250,7 @@ mod test_setter {
         let value = PolyOverZ::default();
 
         assert!(poly_ring_mat.set_entry(2, 0, &value).is_err());
-        assert!(poly_ring_mat.set_entry(-1, 0, value).is_err());
+        assert!(poly_ring_mat.set_entry(-3, 0, value).is_err());
     }
 
     /// Ensure that a wrong number of columns yields an Error.
@@ -249,7 +263,7 @@ mod test_setter {
         let value = PolyOverZ::default();
 
         assert!(poly_ring_mat.set_entry(0, 3, &value).is_err());
-        assert!(poly_ring_mat.set_entry(0, -1, value).is_err());
+        assert!(poly_ring_mat.set_entry(0, -4, value).is_err());
     }
 
     /// Ensure that differing moduli result in an error.

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -59,22 +59,29 @@ impl GetEntry<Q> for MatQ {
     /// - `row`: specifies the row in which the entry is located
     /// - `column`: specifies the column in which the entry is located
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns the [`Q`] value of the matrix at the position of the given
     /// row and column or an error, if the number of rows or columns is
-    /// greater than the matrix or negative.
+    /// greater than the matrix or greater than the matrix.
     ///
     /// # Examples
     /// ```
-    /// use qfall_math::rational::MatQ;
+    /// use qfall_math::rational::{MatQ, Q};
     /// use qfall_math::traits::GetEntry;
+    /// use std::str::FromStr;
     ///
-    /// let matrix = MatQ::new(5, 10);
-    /// let entry = matrix.get_entry(0, 1).unwrap();
+    /// let matrix = MatQ::from_str("[[1,2,3/4],[4,5,6],[7,8,9]]").unwrap();
+    ///
+    /// assert_eq!(matrix.get_entry(0, 2).unwrap(), Q::from((3,4)));
+    /// assert_eq!(matrix.get_entry(2, 1).unwrap(), Q::from(8));
+    /// assert_eq!(matrix.get_entry(-1, -2).unwrap(), Q::from(8));
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of rows or columns is greater than the matrix or negative.
+    /// if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -362,6 +369,7 @@ mod test_get_entry {
         let matrix = MatQ::new(5, 10);
 
         assert!(matrix.get_entry(5, 1).is_err());
+        assert!(matrix.get_entry(-6, 1).is_err());
     }
 
     /// Ensure that a wrong number of columns yields an Error.
@@ -370,6 +378,17 @@ mod test_get_entry {
         let matrix = MatQ::new(5, 10);
 
         assert!(matrix.get_entry(1, 100).is_err());
+        assert!(matrix.get_entry(1, -11).is_err());
+    }
+
+    /// Ensure that negative indices return the correct values.
+    #[test]
+    fn negative_indexing() {
+        let matrix = MatQ::from_str("[[1,2,3],[4,5,6],[7,8,9]]").unwrap();
+
+        assert_eq!(matrix.get_entry(-1, -1).unwrap(), Q::from(9));
+        assert_eq!(matrix.get_entry(-1, -2).unwrap(), Q::from(8));
+        assert_eq!(matrix.get_entry(-3, -3).unwrap(), Q::from(1));
     }
 
     /// Ensure that the entry is a deep copy and not just a clone of the reference.

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -178,13 +178,17 @@ impl MatQ {
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
     /// a new matrix.
-    /// Note that `row1 >= row2` and `col1 >= col2` must hold. Otherwise the function will panic.
+    /// Note that `row1 >= row2` and `col1 >= col2` must hold after converting negative indices.
+    /// Otherwise the function will panic.
     ///
     /// Parameters:
     /// `row1`: The starting row of the submatrix
     /// `row2`: The ending row of the submatrix
     /// `col1`: The starting column of the submatrix
     /// `col2`: The ending column of the submatrix
+    ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
     ///
     /// Returns the submatrix from `(row1, col1)` to `(row2, col2)`(inclusively).
     ///
@@ -194,15 +198,18 @@ impl MatQ {
     /// use std::str::FromStr;
     ///
     /// let mat = MatQ::identity(3,3);
-    /// let sub_mat = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    ///
+    /// let sub_mat_1 = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    /// let sub_mat_2 = mat.get_submatrix(0, -1, 1, -2).unwrap();
     ///
     /// let e2 = MatQ::from_str("[[0],[1],[0]]").unwrap();
-    /// assert_eq!(e2, sub_mat)
+    /// assert_eq!(e2, sub_mat_1);
+    /// assert_eq!(e2, sub_mat_2);
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if any provided row or column is greater than the matrix or negative.
+    /// if any provided row or column is greater than the matrix.
     ///
     /// # Panics ...
     /// - if `col1 > col2` or `row1 > row2`.
@@ -571,8 +578,21 @@ mod test_get_submatrix {
 
         assert!(mat.get_submatrix(0, 0, 0, 10).is_err());
         assert!(mat.get_submatrix(0, 10, 0, 0).is_err());
-        assert!(mat.get_submatrix(0, 0, -1, 0).is_err());
-        assert!(mat.get_submatrix(-1, 0, 0, 0).is_err());
+        assert!(mat.get_submatrix(0, 0, -11, 0).is_err());
+        assert!(mat.get_submatrix(-11, 0, 0, 0).is_err());
+    }
+
+    /// Ensure that negative indices return the correct submatrix.
+    #[test]
+    fn negative_indexing() {
+        let matrix = MatQ::identity(3, 3);
+
+        assert_eq!(matrix, matrix.get_submatrix(0, -1, 0, -1).unwrap());
+        assert_eq!(matrix, matrix.get_submatrix(-3, -1, -3, -1).unwrap());
+        assert_eq!(
+            matrix.get_row(0).unwrap(),
+            matrix.get_submatrix(0, -3, -3, -1).unwrap()
+        );
     }
 
     /// Ensures that the function panics if no columns of the matrix are addressed.

--- a/src/rational/mat_q/set.rs
+++ b/src/rational/mat_q/set.rs
@@ -37,6 +37,9 @@ impl<Rational: Into<Q>> SetEntry<Rational> for MatQ {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if the specified entry is not part of the matrix.
     ///
@@ -44,17 +47,21 @@ impl<Rational: Into<Q>> SetEntry<Rational> for MatQ {
     /// ```
     /// use qfall_math::rational::MatQ;
     /// use qfall_math::rational::Q;
-    /// use std::str::FromStr;
     /// use qfall_math::traits::*;
     ///
-    /// let mut matrix = MatQ::new(5, 10);
+    /// let mut matrix = MatQ::new(3, 3);
     /// let value = Q::from((5, 2));
-    /// matrix.set_entry(1, 1, &value).unwrap();
+    ///
+    /// matrix.set_entry(0, 1, &value).unwrap();
+    /// matrix.set_entry(-1, -1, 5).unwrap();
+    /// matrix.set_entry(0, -1, (2,3)).unwrap();
+    ///
+    /// assert_eq!("[[0, 5/2, 2/3],[0, 0, 0],[0, 0, 5]]", matrix.to_string());
     /// ```
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows or columns is greater than the matrix or negative.
+    /// if `row` or `column` are greater than the matrix size.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,
@@ -202,8 +209,12 @@ impl MatQ {
     /// - `row1`: specifies the row, in which the second entry is located
     /// - `col1`: specifies the column, in which the second entry is located
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns an empty `Ok` if the action could be performed successfully.
-    /// Otherwise, a [`MathError`] is returned if one of the specified entries is not part of the matrix.
+    /// Otherwise, a [`MathError`] is returned if one of the specified entries
+    /// is not part of the matrix.
     ///
     /// # Examples
     /// ```
@@ -215,7 +226,7 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows or columns is greater than the matrix or negative.
+    /// if row or column are greater than the matrix size.
     pub fn swap_entries(
         &mut self,
         row0: impl TryInto<i64> + Display,
@@ -487,6 +498,7 @@ mod test_setter {
         let matrix = MatQ::new(5, 10);
 
         assert!(matrix.get_entry(5, 1).is_err());
+        assert!(matrix.get_entry(-6, 1).is_err());
     }
 
     /// Ensure that a wrong number of columns yields an Error.
@@ -495,6 +507,20 @@ mod test_setter {
         let matrix = MatQ::new(5, 10);
 
         assert!(matrix.get_entry(1, 100).is_err());
+        assert!(matrix.get_entry(1, -11).is_err());
+    }
+
+    /// Ensure that negative indices return address the correct entires.
+    #[test]
+    fn negative_indexing() {
+        let mut matrix = MatQ::new(3, 3);
+
+        matrix.set_entry(-1, -1, 9).unwrap();
+        matrix.set_entry(-1, -2, 8).unwrap();
+        matrix.set_entry(-3, -3, 1).unwrap();
+
+        let matrix_cmp = MatQ::from_str("[[1,0,0],[0,0,0],[0,8,9]]").unwrap();
+        assert_eq!(matrix_cmp, matrix);
     }
 
     /// Ensures that setting columns works fine for small entries
@@ -713,8 +739,8 @@ mod test_swaps {
     fn entries_out_of_bounds() {
         let mut matrix = MatQ::new(5, 2);
 
-        assert!(matrix.swap_entries(-1, 0, 0, 0).is_err());
-        assert!(matrix.swap_entries(0, -1, 0, 0).is_err());
+        assert!(matrix.swap_entries(-6, 0, 0, 0).is_err());
+        assert!(matrix.swap_entries(0, -3, 0, 0).is_err());
         assert!(matrix.swap_entries(0, 0, 5, 0).is_err());
         assert!(matrix.swap_entries(0, 5, 0, 0).is_err());
     }

--- a/src/utils/index.rs
+++ b/src/utils/index.rs
@@ -152,7 +152,7 @@ pub fn evaluate_indices_for_matrix<S: GetNumRows + GetNumColumns>(
     }
     if column_i64 < 0 {
         column_i64 += matrix.get_num_columns();
-        if row_i64 < 0 {
+        if column_i64 < 0 {
             return Err(MathError::OutOfBounds(
                 format!(
                     "be larger or equal to ({},{})",
@@ -215,13 +215,6 @@ mod test_eval_indices {
     use super::evaluate_indices_for_matrix;
     use crate::integer::MatZ;
 
-    /// Tests that negative indices beyond the dimension are not accepted.
-    #[test]
-    fn is_err_negative() {
-        let matrix = MatZ::new(3, 3);
-        assert!(evaluate_indices_for_matrix(&matrix, i32::MIN, 3).is_err())
-    }
-
     /// Test that negative addressing works.
     #[test]
     fn small_negative() {
@@ -232,6 +225,17 @@ mod test_eval_indices {
 
         assert_eq!(a, 9);
         assert_eq!(b, 0);
+    }
+
+    /// Assert that an error is returned if either the row or column
+    /// are just out of bounds.
+    #[test]
+    fn negative_out_of_bounds() {
+        let matrix = MatZ::new(1, 1);
+
+        assert!(evaluate_indices_for_matrix(&matrix, 0, -2).is_err());
+        assert!(evaluate_indices_for_matrix(&matrix, -2, 0).is_err());
+        assert!(evaluate_indices_for_matrix(&matrix, -2, -2).is_err());
     }
 
     /// Tests that the function can be called with several types.


### PR DESCRIPTION
**Description**
Add, document and test negative indexing for:
- [x] MatZ
    - [x] get_entry
    - [x] set_entry
    - [x] swap_entries
    - [x] get_submatrix
- [x] MatQ
    - [x] get_entry
    - [x] set_entry
    - [x] swap_entries
    - [x] get_submatrix
- [x] MatZq
    - [x] get_entry
    - [x] set_entry
    - [x] swap_entries
    - [x] get_submatrix
- [x] MatPolynomialRingZq
    - [x] get_entry
    - [x] set_entry
    - [x] get_submatrix
- [x] MatPolyOverZ
    - [x] get_entry
    - [x] set_entry
    - [x] swap_entries
    - [x] get_submatrix

Did not add negative indexing for `set_column`, `set_row`, `swap_column`, `swap_rows`.

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
