### PR TITLE
TryFrom for i64 with owned Z

### DIFF
--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -282,6 +282,37 @@ impl TryFrom<&Z> for i64 {
     }
 }
 
+impl TryFrom<Z> for i64 {
+    type Error = MathError;
+
+    /// Converts a [`Z`] into an [`i64`]. If the value is either too large
+    /// or too small an error is returned.
+    ///
+    /// Parameters:
+    /// - `value`: the value that will be converted into an [`i64`]
+    ///
+    /// Returns the value as an [`i64`] or an error, if it does not fit
+    /// into an [`i64`]
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::Z;
+    ///
+    /// let max = Z::from(i64::MAX);
+    /// assert_eq!(i64::MAX, i64::try_from(max).unwrap());
+    ///
+    /// let max = Z::from(u64::MAX);
+    /// assert!(i64::try_from(max).is_err());
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
+    /// if the value does not fit into an [`i64`]
+    fn try_from(value: Z) -> Result<Self, Self::Error> {
+        i64::try_from(&value)
+    }
+}
+
 impl From<&Vec<u8>> for Z {
     /// Converts a byte vector of type [`u8`] to [`Z`] using [`Z::from_bytes`].
     fn from(value: &Vec<u8>) -> Self {
@@ -606,6 +637,8 @@ mod test_try_from_into_i64 {
     fn overflow() {
         assert!(i64::try_from(&Z::from(u64::MAX)).is_err());
         assert!(i64::try_from(&(-1 * Z::from(u64::MAX))).is_err());
+        assert!(i64::try_from(Z::from(u64::MAX)).is_err());
+        assert!(i64::try_from(-1 * Z::from(u64::MAX)).is_err());
     }
 
     /// ensure that a correct value is returned for values in bounds.
@@ -619,5 +652,10 @@ mod test_try_from_into_i64 {
         assert_eq!(i64::MAX, i64::try_from(&max).unwrap());
         assert_eq!(0, i64::try_from(&Z::ZERO).unwrap());
         assert_eq!(42, i64::try_from(&z_42).unwrap());
+
+        assert_eq!(i64::MIN, i64::try_from(min).unwrap());
+        assert_eq!(i64::MAX, i64::try_from(max).unwrap());
+        assert_eq!(0, i64::try_from(Z::ZERO).unwrap());
+        assert_eq!(42, i64::try_from(z_42).unwrap());
     }
 }


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Implementations have shown, that always having to include a reference in order to call tryInto for i64 is quite unintuitive.
It should be also possible to use it with ownership. This PR adds this functionality.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [ ] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
