### PR TITLE
Get_row and Get_column for MatPolynomialRingZq

### DIFF
--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -548,7 +548,7 @@ mod test_get_vec {
         assert_eq!(cmp3, column3);
     }
 
-    /// Ensure that wrong row and column dimensions yields an error
+    /// Ensure that wrong row and column dimensions yields an error.
     #[test]
     fn wrong_dim_error() {
         let modulus =

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -14,6 +14,7 @@ use crate::{
     integer::PolyOverZ,
     integer_mod_q::{ModulusPolynomialRingZq, PolynomialRingZq},
     traits::{GetEntry, GetNumColumns, GetNumRows},
+    utils::index::evaluate_index,
 };
 use flint_sys::{fmpz_poly::fmpz_poly_struct, fmpz_poly_mat::fmpz_poly_mat_entry};
 use std::fmt::Display;
@@ -158,6 +159,86 @@ impl GetEntry<PolynomialRingZq> for MatPolynomialRingZq {
 }
 
 impl MatPolynomialRingZq {
+    /// Outputs the row vector of the specified row.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row of the matrix
+    ///
+    /// Returns a row vector of the matrix at the position of the given
+    /// row or an error, if the number of rows is
+    /// greater than the matrix or negative.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();();
+    /// let mat_poly = MatPolyOverZ::identity(3,3);
+    /// let matrix = MatPolynomialRingZq::from((&mat_poly, &modulus));
+    ///
+    /// let row0 = matrix.get_row(0).unwrap(); // first row
+    /// let row1 = matrix.get_row(1).unwrap(); // second row
+    /// let row2 = matrix.get_row(2).unwrap(); // third row
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
+    /// if the number of the row is greater than the matrix or negative.
+    pub fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
+        let row_i64 = evaluate_index(row)?;
+
+        if self.get_num_rows() <= row_i64 {
+            return Err(MathError::OutOfBounds(
+                format!("be smaller than {}", self.get_num_rows()),
+                format!("{row_i64}"),
+            ));
+        }
+
+        self.get_submatrix(row_i64, row_i64, 0, self.get_num_columns() - 1)
+    }
+
+    /// Outputs a column vector of the specified column.
+    ///
+    /// Input parameters:
+    /// * `column`: specifies the column of the matrix
+    ///
+    /// Returns a column vector of the matrix at the position of the given
+    /// column or an error, if the number of columns is
+    /// greater than the matrix or negative.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();();
+    /// let mat_poly = MatPolyOverZ::identity(3,3);
+    /// let matrix = MatPolynomialRingZq::from((&mat_poly, &modulus));
+    ///
+    /// let col0 = matrix.get_column(0).unwrap(); // first column
+    /// let col1 = matrix.get_column(1).unwrap(); // second column
+    /// let col1 = matrix.get_column(2).unwrap(); // third column
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
+    /// if the number of the column is greater than the matrix or negative.
+    pub fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
+        let column_i64 = evaluate_index(column)?;
+
+        if self.get_num_columns() <= column_i64 {
+            return Err(MathError::OutOfBounds(
+                format!("be smaller than {}", self.get_num_columns()),
+                format!("{column_i64}"),
+            ));
+        }
+
+        self.get_submatrix(0, self.get_num_rows() - 1, column_i64, column_i64)
+    }
+
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row1, col1)` to `(row2, col2)`(inclusively) are collected in
     /// a new matrix.
@@ -206,6 +287,7 @@ impl MatPolynomialRingZq {
             modulus: self.get_mod(),
         })
     }
+
     /// Efficiently collects all [`fmpz_poly_struct`]s in a [`MatPolynomialRingZq`] without cloning them.
     ///
     /// Hence, the values on the returned [`Vec`] are intended for short-term use
@@ -400,6 +482,94 @@ mod test_mod {
             modulus,
             ModulusPolynomialRingZq::from_str(&format!("2  42 17 mod {LARGE_PRIME}")).unwrap()
         );
+    }
+}
+
+#[cfg(test)]
+mod test_get_vec {
+    use crate::{
+        integer::MatPolyOverZ,
+        integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq},
+    };
+    use std::str::FromStr;
+
+    /// Ensure that getting a row works.
+    #[test]
+    fn get_row_works() {
+        let matrix = MatPolyOverZ::from_str(&format!(
+            "[[0,0,0],[1  42,1  {},1  {}]]",
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let matrix = MatPolynomialRingZq::from((&matrix, &modulus));
+
+        let row1 = matrix.get_row(0).unwrap();
+        let row2 = matrix.get_row(1).unwrap();
+
+        let cmp1 = MatPolyOverZ::from_str("[[0,0,0]]").unwrap();
+        let cmp2 =
+            MatPolyOverZ::from_str(&format!("[[1  42,1  {},1  {}]]", i64::MAX, i64::MIN)).unwrap();
+        let cmp1 = MatPolynomialRingZq::from((&cmp1, &modulus));
+        let cmp2 = MatPolynomialRingZq::from((&cmp2, &modulus));
+        assert_eq!(cmp1, row1);
+        assert_eq!(cmp2, row2);
+    }
+
+    /// Ensure that getting a column works.
+    #[test]
+    fn get_column_works() {
+        let matrix = MatPolyOverZ::from_str(&format!(
+            "[[1  42,0,2  17 42],[1  {},0,2  17 42],[1  {},0,2  17 42]]",
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let matrix = MatPolynomialRingZq::from((&matrix, &modulus));
+
+        let column1 = matrix.get_column(0).unwrap();
+        let column2 = matrix.get_column(1).unwrap();
+        let column3 = matrix.get_column(2).unwrap();
+
+        let cmp1 =
+            MatPolyOverZ::from_str(&format!("[[1  42],[1  {}],[1  {}]]", i64::MAX, i64::MIN))
+                .unwrap();
+        let cmp2 = MatPolyOverZ::from_str("[[0],[0],[0]]").unwrap();
+        let cmp3 = MatPolyOverZ::from_str("[[2  17 42],[2  17 42],[2  17 42]]").unwrap();
+        let cmp1 = MatPolynomialRingZq::from((&cmp1, &modulus));
+        let cmp2 = MatPolynomialRingZq::from((&cmp2, &modulus));
+        let cmp3 = MatPolynomialRingZq::from((&cmp3, &modulus));
+        assert_eq!(cmp1, column1);
+        assert_eq!(cmp2, column2);
+        assert_eq!(cmp3, column3);
+    }
+
+    /// Ensure that wrong row and column dimensions yields an error
+    #[test]
+    fn wrong_dim_error() {
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let matrix = MatPolyOverZ::from_str(&format!(
+            "[[1  17,2  17 42,3  1 1 1],[1  {},1  1,2  2 3],[1  {},1  142,1  1]]",
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
+        let matrix = MatPolynomialRingZq::from((&matrix, &modulus));
+
+        let row1 = matrix.get_row(-1);
+        let row2 = matrix.get_row(4);
+        let column1 = matrix.get_column(-1);
+        let column2 = matrix.get_column(4);
+
+        assert!(row1.is_err());
+        assert!(row2.is_err());
+        assert!(column1.is_err());
+        assert!(column2.is_err());
     }
 }
 


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Direct accessing of entire rows and columns is a nice to have feature and already present for the other matrix types. This PR adds this functionality to MatPolynomialRingZq.

for/ of `Component`.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
