### PR TITLE
Submatrix for other Matrix Types

### DIFF
--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -17,9 +17,12 @@ use crate::{
 };
 use flint_sys::{
     fmpz_poly::{fmpz_poly_set, fmpz_poly_struct},
-    fmpz_poly_mat::fmpz_poly_mat_entry,
+    fmpz_poly_mat::{
+        fmpz_poly_mat_entry, fmpz_poly_mat_init_set, fmpz_poly_mat_window_clear,
+        fmpz_poly_mat_window_init,
+    },
 };
-use std::fmt::Display;
+use std::{fmt::Display, mem::MaybeUninit};
 
 impl GetNumRows for MatPolyOverZ {
     /// Returns the number of rows of the matrix as a [`i64`].
@@ -130,16 +133,7 @@ impl MatPolyOverZ {
             ));
         }
 
-        let out = MatPolyOverZ::new(1, self.get_num_columns());
-        for column in 0..self.get_num_columns() {
-            unsafe {
-                fmpz_poly_set(
-                    fmpz_poly_mat_entry(&out.matrix, 0, column),
-                    fmpz_poly_mat_entry(&self.matrix, row_i64, column),
-                )
-            };
-        }
-        Ok(out)
+        self.get_submatrix(row_i64, row_i64, 0, self.get_num_columns() - 1)
     }
 
     /// Outputs a column vector of the specified column.
@@ -175,16 +169,78 @@ impl MatPolyOverZ {
             ));
         }
 
-        let out = MatPolyOverZ::new(self.get_num_rows(), 1);
-        for row in 0..self.get_num_rows() {
-            unsafe {
-                fmpz_poly_set(
-                    fmpz_poly_mat_entry(&out.matrix, row, 0),
-                    fmpz_poly_mat_entry(&self.matrix, row, column_i64),
-                )
-            };
+        self.get_submatrix(0, self.get_num_rows() - 1, column_i64, column_i64)
+    }
+
+    /// Returns a deep copy of the submatrix defined by the given parameters.
+    /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
+    /// a new matrix.
+    /// Note that `row1 >= row2` and `col1 >= col2` must hold. Otherwise the function will panic.
+    ///
+    /// Parameters:
+    /// `row1`: The starting row of the submatrix
+    /// `row2`: The ending row of the submatrix
+    /// `col1`: The starting column of the submatrix
+    /// `col2`: The ending column of the submatrix
+    ///
+    /// Returns the submatrix from `(row1, col1)` to `(row2, col2)`(inclusively).
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let mat = MatPolyOverZ::identity(3,3);
+    /// let sub_mat = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    ///
+    /// let e2 = MatPolyOverZ::from_str("[[0],[1  1],[0]]").unwrap();
+    /// assert_eq!(e2, sub_mat)
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
+    /// if any provided row or column is greater than the matrix or negative.
+    ///
+    /// # Panics ...
+    /// - if `col1 > col2` or `row1 > row2`.
+    pub fn get_submatrix(
+        &self,
+        row1: impl TryInto<i64> + Display,
+        row2: impl TryInto<i64> + Display,
+        col1: impl TryInto<i64> + Display,
+        col2: impl TryInto<i64> + Display,
+    ) -> Result<Self, MathError> {
+        let (row1, col1) = evaluate_indices_for_matrix(self, row1, col1)?;
+        let (row2, col2) = evaluate_indices_for_matrix(self, row2, col2)?;
+        assert!(
+            row2 >= row1,
+            "The number of rows must be positive, i.e. row2 ({row2}) must be greater or equal row1 ({row1})"
+        );
+
+        assert!(
+            col2 >= col1,
+            "The number of columns must be positive, i.e. col2 ({col2}) must be greater or equal col1 ({col1})"
+        );
+
+        // increase both values to have an inclusive capturing of the matrix entries
+        let (row2, col2) = (row2 + 1, col2 + 1);
+
+        let mut window = MaybeUninit::uninit();
+        // The memory for the elements of window is shared with self.
+        unsafe {
+            fmpz_poly_mat_window_init(window.as_mut_ptr(), &self.matrix, row1, col1, row2, col2)
+        };
+        let mut window_copy = MaybeUninit::uninit();
+        unsafe {
+            // Deep clone of the content of the window
+            fmpz_poly_mat_init_set(window_copy.as_mut_ptr(), window.as_ptr());
+            // Clears the matrix window and releases any memory that it uses. Note that
+            // the memory to the underlying matrix that window points to is not freed
+            fmpz_poly_mat_window_clear(window.as_mut_ptr());
         }
-        Ok(out)
+        Ok(MatPolyOverZ {
+            matrix: unsafe { window_copy.assume_init() },
+        })
     }
 
     #[allow(dead_code)]
@@ -422,6 +478,117 @@ mod test_get_vec {
         assert!(row2.is_err());
         assert!(column1.is_err());
         assert!(column2.is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_get_submatrix {
+    use crate::{
+        integer::{MatPolyOverZ, Z},
+        traits::{GetNumColumns, GetNumRows},
+    };
+    use std::str::FromStr;
+
+    /// Ensures that getting the entire matrix as a submatrix works.
+    #[test]
+    fn entire_matrix() {
+        let mat = MatPolyOverZ::identity(5, 5);
+
+        let sub_mat = mat.get_submatrix(0, 4, 0, 4).unwrap();
+
+        assert_eq!(mat, sub_mat)
+    }
+
+    /// Ensures that a single matrix entry can be retrieved.
+    #[test]
+    fn matrix_single_entry() {
+        let mat = MatPolyOverZ::identity(5, 5);
+
+        let sub_mat = mat.get_submatrix(0, 0, 0, 0).unwrap();
+
+        let cmp_mat = MatPolyOverZ::identity(1, 1);
+        assert_eq!(cmp_mat, sub_mat)
+    }
+
+    /// Ensures that the dimensions of the submatrix are correct.
+    #[test]
+    fn correct_dimensions() {
+        let mat = MatPolyOverZ::identity(100, 100);
+
+        let sub_mat = mat.get_submatrix(1, 37, 0, 29).unwrap();
+
+        assert_eq!(37, sub_mat.get_num_rows());
+        assert_eq!(30, sub_mat.get_num_columns())
+    }
+
+    /// Ensures that a submatrix can be correctly retrieved for a matrix with large
+    /// entries.
+    #[test]
+    fn large_entries() {
+        let mat = MatPolyOverZ::from_str(&format!(
+            "[[2  {} {}, 1  2, 1  3],[1  1, 1  {}, 1  3]]",
+            u64::MAX,
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+
+        let sub_mat = mat.get_submatrix(0, 1, 0, 1).unwrap();
+
+        let cmp_mat = MatPolyOverZ::from_str(&format!(
+            "[[2  {} {}, 1  2],[1  1, 1  {}]]",
+            u64::MAX,
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+        assert_eq!(cmp_mat, sub_mat)
+    }
+
+    /// Ensures that an error is returned if coordinates are addressed that are not
+    /// within the matrix.
+    #[test]
+    fn invalid_coordinates() {
+        let mat = MatPolyOverZ::identity(10, 10);
+
+        assert!(mat.get_submatrix(0, 0, 0, 10).is_err());
+        assert!(mat.get_submatrix(0, 10, 0, 0).is_err());
+        assert!(mat.get_submatrix(0, 0, -1, 0).is_err());
+        assert!(mat.get_submatrix(-1, 0, 0, 0).is_err());
+    }
+
+    /// Ensures that the function panics if no columns of the matrix are addressed.
+    #[test]
+    #[should_panic]
+    fn no_columns() {
+        let mat = MatPolyOverZ::identity(10, 10);
+
+        let _ = mat.get_submatrix(0, 0, 6, 5);
+    }
+
+    /// Ensures that the function panics if no rows of the matrix are addressed.
+    #[test]
+    #[should_panic]
+    fn no_rows() {
+        let mat = MatPolyOverZ::identity(10, 10);
+
+        let _ = mat.get_submatrix(5, 4, 0, 0);
+    }
+
+    /// Ensure that the submatrix function can be called with several types.
+    #[test]
+    fn availability() {
+        let mat = MatPolyOverZ::identity(10, 10);
+
+        let _ = mat.get_submatrix(0_i8, 0_i8, 0_i8, 0_i8);
+        let _ = mat.get_submatrix(0_i16, 0_i16, 0_i16, 0_i16);
+        let _ = mat.get_submatrix(0_i32, 0_i32, 0_i32, 0_i32);
+        let _ = mat.get_submatrix(0_i64, 0_i64, 0_i64, 0_i64);
+        let _ = mat.get_submatrix(0_u8, 0_u8, 0_u8, 0_u8);
+        let _ = mat.get_submatrix(0_u16, 0_i16, 0_u16, 0_u16);
+        let _ = mat.get_submatrix(0_u32, 0_i32, 0_u32, 0_u32);
+        let _ = mat.get_submatrix(0_u64, 0_i64, 0_u64, 0_u64);
+        let _ = mat.get_submatrix(&Z::ZERO, &Z::ZERO, &Z::ZERO, &Z::ZERO);
     }
 }
 

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -158,6 +158,54 @@ impl GetEntry<PolynomialRingZq> for MatPolynomialRingZq {
 }
 
 impl MatPolynomialRingZq {
+    /// Returns a deep copy of the submatrix defined by the given parameters.
+    /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
+    /// a new matrix.
+    /// Note that `row1 >= row2` and `col1 >= col2` must hold. Otherwise the function will panic.
+    ///
+    /// Parameters:
+    /// `row1`: The starting row of the submatrix
+    /// `row2`: The ending row of the submatrix
+    /// `col1`: The starting column of the submatrix
+    /// `col2`: The ending column of the submatrix
+    ///
+    /// Returns the submatrix from `(row1, col1)` to `(row2, col2)`(inclusively).
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();();
+    /// let mat = MatPolyOverZ::identity(3,3);
+    /// let poly_ring_mat = MatPolynomialRingZq::from((&mat, &modulus));
+    ///
+    /// let sub_mat = poly_ring_mat.get_submatrix(0, 2, 1, 1).unwrap();
+    ///
+    /// let e2 = MatPolyOverZ::from_str("[[0],[1  1],[0]]").unwrap();
+    /// let e2 = MatPolynomialRingZq::from((&e2, &modulus));
+    /// assert_eq!(e2, sub_mat)
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
+    /// if any provided row or column is greater than the matrix or negative.
+    ///
+    /// # Panics ...
+    /// - if `col1 > col2` or `row1 > row2`.
+    pub fn get_submatrix(
+        &self,
+        row1: impl TryInto<i64> + Display,
+        row2: impl TryInto<i64> + Display,
+        col1: impl TryInto<i64> + Display,
+        col2: impl TryInto<i64> + Display,
+    ) -> Result<Self, MathError> {
+        Ok(MatPolynomialRingZq {
+            matrix: self.matrix.get_submatrix(row1, row2, col1, col2)?,
+            modulus: self.modulus.clone(),
+        })
+    }
     /// Efficiently collects all [`fmpz_poly_struct`]s in a [`MatPolynomialRingZq`] without cloning them.
     ///
     /// Hence, the values on the returned [`Vec`] are intended for short-term use
@@ -352,6 +400,142 @@ mod test_mod {
             modulus,
             ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {LARGE_PRIME}")).unwrap()
         );
+    }
+}
+
+#[cfg(test)]
+mod test_get_submatrix {
+    use crate::{
+        integer::{MatPolyOverZ, Z},
+        integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq},
+        traits::{GetNumColumns, GetNumRows},
+    };
+    use std::str::FromStr;
+
+    /// Ensures that getting the entire matrix as a submatrix works.
+    #[test]
+    fn entire_matrix() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let mat = MatPolyOverZ::identity(5, 5);
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
+
+        let sub_mat = mat.get_submatrix(0, 4, 0, 4).unwrap();
+
+        assert_eq!(mat, sub_mat)
+    }
+
+    /// Ensures that a single matrix entry can be retrieved.
+    #[test]
+    fn matrix_single_entry() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let mat = MatPolyOverZ::identity(5, 5);
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
+
+        let sub_mat = mat.get_submatrix(0, 0, 0, 0).unwrap();
+
+        let cmp_mat = MatPolyOverZ::identity(1, 1);
+        let cmp_mat = MatPolynomialRingZq::from((&cmp_mat, &modulus));
+        assert_eq!(cmp_mat, sub_mat)
+    }
+
+    /// Ensures that the dimensions of the submatrix are correct.
+    #[test]
+    fn correct_dimensions() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let mat = MatPolyOverZ::identity(100, 100);
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
+
+        let sub_mat = mat.get_submatrix(1, 37, 0, 29).unwrap();
+
+        assert_eq!(37, sub_mat.get_num_rows());
+        assert_eq!(30, sub_mat.get_num_columns())
+    }
+
+    /// Ensures that a submatrix can be correctly retrieved for a matrix with large
+    /// entries.
+    #[test]
+    fn large_entries() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let mat = MatPolyOverZ::from_str(&format!(
+            "[[2  -1 {}, 1  2, 1  3],[1  1, 1  {}, 1  3]]",
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
+
+        let sub_mat = mat.get_submatrix(0, 1, 0, 1).unwrap();
+
+        let cmp_mat = MatPolyOverZ::from_str(&format!(
+            "[[2  -1 {}, 1  2],[1  1, 1  {}]]",
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+        let cmp_mat = MatPolynomialRingZq::from((&cmp_mat, &modulus));
+        assert_eq!(cmp_mat, sub_mat)
+    }
+
+    /// Ensures that an error is returned if coordinates are addressed that are not
+    /// within the matrix.
+    #[test]
+    fn invalid_coordinates() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let mat = MatPolyOverZ::identity(10, 10);
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
+
+        assert!(mat.get_submatrix(0, 0, 0, 10).is_err());
+        assert!(mat.get_submatrix(0, 10, 0, 0).is_err());
+        assert!(mat.get_submatrix(0, 0, -1, 0).is_err());
+        assert!(mat.get_submatrix(-1, 0, 0, 0).is_err());
+    }
+
+    /// Ensures that the function panics if no columns of the matrix are addressed.
+    #[test]
+    #[should_panic]
+    fn no_columns() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let mat = MatPolyOverZ::identity(10, 10);
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
+
+        let _ = mat.get_submatrix(0, 0, 6, 5);
+    }
+
+    /// Ensures that the function panics if no rows of the matrix are addressed.
+    #[test]
+    #[should_panic]
+    fn no_rows() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let mat = MatPolyOverZ::identity(10, 10);
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
+
+        let _ = mat.get_submatrix(5, 4, 0, 0);
+    }
+
+    /// Ensure that the submatrix function can be called with several types.
+    #[test]
+    fn availability() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let mat = MatPolyOverZ::identity(10, 10);
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
+
+        let _ = mat.get_submatrix(0_i8, 0_i8, 0_i8, 0_i8);
+        let _ = mat.get_submatrix(0_i16, 0_i16, 0_i16, 0_i16);
+        let _ = mat.get_submatrix(0_i32, 0_i32, 0_i32, 0_i32);
+        let _ = mat.get_submatrix(0_i64, 0_i64, 0_i64, 0_i64);
+        let _ = mat.get_submatrix(0_u8, 0_u8, 0_u8, 0_u8);
+        let _ = mat.get_submatrix(0_u16, 0_i16, 0_u16, 0_u16);
+        let _ = mat.get_submatrix(0_u32, 0_i32, 0_u32, 0_u32);
+        let _ = mat.get_submatrix(0_u64, 0_i64, 0_u64, 0_u64);
+        let _ = mat.get_submatrix(&Z::ZERO, &Z::ZERO, &Z::ZERO, &Z::ZERO);
     }
 }
 

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -203,7 +203,7 @@ impl MatPolynomialRingZq {
     ) -> Result<Self, MathError> {
         Ok(MatPolynomialRingZq {
             matrix: self.matrix.get_submatrix(row1, row2, col1, col2)?,
-            modulus: self.modulus.clone(),
+            modulus: self.get_mod(),
         })
     }
     /// Efficiently collects all [`fmpz_poly_struct`]s in a [`MatPolynomialRingZq`] without cloning them.

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -287,7 +287,7 @@ impl MatZq {
         }
         Ok(MatZq {
             matrix: unsafe { window_copy.assume_init() },
-            modulus: self.modulus.clone(),
+            modulus: self.get_mod(),
         })
     }
 

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -18,10 +18,12 @@ use crate::{
 };
 use flint_sys::{
     fmpz::{fmpz, fmpz_set},
-    fmpz_mat::fmpz_mat_entry,
-    fmpz_mod_mat::fmpz_mod_mat_entry,
+    fmpz_mod_mat::{
+        fmpz_mod_mat_entry, fmpz_mod_mat_init_set, fmpz_mod_mat_window_clear,
+        fmpz_mod_mat_window_init,
+    },
 };
-use std::fmt::Display;
+use std::{fmt::Display, mem::MaybeUninit};
 
 impl MatZq {
     /// Returns the modulus of the matrix as a [`Modulus`].
@@ -177,16 +179,7 @@ impl MatZq {
             ));
         }
 
-        let out = MatZq::new(1, self.get_num_columns(), self.get_mod());
-        for column in 0..self.get_num_columns() {
-            unsafe {
-                fmpz_set(
-                    fmpz_mat_entry(&out.matrix.mat[0], 0, column),
-                    fmpz_mod_mat_entry(&self.matrix, row_i64, column),
-                )
-            };
-        }
-        Ok(out)
+        self.get_submatrix(row_i64, row_i64, 0, self.get_num_columns() - 1)
     }
 
     /// Outputs a column vector of the specified column.
@@ -223,16 +216,79 @@ impl MatZq {
             ));
         }
 
-        let out = MatZq::new(self.get_num_rows(), 1, self.get_mod());
-        for row in 0..self.get_num_rows() {
-            unsafe {
-                fmpz_set(
-                    fmpz_mat_entry(&out.matrix.mat[0], row, 0),
-                    fmpz_mod_mat_entry(&self.matrix, row, column_i64),
-                )
-            };
+        self.get_submatrix(0, self.get_num_rows() - 1, column_i64, column_i64)
+    }
+
+    /// Returns a deep copy of the submatrix defined by the given parameters.
+    /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
+    /// a new matrix.
+    /// Note that `row1 >= row2` and `col1 >= col2` must hold. Otherwise the function will panic.
+    ///
+    /// Parameters:
+    /// `row1`: The starting row of the submatrix
+    /// `row2`: The ending row of the submatrix
+    /// `col1`: The starting column of the submatrix
+    /// `col2`: The ending column of the submatrix
+    ///
+    /// Returns the submatrix from `(row1, col1)` to `(row2, col2)`(inclusively).
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::MatZq;
+    /// use std::str::FromStr;
+    ///
+    /// let mat = MatZq::identity(3,3, 17);
+    /// let sub_mat = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    ///
+    /// let e2 = MatZq::from_str("[[0],[1],[0]] mod 17").unwrap();
+    /// assert_eq!(e2, sub_mat)
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
+    /// if any provided row or column is greater than the matrix or negative.
+    ///
+    /// # Panics ...
+    /// - if `col1 > col2` or `row1 > row2`.
+    pub fn get_submatrix(
+        &self,
+        row1: impl TryInto<i64> + Display,
+        row2: impl TryInto<i64> + Display,
+        col1: impl TryInto<i64> + Display,
+        col2: impl TryInto<i64> + Display,
+    ) -> Result<Self, MathError> {
+        let (row1, col1) = evaluate_indices_for_matrix(self, row1, col1)?;
+        let (row2, col2) = evaluate_indices_for_matrix(self, row2, col2)?;
+        assert!(
+            row2 >= row1,
+            "The number of rows must be positive, i.e. row2 ({row2}) must be greater or equal row1 ({row1})"
+        );
+
+        assert!(
+            col2 >= col1,
+            "The number of columns must be positive, i.e. col2 ({col2}) must be greater or equal col1 ({col1})"
+        );
+
+        // increase both values to have an inclusive capturing of the matrix entries
+        let (row2, col2) = (row2 + 1, col2 + 1);
+
+        let mut window = MaybeUninit::uninit();
+        // The memory for the elements of window is shared with self.
+        unsafe {
+            fmpz_mod_mat_window_init(window.as_mut_ptr(), &self.matrix, row1, col1, row2, col2)
+        };
+        let mut window_copy = MaybeUninit::uninit();
+        unsafe {
+            // Deep clone of the content of the window
+            fmpz_mod_mat_init_set(window_copy.as_mut_ptr(), window.as_ptr());
+            // Clears the matrix window and releases any memory that it uses. Note that
+            // the memory to the underlying matrix that window points to is not freed
+            fmpz_mod_mat_window_clear(window.as_mut_ptr());
         }
-        Ok(out)
+        Ok(MatZq {
+            matrix: unsafe { window_copy.assume_init() },
+            modulus: self.modulus.clone(),
+        })
     }
 
     /// Efficiently collects all [`fmpz`]s in a [`MatZq`] without cloning them.
@@ -563,6 +619,118 @@ mod test_get_vec {
         assert!(row2.is_err());
         assert!(column1.is_err());
         assert!(column2.is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_get_submatrix {
+    use crate::{
+        integer::Z,
+        integer_mod_q::MatZq,
+        traits::{GetNumColumns, GetNumRows},
+    };
+    use std::str::FromStr;
+
+    /// Ensures that getting the entire matrix as a submatrix works.
+    #[test]
+    fn entire_matrix() {
+        let mat = MatZq::identity(5, 5, i64::MAX);
+
+        let sub_mat = mat.get_submatrix(0, 4, 0, 4).unwrap();
+
+        assert_eq!(mat, sub_mat)
+    }
+
+    /// Ensures that a single matrix entry can be retrieved.
+    #[test]
+    fn matrix_single_entry() {
+        let mat = MatZq::identity(5, 5, i64::MAX);
+
+        let sub_mat = mat.get_submatrix(0, 0, 0, 0).unwrap();
+
+        let cmp_mat = MatZq::identity(1, 1, i64::MAX);
+        assert_eq!(cmp_mat, sub_mat)
+    }
+
+    /// Ensures that the dimensions of the submatrix are correct.
+    #[test]
+    fn correct_dimensions() {
+        let mat = MatZq::identity(100, 100, i64::MAX);
+
+        let sub_mat = mat.get_submatrix(1, 37, 0, 29).unwrap();
+
+        assert_eq!(37, sub_mat.get_num_rows());
+        assert_eq!(30, sub_mat.get_num_columns())
+    }
+
+    /// Ensures that a submatrix can be correctly retrieved for a matrix with large
+    /// entries.
+    #[test]
+    fn large_entries() {
+        let mat = MatZq::from_str(&format!(
+            "[[{}, 2, 3],[1, {}, 3]] mod {}",
+            u64::MAX,
+            i64::MIN,
+            u128::MAX
+        ))
+        .unwrap();
+
+        let sub_mat = mat.get_submatrix(0, 1, 0, 1).unwrap();
+
+        let cmp_mat = MatZq::from_str(&format!(
+            "[[{}, 2],[1, {}]] mod {}",
+            u64::MAX,
+            i64::MIN,
+            u128::MAX
+        ))
+        .unwrap();
+        assert_eq!(cmp_mat, sub_mat)
+    }
+
+    /// Ensures that an error is returned if coordinates are addressed that are not
+    /// within the matrix.
+    #[test]
+    fn invalid_coordinates() {
+        let mat = MatZq::identity(10, 10, u64::MAX);
+
+        assert!(mat.get_submatrix(0, 0, 0, 10).is_err());
+        assert!(mat.get_submatrix(0, 10, 0, 0).is_err());
+        assert!(mat.get_submatrix(0, 0, -1, 0).is_err());
+        assert!(mat.get_submatrix(-1, 0, 0, 0).is_err());
+    }
+
+    /// Ensures that the function panics if no columns of the matrix are addressed.
+    #[test]
+    #[should_panic]
+    fn no_columns() {
+        let mat = MatZq::identity(10, 10, u64::MAX);
+
+        let _ = mat.get_submatrix(0, 0, 6, 5);
+    }
+
+    /// Ensures that the function panics if no rows of the matrix are addressed.
+    #[test]
+    #[should_panic]
+    fn no_rows() {
+        let mat = MatZq::identity(10, 10, u64::MAX);
+
+        let _ = mat.get_submatrix(5, 4, 0, 0);
+    }
+
+    /// Ensure that the submatrix function can be called with several types.
+    #[test]
+    fn availability() {
+        let mat = MatZq::identity(10, 10, u64::MAX);
+
+        let _ = mat.get_submatrix(0_i8, 0_i8, 0_i8, 0_i8);
+        let _ = mat.get_submatrix(0_i16, 0_i16, 0_i16, 0_i16);
+        let _ = mat.get_submatrix(0_i32, 0_i32, 0_i32, 0_i32);
+        let _ = mat.get_submatrix(0_i64, 0_i64, 0_i64, 0_i64);
+        let _ = mat.get_submatrix(0_u8, 0_u8, 0_u8, 0_u8);
+        let _ = mat.get_submatrix(0_u16, 0_i16, 0_u16, 0_u16);
+        let _ = mat.get_submatrix(0_u32, 0_i32, 0_u32, 0_u32);
+        let _ = mat.get_submatrix(0_u64, 0_i64, 0_u64, 0_u64);
+        let _ = mat.get_submatrix(&Z::ZERO, &Z::ZERO, &Z::ZERO, &Z::ZERO);
     }
 }
 

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -12,11 +12,13 @@ use super::MatQ;
 use crate::traits::{GetEntry, GetNumColumns, GetNumRows};
 use crate::utils::index::{evaluate_index, evaluate_indices_for_matrix};
 use crate::{error::MathError, rational::Q};
+use flint_sys::fmpq_mat::{fmpq_mat_init_set, fmpq_mat_window_clear, fmpq_mat_window_init};
 use flint_sys::{
     fmpq::{fmpq, fmpq_set},
     fmpq_mat::fmpq_mat_entry,
 };
 use std::fmt::Display;
+use std::mem::MaybeUninit;
 
 impl GetNumRows for MatQ {
     /// Returns the number of rows of the matrix as a [`i64`].
@@ -126,16 +128,7 @@ impl MatQ {
             ));
         }
 
-        let out = MatQ::new(1, self.get_num_columns());
-        for column in 0..self.get_num_columns() {
-            unsafe {
-                fmpq_set(
-                    fmpq_mat_entry(&out.matrix, 0, column),
-                    fmpq_mat_entry(&self.matrix, row_i64, column),
-                )
-            };
-        }
-        Ok(out)
+        self.get_submatrix(row_i64, row_i64, 0, self.get_num_columns() - 1)
     }
 
     /// Outputs a column vector of the specified column.
@@ -172,16 +165,76 @@ impl MatQ {
             ));
         }
 
-        let out = MatQ::new(self.get_num_rows(), 1);
-        for row in 0..self.get_num_rows() {
-            unsafe {
-                fmpq_set(
-                    fmpq_mat_entry(&out.matrix, row, 0),
-                    fmpq_mat_entry(&self.matrix, row, column_i64),
-                )
-            };
+        self.get_submatrix(0, self.get_num_rows() - 1, column_i64, column_i64)
+    }
+
+    /// Returns a deep copy of the submatrix defined by the given parameters.
+    /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
+    /// a new matrix.
+    /// Note that `row1 >= row2` and `col1 >= col2` must hold. Otherwise the function will panic.
+    ///
+    /// Parameters:
+    /// `row1`: The starting row of the submatrix
+    /// `row2`: The ending row of the submatrix
+    /// `col1`: The starting column of the submatrix
+    /// `col2`: The ending column of the submatrix
+    ///
+    /// Returns the submatrix from `(row1, col1)` to `(row2, col2)`(inclusively).
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::MatQ;
+    /// use std::str::FromStr;
+    ///
+    /// let mat = MatQ::identity(3,3);
+    /// let sub_mat = mat.get_submatrix(0, 2, 1, 1).unwrap();
+    ///
+    /// let e2 = MatQ::from_str("[[0],[1],[0]]").unwrap();
+    /// assert_eq!(e2, sub_mat)
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
+    /// if any provided row or column is greater than the matrix or negative.
+    ///
+    /// # Panics ...
+    /// - if `col1 > col2` or `row1 > row2`.
+    pub fn get_submatrix(
+        &self,
+        row1: impl TryInto<i64> + Display,
+        row2: impl TryInto<i64> + Display,
+        col1: impl TryInto<i64> + Display,
+        col2: impl TryInto<i64> + Display,
+    ) -> Result<Self, MathError> {
+        let (row1, col1) = evaluate_indices_for_matrix(self, row1, col1)?;
+        let (row2, col2) = evaluate_indices_for_matrix(self, row2, col2)?;
+        assert!(
+            row2 >= row1,
+            "The number of rows must be positive, i.e. row2 ({row2}) must be greater or equal row1 ({row1})"
+        );
+
+        assert!(
+            col2 >= col1,
+            "The number of columns must be positive, i.e. col2 ({col2}) must be greater or equal col1 ({col1})"
+        );
+
+        // increase both values to have an inclusive capturing of the matrix entries
+        let (row2, col2) = (row2 + 1, col2 + 1);
+
+        let mut window = MaybeUninit::uninit();
+        // The memory for the elements of window is shared with self.
+        unsafe { fmpq_mat_window_init(window.as_mut_ptr(), &self.matrix, row1, col1, row2, col2) };
+        let mut window_copy = MaybeUninit::uninit();
+        unsafe {
+            // Deep clone of the content of the window
+            fmpq_mat_init_set(window_copy.as_mut_ptr(), window.as_ptr());
+            // Clears the matrix window and releases any memory that it uses. Note that
+            // the memory to the underlying matrix that window points to is not freed
+            fmpq_mat_window_clear(window.as_mut_ptr());
         }
-        Ok(out)
+        Ok(MatQ {
+            matrix: unsafe { window_copy.assume_init() },
+        })
     }
 
     /// Efficiently collects all [`fmpq`]s in a [`MatQ`] without cloning them.
@@ -434,6 +487,107 @@ mod test_get_vec {
         assert!(row2.is_err());
         assert!(column1.is_err());
         assert!(column2.is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_get_submatrix {
+    use crate::{
+        integer::Z,
+        rational::MatQ,
+        traits::{GetNumColumns, GetNumRows},
+    };
+    use std::str::FromStr;
+
+    /// Ensures that getting the entire matrix as a submatrix works.
+    #[test]
+    fn entire_matrix() {
+        let mat = MatQ::identity(5, 5);
+
+        let sub_mat = mat.get_submatrix(0, 4, 0, 4).unwrap();
+
+        assert_eq!(mat, sub_mat)
+    }
+
+    /// Ensures that a single matrix entry can be retrieved.
+    #[test]
+    fn matrix_single_entry() {
+        let mat = MatQ::identity(5, 5);
+
+        let sub_mat = mat.get_submatrix(0, 0, 0, 0).unwrap();
+
+        let cmp_mat = MatQ::identity(1, 1);
+        assert_eq!(cmp_mat, sub_mat)
+    }
+
+    /// Ensures that the dimensions of the submatrix are correct.
+    #[test]
+    fn correct_dimensions() {
+        let mat = MatQ::identity(100, 100);
+
+        let sub_mat = mat.get_submatrix(1, 37, 0, 29).unwrap();
+
+        assert_eq!(37, sub_mat.get_num_rows());
+        assert_eq!(30, sub_mat.get_num_columns())
+    }
+
+    /// Ensures that a submatrix can be correctly retrieved for a matrix with large
+    /// entries.
+    #[test]
+    fn large_entries() {
+        let mat =
+            MatQ::from_str(&format!("[[{}/3, 2, 3],[1, {}, 3]]", u64::MAX, i64::MIN)).unwrap();
+
+        let sub_mat = mat.get_submatrix(0, 1, 0, 1).unwrap();
+
+        let cmp_mat = MatQ::from_str(&format!("[[{}/3, 2],[1, {}]]", u64::MAX, i64::MIN)).unwrap();
+        assert_eq!(cmp_mat, sub_mat)
+    }
+
+    /// Ensures that an error is returned if coordinates are addressed that are not
+    /// within the matrix.
+    #[test]
+    fn invalid_coordinates() {
+        let mat = MatQ::identity(10, 10);
+
+        assert!(mat.get_submatrix(0, 0, 0, 10).is_err());
+        assert!(mat.get_submatrix(0, 10, 0, 0).is_err());
+        assert!(mat.get_submatrix(0, 0, -1, 0).is_err());
+        assert!(mat.get_submatrix(-1, 0, 0, 0).is_err());
+    }
+
+    /// Ensures that the function panics if no columns of the matrix are addressed.
+    #[test]
+    #[should_panic]
+    fn no_columns() {
+        let mat = MatQ::identity(10, 10);
+
+        let _ = mat.get_submatrix(0, 0, 6, 5);
+    }
+
+    /// Ensures that the function panics if no rows of the matrix are addressed.
+    #[test]
+    #[should_panic]
+    fn no_rows() {
+        let mat = MatQ::identity(10, 10);
+
+        let _ = mat.get_submatrix(5, 4, 0, 0);
+    }
+
+    /// Ensure that the submatrix function can be called with several types.
+    #[test]
+    fn availability() {
+        let mat = MatQ::identity(10, 10);
+
+        let _ = mat.get_submatrix(0_i8, 0_i8, 0_i8, 0_i8);
+        let _ = mat.get_submatrix(0_i16, 0_i16, 0_i16, 0_i16);
+        let _ = mat.get_submatrix(0_i32, 0_i32, 0_i32, 0_i32);
+        let _ = mat.get_submatrix(0_i64, 0_i64, 0_i64, 0_i64);
+        let _ = mat.get_submatrix(0_u8, 0_u8, 0_u8, 0_u8);
+        let _ = mat.get_submatrix(0_u16, 0_i16, 0_u16, 0_u16);
+        let _ = mat.get_submatrix(0_u32, 0_i32, 0_u32, 0_u32);
+        let _ = mat.get_submatrix(0_u64, 0_i64, 0_u64, 0_u64);
+        let _ = mat.get_submatrix(&Z::ZERO, &Z::ZERO, &Z::ZERO, &Z::ZERO);
     }
 }
 


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->


This PR implements the window functionality for all other matrix types. These include
- [x] MatQ
- [x] MatZq
- [x] MatPolyOverZ
- [x] MatPolynomialRingZq


<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
