### PR TITLE
Window Function for MatZ

### DIFF
--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -185,9 +185,13 @@ impl MatZ {
     /// # Examples
     /// ```
     /// use qfall_math::integer::MatZ;
+    /// use std::str::FromStr;
     ///
     /// let mat = MatZ::identity(3,3);
     /// let sub_mat = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    ///
+    /// let e2 = MatZ::from_str("[[0],[1],[0]]").unwrap();
+    /// assert_eq!(e2, sub_mat)
     /// ```
     ///
     /// # Errors and Failures

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -170,17 +170,17 @@ impl MatZ {
     }
 
     /// Returns a deep copy of the submatrix defined by the given parameters.
-    /// All entries starting from `(r1, c1)` to `(r2, c2)`(inclusively) are collected in
+    /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
     /// a new matrix.
-    /// Note that `r1 >= r2` and `c1 >= c2` must hold. Otherwise the function will panic.
+    /// Note that `row1 >= row2` and `col1 >= col2` must hold. Otherwise the function will panic.
     ///
     /// Parameters:
-    /// `r1`: The starting row of the submatrix
-    /// `r2`: The ending row of the submatrix
-    /// `c1`: The starting column of the submatrix
-    /// `c2`: The ending column of the submatrix
+    /// `row1`: The starting row of the submatrix
+    /// `row2`: The ending row of the submatrix
+    /// `col1`: The starting column of the submatrix
+    /// `col2`: The ending column of the submatrix
     ///
-    /// Returns the submatrix from `(r1, c1)` to `(r2, c2)`(inclusively).
+    /// Returns the submatrix from `(row1, col1)` to `(row2, col2)`(inclusively).
     ///
     /// # Examples
     /// ```
@@ -195,32 +195,32 @@ impl MatZ {
     /// if any provided row or column is greater than the matrix or negative.
     ///
     /// # Panics ...
-    /// - if `c1 > c2` or `r1 > r2`.
+    /// - if `col1 > col2` or `row1 > row2`.
     pub fn get_submatrix(
         &self,
-        r1: impl TryInto<i64> + Display,
-        r2: impl TryInto<i64> + Display,
-        c1: impl TryInto<i64> + Display,
-        c2: impl TryInto<i64> + Display,
+        row1: impl TryInto<i64> + Display,
+        row2: impl TryInto<i64> + Display,
+        col1: impl TryInto<i64> + Display,
+        col2: impl TryInto<i64> + Display,
     ) -> Result<Self, MathError> {
-        let (r1, c1) = evaluate_indices_for_matrix(self, r1, c1)?;
-        let (r2, c2) = evaluate_indices_for_matrix(self, r2, c2)?;
+        let (row1, col1) = evaluate_indices_for_matrix(self, row1, col1)?;
+        let (row2, col2) = evaluate_indices_for_matrix(self, row2, col2)?;
         assert!(
-            r2 >= r1,
-            "The number of rows must be positive, i.e. r2 ({r2}) must be greater or equal r1 ({r1})"
+            row2 >= row1,
+            "The number of rows must be positive, i.e. row2 ({row2}) must be greater or equal row1 ({row1})"
         );
 
         assert!(
-            c2 >= c1,
-            "The number of columns must be positive, i.e. c2 ({c2}) must be greater or equal c1 ({c1})"
+            col2 >= col1,
+            "The number of columns must be positive, i.e. col2 ({col2}) must be greater or equal col1 ({col1})"
         );
 
         // increase both values to have an inclusive capturing of the matrix entries
-        let (r2, c2) = (r2 + 1, c2 + 1);
+        let (row2, col2) = (row2 + 1, col2 + 1);
 
         let mut window = MaybeUninit::uninit();
         // The memory for the elements of window is shared with self.
-        unsafe { fmpz_mat_window_init(window.as_mut_ptr(), &self.matrix, r1, c1, r2, c2) };
+        unsafe { fmpz_mat_window_init(window.as_mut_ptr(), &self.matrix, row1, col1, row2, col2) };
         let mut window_copy = MaybeUninit::uninit();
         unsafe {
             // Deep clone of the content of the window

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -195,7 +195,7 @@ impl MatZ {
     /// if any provided row or column is greater than the matrix or negative.
     ///
     /// # Panics ...
-    /// - if the `c1 > c2` or `r1 > r2`.
+    /// - if `c1 > c2` or `r1 > r2`.
     pub fn get_submatrix(
         &self,
         r1: impl TryInto<i64> + Display,
@@ -487,11 +487,11 @@ mod test_get_submatrix {
     /// entries.
     #[test]
     fn large_entries() {
-        let mat = MatZ::from_str(&format!("[[{}, 2, 3],[1, {}, 3]]", u64::MAX, i64::MAX)).unwrap();
+        let mat = MatZ::from_str(&format!("[[{}, 2, 3],[1, {}, 3]]", u64::MAX, i64::MIN)).unwrap();
 
         let sub_mat = mat.get_submatrix(0, 1, 0, 1).unwrap();
 
-        let cmp_mat = MatZ::from_str(&format!("[[{}, 2],[1, {}]]", u64::MAX, i64::MAX)).unwrap();
+        let cmp_mat = MatZ::from_str(&format!("[[{}, 2],[1, {}]]", u64::MAX, i64::MIN)).unwrap();
         assert_eq!(cmp_mat, sub_mat)
     }
 
@@ -507,7 +507,7 @@ mod test_get_submatrix {
         assert!(mat.get_submatrix(-1, 0, 0, 0).is_err());
     }
 
-    /// Ensures that the function panics if the no columns of the matrix are addressed.
+    /// Ensures that the function panics if no columns of the matrix are addressed.
     #[test]
     #[should_panic]
     fn no_columns() {
@@ -516,7 +516,7 @@ mod test_get_submatrix {
         let _ = mat.get_submatrix(0, 0, 6, 5);
     }
 
-    /// Ensures that the function panics if the no rows of the matrix are addressed.
+    /// Ensures that the function panics if no rows of the matrix are addressed.
     #[test]
     #[should_panic]
     fn no_rows() {

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -196,7 +196,13 @@ impl MatZ {
     ///
     /// # Panics ...
     /// - if the `c1 > c2` or `r1 > r2`.
-    pub fn get_submatrix(&self, r1: i64, r2: i64, c1: i64, c2: i64) -> Result<Self, MathError> {
+    pub fn get_submatrix(
+        &self,
+        r1: impl TryInto<i64> + Display,
+        r2: impl TryInto<i64> + Display,
+        c1: impl TryInto<i64> + Display,
+        c2: impl TryInto<i64> + Display,
+    ) -> Result<Self, MathError> {
         let (r1, c1) = evaluate_indices_for_matrix(self, r1, c1)?;
         let (r2, c2) = evaluate_indices_for_matrix(self, r2, c2)?;
         assert!(
@@ -440,7 +446,7 @@ mod test_get_vec {
 #[cfg(test)]
 mod test_get_submatrix {
     use crate::{
-        integer::MatZ,
+        integer::{MatZ, Z},
         traits::{GetNumColumns, GetNumRows},
     };
     use std::str::FromStr;
@@ -517,6 +523,22 @@ mod test_get_submatrix {
         let mat = MatZ::identity(10, 10);
 
         let _ = mat.get_submatrix(5, 4, 0, 0);
+    }
+
+    /// Ensure that the submatrix function can be called with several types.
+    #[test]
+    fn availability() {
+        let mat = MatZ::identity(10, 10);
+
+        let _ = mat.get_submatrix(0_i8, 0_i8, 0_i8, 0_i8);
+        let _ = mat.get_submatrix(0_i16, 0_i16, 0_i16, 0_i16);
+        let _ = mat.get_submatrix(0_i32, 0_i32, 0_i32, 0_i32);
+        let _ = mat.get_submatrix(0_i64, 0_i64, 0_i64, 0_i64);
+        let _ = mat.get_submatrix(0_u8, 0_u8, 0_u8, 0_u8);
+        let _ = mat.get_submatrix(0_u16, 0_i16, 0_u16, 0_u16);
+        let _ = mat.get_submatrix(0_u32, 0_i32, 0_u32, 0_u32);
+        let _ = mat.get_submatrix(0_u64, 0_i64, 0_u64, 0_u64);
+        let _ = mat.get_submatrix(&Z::ZERO, &Z::ZERO, &Z::ZERO, &Z::ZERO);
     }
 }
 


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Getting a certain window of a matrix appears to be very much needed to write nice tests and have a good code base.
This PR implements an efficient deep clone of the submatrix where we do not have to clone all entries more than once.
Additionally the window function is also directly applied for get_row and get_column to improve the code base with regards to less unsafe blocks and nicer to read code.

This PR implements...
- [x] get_submatrix fucntion for MatZ
- [x] improve code base for get_row and get_column of MatZ

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
