### PR TITLE
Tensor product for MatPolyOverZ

### DIFF
--- a/src/integer/mat_poly_over_z.rs
+++ b/src/integer/mat_poly_over_z.rs
@@ -24,6 +24,7 @@ mod properties;
 mod sample;
 mod serialize;
 mod set;
+mod tensor;
 mod to_string;
 mod trace;
 mod transpose;

--- a/src/integer/mat_poly_over_z/tensor.rs
+++ b/src/integer/mat_poly_over_z/tensor.rs
@@ -1,0 +1,257 @@
+// Copyright © 2023 Marvin Beckmann
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains the implementation of the `tensor` product.
+
+use super::MatPolyOverZ;
+use crate::{
+    integer::PolyOverZ,
+    traits::{GetEntry, GetNumColumns, GetNumRows, Tensor},
+};
+use flint_sys::{fmpz_poly::fmpz_poly_mul, fmpz_poly_mat::fmpz_poly_mat_entry};
+
+impl Tensor for MatPolyOverZ {
+    /// Computes the tensor product of `self` with `other`
+    ///
+    /// Parameters:
+    /// - `other`: the value with which the tensor product is computed.
+    ///
+    /// Returns the tensor product of `self` with `other`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use qfall_math::traits::Tensor;
+    /// use std::str::FromStr;
+    ///
+    /// let mat_a = MatPolyOverZ::from_str("[[1  1, 2  1 1]]").unwrap();
+    /// let mat_b = MatPolyOverZ::from_str("[[1  1, 1  2]]").unwrap();
+    ///
+    /// let mat_ab = mat_a.tensor_product(&mat_b);
+    /// let res_ab = "[[1  1, 1  2, 2  1 1, 2  2 2]]";
+    /// assert_eq!(mat_ab, MatPolyOverZ::from_str(res_ab).unwrap());
+    ///
+    /// let mat_ba = mat_b.tensor_product(&mat_a);
+    /// let res_ba = "[[1  1, 2  1 1, 1  2, 2  2 2]]";
+    /// assert_eq!(mat_ba, MatPolyOverZ::from_str(res_ba).unwrap());
+    /// ```
+    fn tensor_product(&self, other: &Self) -> Self {
+        let mut out = MatPolyOverZ::new(
+            self.get_num_rows() * other.get_num_rows(),
+            self.get_num_columns() * other.get_num_columns(),
+        );
+
+        for i in 0..self.get_num_rows() {
+            for j in 0..self.get_num_columns() {
+                let entry = self.get_entry(i, j).unwrap();
+
+                if !entry.is_zero() {
+                    unsafe { set_matrix_window_mul(&mut out, i, j, entry, other) }
+                }
+            }
+        }
+
+        out
+    }
+}
+
+/// This function sets a specific window of the provided matrix `out`
+/// according to the `scalar` multiple of `matrix`.
+///
+/// Sets the entries
+/// `[i*rows_other, j*columns_other]` up till `[row_left*(row_other +1), column_upper*(columns_other + 1)]`
+///
+/// Parameters:
+/// - `out`: the matrix in which the result is saved
+/// - `row_left`: defines the leftmost row of the set window
+/// - `column_upper`: defines the highest column of the set window
+/// - `scalar`: defines the value with which the part of the tensor product
+/// is calculated
+/// - `matrix`: the matrix with which the scalar is multiplied
+/// before setting the entries in `out`
+///
+/// Implicitly sets the entries of the matrix according to the definition
+/// of the tensor product.
+unsafe fn set_matrix_window_mul(
+    out: &mut MatPolyOverZ,
+    row_left: i64,
+    column_upper: i64,
+    scalar: PolyOverZ,
+    matrix: &MatPolyOverZ,
+) {
+    let columns_other = matrix.get_num_columns();
+    let rows_other = matrix.get_num_rows();
+
+    for i_other in 0..rows_other {
+        for j_other in 0..columns_other {
+            unsafe {
+                fmpz_poly_mul(
+                    fmpz_poly_mat_entry(
+                        &out.matrix,
+                        row_left * rows_other + i_other,
+                        column_upper * columns_other + j_other,
+                    ),
+                    &scalar.poly,
+                    fmpz_poly_mat_entry(&matrix.matrix, i_other, j_other),
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_tensor {
+    use crate::{
+        integer::MatPolyOverZ,
+        traits::{GetNumColumns, GetNumRows, Tensor},
+    };
+    use std::str::FromStr;
+
+    /// Ensure that the dimensions of the tensor product are taken over correctly.
+    #[test]
+    fn dimensions_fit() {
+        let mat_1 = MatPolyOverZ::new(17, 13);
+        let mat_2 = MatPolyOverZ::new(3, 4);
+
+        let mat_3 = mat_1.tensor_product(&mat_2);
+
+        assert_eq!(51, mat_3.get_num_rows());
+        assert_eq!(52, mat_3.get_num_columns());
+    }
+
+    /// Ensure that the tensor works correctly with identity
+    #[test]
+    fn identity() {
+        let identity = MatPolyOverZ::from_str("[[1  1, 0],[0, 1  1]]").unwrap();
+        let mat_1 = MatPolyOverZ::from_str(&format!(
+            "[[1  1, 1  {}, 1  1],[0, 1  {}, 1  -1]]",
+            u64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+
+        let mat_2 = identity.tensor_product(&mat_1);
+        let mat_3 = mat_1.tensor_product(&identity);
+
+        let cmp_mat_2 = MatPolyOverZ::from_str(&format!(
+            "[[1  1, 1  {}, 1  1, 0, 0, 0],[0, 1  {}, 1  -1, 0, 0, 0],[0, 0, 0, 1  1, 1  {}, 1  1],[0, 0, 0, 0, 1  {}, 1  -1]]",
+            u64::MAX,
+            i64::MIN,
+            u64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+        let cmp_mat_3 = MatPolyOverZ::from_str(&format!(
+            "[[1  1, 0, 1  {}, 0, 1  1, 0],[0, 1  1, 0, 1  {}, 0, 1  1],[0, 0, 1  {}, 0, 1  -1, 0],[0, 0, 0, 1  {}, 0, 1  -1]]",
+            u64::MAX,
+            u64::MAX,
+            i64::MIN,
+            i64::MIN
+        ))
+        .unwrap();
+
+        assert_eq!(cmp_mat_2, mat_2);
+        assert_eq!(cmp_mat_3, mat_3);
+    }
+
+    /// Ensure the tensor product works where one is a vector and the other is a matrix
+    #[test]
+    fn vector_matrix() {
+        let vector = MatPolyOverZ::from_str("[[1  1],[1  -1]]").unwrap();
+        let mat_1 = MatPolyOverZ::from_str(&format!(
+            "[[1  1, 1  {}, 1  1],[0, 1  {}, 1  -1]]",
+            u64::MAX,
+            i64::MAX
+        ))
+        .unwrap();
+
+        let mat_2 = vector.tensor_product(&mat_1);
+        let mat_3 = mat_1.tensor_product(&vector);
+
+        let cmp_mat_2 = MatPolyOverZ::from_str(&format!(
+            "[[1  1, 1  {}, 1  1],[0, 1  {}, 1  -1],[1  -1, 1  -{}, 1  -1],[0, 1  -{}, 1  1]]",
+            u64::MAX,
+            i64::MAX,
+            u64::MAX,
+            i64::MAX
+        ))
+        .unwrap();
+        let cmp_mat_3 = MatPolyOverZ::from_str(&format!(
+            "[[1  1, 1  {}, 1  1],[1  -1, 1  -{}, 1  -1],[0, 1  {}, 1  -1],[0, 1  -{}, 1  1]]",
+            u64::MAX,
+            u64::MAX,
+            i64::MAX,
+            i64::MAX
+        ))
+        .unwrap();
+
+        assert_eq!(cmp_mat_2, mat_2);
+        assert_eq!(cmp_mat_3, mat_3);
+    }
+
+    /// Ensure that the tensor product works correctly with two vectors
+    #[test]
+    fn vector_vector() {
+        let vec_1 = MatPolyOverZ::from_str("[[1  2],[1  1]]").unwrap();
+        let vec_2 = MatPolyOverZ::from_str(&format!(
+            "[[1  {}],[1  {}]]",
+            (u64::MAX - 1) / 2,
+            i64::MIN / 2
+        ))
+        .unwrap();
+
+        let vec_3 = vec_1.tensor_product(&vec_2);
+        let vec_4 = vec_2.tensor_product(&vec_1);
+
+        let cmp_vec_3 = MatPolyOverZ::from_str(&format!(
+            "[[1  {}],[1  {}],[1  {}],[1  {}]]",
+            u64::MAX - 1,
+            i64::MIN,
+            (u64::MAX - 1) / 2,
+            i64::MIN / 2
+        ))
+        .unwrap();
+        let cmp_vec_4 = MatPolyOverZ::from_str(&format!(
+            "[[1  {}],[1  {}],[1  {}],[1  {}]]",
+            u64::MAX - 1,
+            (u64::MAX - 1) / 2,
+            i64::MIN,
+            i64::MIN / 2
+        ))
+        .unwrap();
+
+        assert_eq!(cmp_vec_3, vec_3);
+        assert_eq!(cmp_vec_4, vec_4);
+    }
+
+    /// Ensures that the tensor product works for higher degree polynomials.
+    #[test]
+    fn higher_degree() {
+        let higher_degree = MatPolyOverZ::from_str("[[1  1, 2  0 1, 2  1 1]]").unwrap();
+        let mat_1 =
+            MatPolyOverZ::from_str(&format!("[[1  1, 1  {}, 2  1 {}]]", u64::MAX, i64::MIN))
+                .unwrap();
+
+        let mat_2 = higher_degree.tensor_product(&mat_1);
+
+        let cmp_mat_2 = MatPolyOverZ::from_str(&format!(
+            "[[1  1, 1  {}, 2  1 {}, 2  0 1, 2  0 {}, 3  0 1 {}, 2  1 1, 2  {} {}, 3  1 {} {}]]",
+            u64::MAX,
+            i64::MIN,
+            u64::MAX,
+            i64::MIN,
+            u64::MAX,
+            u64::MAX,
+            i64::MIN + 1,
+            i64::MIN,
+        ))
+        .unwrap();
+
+        assert_eq!(cmp_mat_2, mat_2);
+    }
+}

--- a/src/integer/mat_z/tensor.rs
+++ b/src/integer/mat_z/tensor.rs
@@ -13,7 +13,7 @@ use crate::traits::{GetNumColumns, GetNumRows, Tensor};
 use flint_sys::fmpz_mat::fmpz_mat_kronecker_product;
 
 impl Tensor for MatZ {
-    /// Computes the tensor product of `self` with `other`
+    /// Computes the tensor product of `self` with `other`.
     ///
     /// Parameters:
     /// - `other`: the value with which the tensor product is computed.
@@ -30,11 +30,11 @@ impl Tensor for MatZ {
     /// let mat_b = MatZ::from_str("[[1, 2],[3, 4]]").unwrap();
     ///
     /// let mat_ab = mat_a.tensor_product(&mat_b);
-    /// let res_ab = "[[1, 2, 1, 2],[3, 4, 3, 4],[2, 4, 2, 4],[6, 8, 6, 8]]";
-    /// assert_eq!(mat_ab, MatZ::from_str(res_ab).unwrap());
-    ///
     /// let mat_ba = mat_b.tensor_product(&mat_a);
+    ///
+    /// let res_ab = "[[1, 2, 1, 2],[3, 4, 3, 4],[2, 4, 2, 4],[6, 8, 6, 8]]";
     /// let res_ba = "[[1, 1, 2, 2],[2, 2, 4, 4],[3, 3, 4, 4],[6, 6, 8, 8]]";
+    /// assert_eq!(mat_ab, MatZ::from_str(res_ab).unwrap());
     /// assert_eq!(mat_ba, MatZ::from_str(res_ba).unwrap());
     /// ```
     fn tensor_product(&self, other: &Self) -> Self {
@@ -68,7 +68,7 @@ mod test_tensor {
         assert_eq!(52, mat_3.get_num_columns());
     }
 
-    /// Ensure that the tensor works correctly with identity
+    /// Ensure that the tensor works correctly with identity.
     #[test]
     fn identity() {
         let identity = MatZ::from_str("[[1, 0],[0, 1]]").unwrap();
@@ -99,7 +99,7 @@ mod test_tensor {
         assert_eq!(cmp_mat_3, mat_3);
     }
 
-    /// Ensure the tensor product works where one is a vector and the other is a matrix
+    /// Ensure the tensor product works where one is a vector and the other is a matrix.
     #[test]
     fn vector_matrix() {
         let vector = MatZ::from_str("[[1],[-1]]").unwrap();
@@ -130,7 +130,7 @@ mod test_tensor {
         assert_eq!(cmp_mat_3, mat_3);
     }
 
-    /// Ensure that the tensor product works correctly with two vectors
+    /// Ensure that the tensor product works correctly with two vectors.
     #[test]
     fn vector_vector() {
         let vec_1 = MatZ::from_str("[[2],[1]]").unwrap();

--- a/src/integer_mod_q/mat_zq/tensor.rs
+++ b/src/integer_mod_q/mat_zq/tensor.rs
@@ -16,7 +16,7 @@ use crate::{
 use flint_sys::{fmpz_mat::fmpz_mat_kronecker_product, fmpz_mod_mat::_fmpz_mod_mat_reduce};
 
 impl Tensor for MatZq {
-    /// Computes the tensor product of `self` with `other`
+    /// Computes the tensor product of `self` with `other`.
     ///
     /// Parameters:
     /// - `other`: the value with which the tensor product is computed.
@@ -34,11 +34,11 @@ impl Tensor for MatZq {
     /// let mat_b = MatZq::from_str("[[1, 2],[3, 4]] mod 7").unwrap();
     ///
     /// let mat_ab = mat_a.tensor_product(&mat_b);
-    /// let res_ab = "[[1, 2, 1, 2],[3, 4, 3, 4],[2, 4, 2, 4],[6, 1, 6, 1]] mod 7";
-    /// assert_eq!(mat_ab, MatZq::from_str(res_ab).unwrap());
-    ///
     /// let mat_ba = mat_b.tensor_product(&mat_a);
+    ///
+    /// let res_ab = "[[1, 2, 1, 2],[3, 4, 3, 4],[2, 4, 2, 4],[6, 1, 6, 1]] mod 7";
     /// let res_ba = "[[1, 1, 2, 2],[2, 2, 4, 4],[3, 3, 4, 4],[6, 6, 1, 1]] mod 7";
+    /// assert_eq!(mat_ab, MatZq::from_str(res_ab).unwrap());
     /// assert_eq!(mat_ba, MatZq::from_str(res_ba).unwrap());
     /// ```
     ///
@@ -51,7 +51,7 @@ impl Tensor for MatZq {
 }
 
 impl MatZq {
-    /// Computes the tensor product of `self` with `other`
+    /// Computes the tensor product of `self` with `other`.
     ///
     /// Parameters:
     /// - `other`: the value with which the tensor product is computed.
@@ -68,11 +68,11 @@ impl MatZq {
     /// let mat_b = MatZq::from_str("[[1, 2],[3, 4]] mod 7").unwrap();
     ///
     /// let mat_ab = mat_a.tensor_product_safe(&mat_b).unwrap();
-    /// let res_ab = "[[1, 2, 1, 2],[3, 4, 3, 4],[2, 4, 2, 4],[6, 1, 6, 1]] mod 7";
-    /// assert_eq!(mat_ab, MatZq::from_str(res_ab).unwrap());
-    ///
     /// let mat_ba = mat_b.tensor_product_safe(&mat_a).unwrap();
+    ///
+    /// let res_ab = "[[1, 2, 1, 2],[3, 4, 3, 4],[2, 4, 2, 4],[6, 1, 6, 1]] mod 7";
     /// let res_ba = "[[1, 1, 2, 2],[2, 2, 4, 4],[3, 3, 4, 4],[6, 6, 1, 1]] mod 7";
+    /// assert_eq!(mat_ab, MatZq::from_str(res_ab).unwrap());
     /// assert_eq!(mat_ba, MatZq::from_str(res_ba).unwrap());
     /// ```
     ///
@@ -131,7 +131,7 @@ mod test_tensor {
         assert_eq!(&mat_3, &mat_3_safe);
     }
 
-    /// Ensure that the tensor works correctly with identity
+    /// Ensure that the tensor works correctly with identity.
     #[test]
     fn identity() {
         let identity = MatZq::from_str(&format!("[[1, 0],[0, 1]] mod {}", u128::MAX)).unwrap();
@@ -179,7 +179,7 @@ mod test_tensor {
         assert_eq!(cmp_mat_3, mat_3_safe);
     }
 
-    /// Ensure the tensor product works where one is a vector and the other is a matrix
+    /// Ensure the tensor product works where one is a vector and the other is a matrix.
     #[test]
     fn vector_matrix() {
         let vector = MatZq::from_str(&format!("[[1],[-1]] mod {}", u128::MAX)).unwrap();
@@ -221,7 +221,7 @@ mod test_tensor {
         assert_eq!(cmp_mat_3, mat_3_safe);
     }
 
-    /// Ensure that the tensor product works correctly with two vectors
+    /// Ensure that the tensor product works correctly with two vectors.
     #[test]
     fn vector_vector() {
         let vec_1 = MatZq::from_str(&format!("[[2],[1]] mod {}", u128::MAX)).unwrap();
@@ -263,7 +263,7 @@ mod test_tensor {
         assert_eq!(cmp_vec_4, vec_4_safe);
     }
 
-    /// Ensure that entries are reduced by the modulus
+    /// Ensure that entries are reduced by the modulus.
     #[test]
     fn entries_reduced() {
         let mat_1 = MatZq::from_str(&format!("[[1, 2],[3, 4]] mod {}", u64::MAX - 58)).unwrap();
@@ -281,7 +281,7 @@ mod test_tensor {
         assert_eq!(mat_3_cmp, mat_3_safe);
     }
 
-    /// Ensure that tensor panics if the moduli mismatch
+    /// Ensure that tensor panics if the moduli mismatch.
     #[test]
     #[should_panic]
     fn mismatching_moduli_tensor_product() {
@@ -291,7 +291,7 @@ mod test_tensor {
         let _ = mat_1.tensor_product(&mat_2);
     }
 
-    /// Ensure that tensor_product_safe returns an error if the moduli mismatch
+    /// Ensure that tensor_product_safe returns an error if the moduli mismatch.
     #[test]
     fn mismatching_moduli_tensor_product_safe() {
         let mat_1 = MatZq::new(1, 2, u64::MAX);


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements
- [x] Tensor product for MatPolyOverZ.
It resues an old implementation of the tensor product for MatZ. For MatZ we were able to use a dedicated method, for MatPolyOverZ, we are not able to -> hence reuse that implementation. The corresponding PR: <https://github.com/qfall/math/pull/160>

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
