### PR TITLE
Coefficient embedding for PolyOverZ + MatPolyOverZ

### DIFF
--- a/src/integer/mat_poly_over_z.rs
+++ b/src/integer/mat_poly_over_z.rs
@@ -13,6 +13,7 @@ use flint_sys::fmpz_poly_mat::fmpz_poly_mat_struct;
 
 mod arithmetic;
 mod cmp;
+mod coefficient_embedding;
 mod concat;
 mod default;
 mod evaluate;

--- a/src/integer/mat_poly_over_z/coefficient_embedding.rs
+++ b/src/integer/mat_poly_over_z/coefficient_embedding.rs
@@ -1,0 +1,169 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This modules contains implementations to transform a [`MatPolyOverZ`]
+//! into a [`MatZ`] and reverse by using the coefficient embedding.
+
+use super::MatPolyOverZ;
+use crate::{
+    integer::{MatZ, PolyOverZ},
+    traits::{
+        FromCoefficientEmbedding, GetCoefficient, GetEntry, GetNumColumns,
+        IntoCoefficientEmbedding, SetEntry,
+    },
+};
+
+impl IntoCoefficientEmbedding<MatZ> for MatPolyOverZ {
+    /// Computes the coefficient embedding of the row vector of polynomials
+    /// in a [`MatZ`]. The (i,j) th entry corresponds to the i-th coefficient
+    /// of the j-th polynomial provided.
+    ///
+    /// Parameters:
+    /// - `size`: determines the number of rows of the embedding
+    ///
+    /// Returns a coefficient embedding as a matrix
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use qfall_math::{
+    ///     integer::{MatZ, MatPolyOverZ},
+    ///     traits::IntoCoefficientEmbedding,
+    /// };
+    ///
+    /// let poly = MatPolyOverZ::from_str("[[3  17 3 -5, 4  1 2 3 4]]").unwrap();
+    /// let mat = poly.into_coefficient_embedding(4);
+    /// let cmp_mat = MatZ::from_str("[[17, 1],[3, 2],[-5, 3],[0, 4]]").unwrap();
+    /// assert_eq!(cmp_mat, mat)
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `size` is not larger than the degree of the polynomial, i.e.
+    /// the coefficients can not be embedded correctly.
+    /// - if `self` is not a row vector
+    fn into_coefficient_embedding(&self, size: impl Into<i64>) -> MatZ {
+        assert!(self.is_row_vector());
+        let size = size.into();
+
+        let mut poly: Vec<PolyOverZ> = Vec::new();
+        for i in 0..self.get_num_columns() {
+            let entry = self.get_entry(0, i).unwrap();
+            assert!(entry.get_degree() < size);
+            poly.push(entry);
+        }
+        let mut out = MatZ::new(size, poly.len());
+
+        for (i, entry) in poly.iter().enumerate() {
+            for j in 0..size {
+                match entry.get_coeff(j) {
+                    Ok(value) => out.set_entry(j, i, &value).unwrap(),
+                    Err(_) => break,
+                }
+            }
+        }
+
+        out
+    }
+}
+
+impl FromCoefficientEmbedding<&MatZ> for MatPolyOverZ {
+    /// Computes a row vector of polynomials from a matrix.
+    /// The j-th entry of the i-th column vector is taken
+    /// as the coefficient of the polynomial of the i-th polynomial.
+    ///
+    /// Parameters:
+    /// - `embedding`: the column vector that encodes the embedding
+    ///
+    /// Returns a row vector of polynomials that corresponds to the embedding
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use qfall_math::{
+    ///     integer::{MatZ, MatPolyOverZ},
+    ///     traits::FromCoefficientEmbedding,
+    /// };
+    ///
+    /// let matrix = MatZ::from_str("[[17, 1],[3, 2],[-5, 3]]").unwrap();
+    /// let poly = MatPolyOverZ::from_coefficient_embedding(&matrix);
+    /// let cmp_poly = MatPolyOverZ::from_str("[[3  17 3 -5, 3  1 2 3]]").unwrap();
+    /// assert_eq!(cmp_poly, poly)
+    /// ```
+    fn from_coefficient_embedding(embedding: &MatZ) -> Self {
+        let mut out = MatPolyOverZ::new(1, embedding.get_num_columns());
+
+        for i in 0..embedding.get_num_columns() {
+            let col_vec = embedding.get_column(i).unwrap();
+            let entry = PolyOverZ::from_coefficient_embedding(&col_vec);
+            out.set_entry(0, i, entry).unwrap();
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod test_into_coefficient_embedding {
+    use crate::{
+        integer::{MatPolyOverZ, MatZ},
+        traits::IntoCoefficientEmbedding,
+    };
+    use std::str::FromStr;
+
+    /// Ensure that the initialization of the identity matrix works
+    #[test]
+    fn standard_basis() {
+        let standard_basis = MatPolyOverZ::from_str("[[1  1, 2  0 1]]").unwrap();
+        let basis = standard_basis.into_coefficient_embedding(3);
+
+        assert_eq!(MatZ::identity(3, 2), basis)
+    }
+
+    /// Ensure that the embedding works with large entries
+    #[test]
+    fn large_entries() {
+        let cmp_poly =
+            MatPolyOverZ::from_str(&format!("[[3  17 {} {}, 1  1]]", i64::MAX, i64::MIN)).unwrap();
+        let matrix = cmp_poly.into_coefficient_embedding(3);
+
+        let cmp_matrix =
+            MatZ::from_str(&format!("[[17, 1],[{}, 0],[{}, 0]]", i64::MAX, i64::MIN)).unwrap();
+        assert_eq!(cmp_matrix, matrix)
+    }
+
+    /// Ensure that the function panics if the the provided size is too small
+    #[test]
+    #[should_panic]
+    fn size_too_small() {
+        let cmp_poly =
+            MatPolyOverZ::from_str(&format!("[[3  17 {} {}, 2  0 1]]", i64::MAX, i64::MIN))
+                .unwrap();
+        let _ = cmp_poly.into_coefficient_embedding(2);
+    }
+}
+
+#[cfg(test)]
+mod test_from_coefficient_embedding {
+    use crate::{
+        integer::{MatPolyOverZ, MatZ},
+        traits::FromCoefficientEmbedding,
+    };
+    use std::str::FromStr;
+
+    /// Ensure that the embedding works with large entries
+    #[test]
+    fn large_entries() {
+        let matrix =
+            MatZ::from_str(&format!("[[17, 0],[{}, -1],[{}, 0]]", i64::MAX, i64::MIN)).unwrap();
+        let poly = MatPolyOverZ::from_coefficient_embedding(&matrix);
+
+        let cmp_poly =
+            MatPolyOverZ::from_str(&format!("[[3  17 {} {}, 2  0 -1]]", i64::MAX, i64::MIN))
+                .unwrap();
+        assert_eq!(cmp_poly, poly)
+    }
+}

--- a/src/integer/mat_poly_over_z/coefficient_embedding.rs
+++ b/src/integer/mat_poly_over_z/coefficient_embedding.rs
@@ -6,7 +6,7 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! This modules contains implementations to transform a [`MatPolyOverZ`]
+//! This module contains implementations to transform a [`MatPolyOverZ`]
 //! into a [`MatZ`] and reverse by using the coefficient embedding.
 
 use super::MatPolyOverZ;
@@ -22,7 +22,7 @@ impl IntoCoefficientEmbedding<MatZ> for &MatPolyOverZ {
     /// Computes the coefficient embedding of the row vector of polynomials
     /// in a [`MatZ`]. The (i,j) th entry corresponds to the i-th coefficient
     /// of the j-th polynomial provided.
-    /// It inverses the operation of [`MatPolyOverZ::from_coefficient_embedding`]
+    /// It inverses the operation of [`MatPolyOverZ::from_coefficient_embedding`].
     ///
     /// Parameters:
     /// - `size`: determines the number of rows of the embedding. It has to be larger
@@ -83,7 +83,8 @@ impl FromCoefficientEmbedding<&MatZ> for MatPolyOverZ {
     /// Computes a row vector of polynomials from a matrix.
     /// The j-th entry of the i-th column vector is taken
     /// as the coefficient of the polynomial of the i-th polynomial.
-    /// It inverses the operation of `into_coefficient_embedding`.
+    /// It inverses the operation of
+    /// [`MatPolyOverZ::into_coefficient_embedding`](#method.into_coefficient_embedding).
     ///
     /// Parameters:
     /// - `embedding`: the column vector that encodes the embedding

--- a/src/integer/poly_over_z.rs
+++ b/src/integer/poly_over_z.rs
@@ -14,6 +14,7 @@ use flint_sys::fmpz_poly::fmpz_poly_struct;
 
 mod arithmetic;
 mod cmp;
+mod coefficient_embedding;
 mod default;
 mod evaluate;
 mod from;

--- a/src/integer/poly_over_z/coefficient_embedding.rs
+++ b/src/integer/poly_over_z/coefficient_embedding.rs
@@ -1,0 +1,150 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This modules contains implementations to transform a [`PolyOverZ`]
+//! into a [`MatZ`] and reverse by using the coefficient embedding.
+
+use crate::{
+    integer::{MatZ, PolyOverZ},
+    traits::{
+        FromCoefficientEmbedding, GetCoefficient, GetEntry, GetNumRows, IntoCoefficientEmbedding,
+        SetCoefficient, SetEntry,
+    },
+};
+
+impl IntoCoefficientEmbedding<MatZ> for PolyOverZ {
+    /// Computes the coefficient embedding of the polynomial
+    /// in a [`MatZ`] as a column vector, where the i-th entry
+    /// of the vector corresponds to the i-th coefficient.
+    ///
+    /// Parameters:
+    /// - `size`: determines the length of the vector
+    ///
+    /// Returns a coefficient embedding as a vector
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use qfall_math::{
+    ///     integer::{MatZ, PolyOverZ},
+    ///     traits::IntoCoefficientEmbedding,
+    /// };
+    ///
+    /// let poly = PolyOverZ::from_str("3  17 3 -5").unwrap();
+    /// let vector = poly.into_coefficient_embedding(4);
+    /// let cmp_vector = MatZ::from_str("[[17],[3],[-5],[0]]").unwrap();
+    /// assert_eq!(cmp_vector, vector)
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `size` is not larger than the degree of the polynomial, i.e.
+    /// the coefficients can not be embedded correctly.
+    fn into_coefficient_embedding(&self, size: impl Into<i64>) -> MatZ {
+        let size = size.into();
+        assert!(size > self.get_degree());
+        let mut out = MatZ::new(size, 1);
+        for j in 0..size {
+            match self.get_coeff(j) {
+                Ok(value) => out.set_entry(j, 0, &value).unwrap(),
+                Err(_) => break,
+            }
+        }
+        out
+    }
+}
+
+impl FromCoefficientEmbedding<&MatZ> for PolyOverZ {
+    /// Computes a polynomial from a vector.
+    /// The first i-th entry of the column vector is taken
+    /// as the coefficient of the polynomial.
+    ///
+    /// Parameters:
+    /// - `embedding`: the column vector that encodes the embedding
+    ///
+    /// Returns a polynomial that corresponds to the embedding
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use qfall_math::{
+    ///     integer::{MatZ, PolyOverZ},
+    ///     traits::FromCoefficientEmbedding,
+    /// };
+    ///
+    /// let vector = MatZ::from_str("[[17],[3],[-5]]").unwrap();
+    /// let poly = PolyOverZ::from_coefficient_embedding(&vector);
+    /// let cmp_poly = PolyOverZ::from_str("3  17 3 -5").unwrap();
+    /// assert_eq!(cmp_poly, poly)
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the provided embedding is not a column vector.
+    fn from_coefficient_embedding(embedding: &MatZ) -> Self {
+        assert!(embedding.is_column_vector());
+        let mut out = PolyOverZ::default();
+        for i in 0..embedding.get_num_rows() {
+            out.set_coeff(i, embedding.get_entry(i, 0).unwrap())
+                .unwrap()
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod test_into_coefficient_embedding {
+    use crate::{
+        integer::{MatZ, PolyOverZ},
+        traits::IntoCoefficientEmbedding,
+    };
+    use std::str::FromStr;
+
+    /// Ensure that the embedding works with large entries
+    #[test]
+    fn large_entries() {
+        let cmp_poly = PolyOverZ::from_str(&format!("3  17 {} {}", i64::MAX, i64::MIN)).unwrap();
+        let vector = cmp_poly.into_coefficient_embedding(3);
+
+        let cmp_vector = MatZ::from_str(&format!("[[17],[{}],[{}]]", i64::MAX, i64::MIN)).unwrap();
+        assert_eq!(cmp_vector, vector)
+    }
+
+    /// Ensure that the function panics if the the provided size is too small
+    #[test]
+    #[should_panic]
+    fn size_too_small() {
+        let cmp_poly = PolyOverZ::from_str(&format!("3  17 {} {}", i64::MAX, i64::MIN)).unwrap();
+        let _ = cmp_poly.into_coefficient_embedding(2);
+    }
+}
+
+#[cfg(test)]
+mod test_from_coefficient_embedding {
+    use crate::{
+        integer::{MatZ, PolyOverZ},
+        traits::FromCoefficientEmbedding,
+    };
+    use std::str::FromStr;
+
+    /// Ensure that the embedding works with large entries
+    #[test]
+    fn large_entries() {
+        let vector = MatZ::from_str(&format!("[[17],[{}],[{}]]", i64::MAX, i64::MIN)).unwrap();
+        let poly = PolyOverZ::from_coefficient_embedding(&vector);
+
+        let cmp_poly = PolyOverZ::from_str(&format!("3  17 {} {}", i64::MAX, i64::MIN)).unwrap();
+        assert_eq!(cmp_poly, poly)
+    }
+
+    /// Ensure that the function panics if the provided matrix is not a column vector
+    #[test]
+    #[should_panic]
+    fn not_column_vector() {
+        let vector = MatZ::from_str("[[17, 1],[-17, -1],[5, 9]]").unwrap();
+        let _ = PolyOverZ::from_coefficient_embedding(&vector);
+    }
+}

--- a/src/integer/poly_over_z/coefficient_embedding.rs
+++ b/src/integer/poly_over_z/coefficient_embedding.rs
@@ -6,7 +6,7 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! This modules contains implementations to transform a [`PolyOverZ`]
+//! This module contains implementations to transform a [`PolyOverZ`]
 //! into a [`MatZ`] and reverse by using the coefficient embedding.
 
 use crate::{
@@ -21,7 +21,7 @@ impl IntoCoefficientEmbedding<MatZ> for &PolyOverZ {
     /// Computes the coefficient embedding of the polynomial
     /// in a [`MatZ`] as a column vector, where the i-th entry
     /// of the vector corresponds to the i-th coefficient.
-    /// It inverses the operation of [`PolyOverZ::from_coefficient_embedding`]
+    /// It inverses the operation of [`PolyOverZ::from_coefficient_embedding`].
     ///
     /// Parameters:
     /// - `size`: determines the number of rows of the embedding. It has to be larger
@@ -70,7 +70,8 @@ impl FromCoefficientEmbedding<&MatZ> for PolyOverZ {
     /// Computes a polynomial from a vector.
     /// The first i-th entry of the column vector is taken
     /// as the coefficient of the polynomial.
-    /// It inverses the operation of `into_coefficient_embedding`.
+    /// It inverses the operation of
+    /// [`PolyOverZ::into_coefficient_embedding`](#method.into_coefficient_embedding).
     ///
     /// Parameters:
     /// - `embedding`: the column vector that encodes the embedding

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -241,18 +241,17 @@ pub(crate) unsafe trait AsInteger {
 
 pub trait IntoCoefficientEmbedding<T> {
     /// Returns a canonical coefficient embedding of the value,
-    /// e.g. a matrix representation of the coefficients of a polynomial
+    /// e.g. a matrix representation of the coefficients of a polynomial.
     ///
     /// Parameters:
     /// - `size`: determines the length of the object in which the coefficients are
     /// embedded, e.g. length of the vector
-    #[allow(clippy::wrong_self_convention)]
-    fn into_coefficient_embedding(&self, size: impl Into<i64>) -> T;
+    fn into_coefficient_embedding(self, size: impl Into<i64>) -> T;
 }
 
 pub trait FromCoefficientEmbedding<T> {
     /// Reverses the coefficient embedding, e.g. takes as input a vector and
-    /// returns a polynomial
+    /// returns a polynomial.
     ///
     /// Parameters:
     /// - `embedding`: the coefficient embedding

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -238,3 +238,23 @@ pub(crate) unsafe trait AsInteger {
         None
     }
 }
+
+pub trait IntoCoefficientEmbedding<T> {
+    /// Returns a canonical coefficient embedding of the value,
+    /// e.g. a matrix representation of the coefficients of a polynomial
+    ///
+    /// Parameters:
+    /// - `size`: determines the length of the object in which the coefficients are
+    /// embedded, e.g. length of the vector
+    #[allow(clippy::wrong_self_convention)]
+    fn into_coefficient_embedding(&self, size: impl Into<i64>) -> T;
+}
+
+pub trait FromCoefficientEmbedding<T> {
+    /// Reverses the coefficient embedding, e.g. takes as input a vector and
+    /// returns a polynomial
+    ///
+    /// Parameters:
+    /// - `embedding`: the coefficient embedding
+    fn from_coefficient_embedding(embedding: T) -> Self;
+}


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

In order to call functions like sampleD, we need to be able to interpret vectors as polynomials and vice versa.
This PR implements the corresponding methods.

This PR implements...
- [x] the coefficient embedding traits
  - [x] for MatPolyOverZ
  - [x] for PolyOverZ

for/ of `Component`.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
