### PR TITLE
Sample_d with precomputed GSO

### DIFF
--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -13,7 +13,7 @@ use crate::{
     integer::{MatZ, Z},
     rational::{MatQ, Q},
     traits::{GetNumColumns, GetNumRows, SetEntry},
-    utils::sample::discrete_gauss::{sample_d, sample_z},
+    utils::sample::discrete_gauss::{sample_d, sample_d_precomputed_gso, sample_z},
 };
 use std::fmt::Display;
 
@@ -143,6 +143,61 @@ impl MatZ {
 
         MatZ::sample_d(&basis, n, &center, s)
     }
+
+    /// SampleD samples a discrete Gaussian from the lattice with a provided `basis`.
+    ///
+    /// We do not check whether basis is actually a basis or whether `basis_gso` is
+    /// actually the gso of `basis`. Hence, the callee is responsible for making sure
+    /// that basis provides a suitable basis and basis_gso is a corresponding GSO.
+    ///
+    /// Parameters:
+    /// - `basis`: specifies a basis for the lattice from which is sampled
+    /// - `basis_gso`: specifies the precomputed gso for `basis`
+    /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
+    /// - `center`: specifies the positions of the center with peak probability
+    /// - `s`: specifies the Gaussian parameter, which is proportional
+    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///
+    /// Returns a lattice vector sampled according to the discrete Gaussian distribution.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer::{MatZ, Z}, rational::{MatQ, Q}};
+    /// let basis = MatZ::identity(5, 5);
+    /// let center = MatQ::new(5, 1);
+    /// let basis_gso = MatQ::from(&basis).gso();
+    ///
+    /// let sample = MatZ::sample_d_precomputed_gso(&basis,&basis_gso, 1024, &center, 1.25f32).unwrap();
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
+    /// if the `n <= 1` or `s <= 0`.
+    /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    /// if the number of rows of the `basis` and `center` differ.
+    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+    /// if `center` is not a column vector.
+    ///
+    /// # Panics ...
+    /// - if the number of rows/columns of `basis_gso` and `basis` mismatch.
+    ///
+    /// This function implements SampleD according to:
+    /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
+    /// Trapdoors for hard lattices and new cryptographic constructions.
+    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    pub fn sample_d_precomputed_gso(
+        basis: &MatZ,
+        basis_gso: &MatQ,
+        n: impl Into<Z>,
+        center: &MatQ,
+        s: impl Into<Q>,
+    ) -> Result<Self, MathError> {
+        let n: Z = n.into();
+        let s: Q = s.into();
+
+        sample_d_precomputed_gso(basis, basis_gso, &n, center, &s)
+    }
 }
 
 #[cfg(test)]
@@ -214,6 +269,32 @@ mod test_sample_d {
         let _ = MatZ::sample_d(&basis, 2, &center, &s);
         let _ = MatZ::sample_d(&basis, 2, &center, 1.25f64);
         let _ = MatZ::sample_d(&basis, 2, &center, 15.75f32);
+    }
+
+    /// Checks whether `sample_d_precomputed_gso` is available for all types
+    /// implementing [`Into<Z>`], i.e. u8, u16, u32, u64, i8, ...
+    /// or [`Into<Q>`], i.e. u8, i16, f32, Z, Q, ...
+    #[test]
+    fn availability_prec_gso() {
+        let basis = MatZ::identity(5, 5);
+        let n = Z::from(1024);
+        let center = MatQ::new(5, 1);
+        let s = Q::ONE;
+        let basis_gso = MatQ::from(&basis);
+
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 16u16, &center, 1u16);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2u32, &center, 1u8);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2u64, &center, 1u32);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2i8, &center, 1u64);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2i16, &center, 1i64);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2i32, &center, 1i32);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2i64, &center, 1i16);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, &n, &center, 1i8);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2u8, &center, 1i64);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2, &center, &n);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2, &center, &s);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2, &center, 1.25f64);
+        let _ = MatZ::sample_d_precomputed_gso(&basis, &basis_gso, 2, &center, 15.75f32);
     }
 
     // As `sample_d_common` just calls `MatZ::sample_d` with identity basis

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -14,7 +14,7 @@ use crate::{
     integer_mod_q::{MatZq, Modulus},
     rational::{MatQ, Q},
     traits::{GetNumColumns, GetNumRows, SetEntry},
-    utils::sample::discrete_gauss::{sample_d, sample_z},
+    utils::sample::discrete_gauss::{sample_d, sample_d_precomputed_gso, sample_z},
 };
 use std::fmt::Display;
 
@@ -147,6 +147,63 @@ impl MatZq {
 
         Self::sample_d(&basis, n, &center, s)
     }
+
+    /// SampleD samples a discrete Gaussian from the lattice with a provided `basis`.
+    ///
+    /// We do not check whether basis is actually a basis or whether `basis_gso` is
+    /// actually the gso of `basis`. Hence, the callee is responsible for making sure
+    /// that basis provides a suitable basis and basis_gso is a corresponding GSO.
+    ///
+    /// Parameters:
+    /// - `basis`: specifies a basis for the lattice from which is sampled
+    /// - `basis_gso`: specifies the precomputed gso for `basis`
+    /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
+    /// - `center`: specifies the positions of the center with peak probability
+    /// - `s`: specifies the Gaussian parameter, which is proportional
+    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///
+    /// Returns a lattice vector sampled according to the discrete Gaussian distribution.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer::MatZ, integer_mod_q::MatZq, rational::MatQ};
+    /// let basis = MatZq::identity(5, 5, 17);
+    /// let center = MatQ::new(5, 1);
+    /// let basis_gso = MatQ::from(&MatZ::from(&basis)).gso();
+    ///
+    /// let sample = MatZq::sample_d_precomputed_gso(&basis,&basis_gso, 1024, &center, 1.25f32).unwrap();
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
+    /// if the `n <= 1` or `s <= 0`.
+    /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    /// if the number of rows of the `basis` and `center` differ.
+    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+    /// if `center` is not a column vector.
+    ///
+    /// # Panics ...
+    /// - if the number of rows/columns of `basis_gso` and `basis` mismatch.
+    ///
+    /// This function implements SampleD according to:
+    /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
+    /// Trapdoors for hard lattices and new cryptographic constructions.
+    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    pub fn sample_d_precomputed_gso(
+        basis: &MatZq,
+        basis_gso: &MatQ,
+        n: impl Into<Z>,
+        center: &MatQ,
+        s: impl Into<Q>,
+    ) -> Result<Self, MathError> {
+        let n: Z = n.into();
+        let s: Q = s.into();
+
+        let sample = sample_d_precomputed_gso(&MatZ::from(basis), basis_gso, &n, center, &s)?;
+
+        Ok(MatZq::from_mat_z_modulus(&sample, &basis.get_mod()))
+    }
 }
 
 #[cfg(test)]
@@ -189,7 +246,7 @@ mod test_sample_discrete_gauss {
 #[cfg(test)]
 mod test_sample_d {
     use crate::{
-        integer::Z,
+        integer::{MatZ, Z},
         integer_mod_q::{MatZq, Modulus},
         rational::{MatQ, Q},
     };
@@ -220,6 +277,32 @@ mod test_sample_d {
         let _ = MatZq::sample_d(&basis, 2, &center, &s);
         let _ = MatZq::sample_d(&basis, 2, &center, 1.25f64);
         let _ = MatZq::sample_d(&basis, 2, &center, 15.75f32);
+    }
+
+    /// Checks whether `sample_d_precomputed_gso` is available for all types
+    /// implementing [`Into<Z>`], i.e. u8, u16, u32, u64, i8, ...
+    /// or [`Into<Q>`], i.e. u8, i16, f32, Z, Q, ...
+    #[test]
+    fn availability_prec_gso() {
+        let basis = MatZq::identity(5, 5, 17);
+        let n = Z::from(1024);
+        let center = MatQ::new(5, 1);
+        let s = Q::ONE;
+        let basis_gso = MatQ::from(&MatZ::from(&basis));
+
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 16u16, &center, 1u16);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2u32, &center, 1u8);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2u64, &center, 1u32);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2i8, &center, 1u64);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2i16, &center, 1i64);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2i32, &center, 1i32);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2i64, &center, 1i16);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, &n, &center, 1i8);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2u8, &center, 1i64);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2, &center, &n);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2, &center, &s);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2, &center, 1.25f64);
+        let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2, &center, 15.75f32);
     }
 
     // As `sample_d_common` just calls `MatZq::sample_d` with identity basis

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -270,6 +270,7 @@ pub(crate) fn sample_d_precomputed_gso(
 
     Ok(out)
 }
+
 #[cfg(test)]
 mod test_sample_z {
     use super::{sample_z, Q, Z};
@@ -346,7 +347,7 @@ mod test_gaussian_function {
     use super::{gaussian_function, Q, Z};
     use crate::traits::Distance;
 
-    /// Ensures that the doc test would run properly
+    /// Ensures that the doc test would run properly.
     #[test]
     fn doc_test() {
         let sample = Z::ONE;
@@ -361,7 +362,7 @@ mod test_gaussian_function {
     }
 
     /// Checks whether the values for small values are computed appropriately
-    /// and with appropriate precision
+    /// and with appropriate precision.
     #[test]
     fn small_values() {
         let sample_0 = Z::ZERO;
@@ -386,7 +387,7 @@ mod test_gaussian_function {
     }
 
     /// Checks whether the values for large values are computed appropriately
-    /// and with appropriate precision
+    /// and with appropriate precision.
     #[test]
     fn large_values() {
         let sample = Z::from(i64::MAX);
@@ -400,7 +401,7 @@ mod test_gaussian_function {
         assert!(cmp.distance(&res) < Q::from((3, 1_000_000_000)));
     }
 
-    /// Checks whether `s = 0` results in a panic
+    /// Checks whether `s = 0` results in a panic.
     #[test]
     #[should_panic]
     fn invalid_s() {
@@ -425,7 +426,7 @@ mod test_sample_d {
 
     use super::sample_d_precomputed_gso;
 
-    /// Ensures that the doc-test compiles and runs properly
+    /// Ensures that the doc-test compiles and runs properly.
     #[test]
     fn doc_test() {
         let basis = MatZ::identity(5, 5);
@@ -439,7 +440,7 @@ mod test_sample_d {
             sample_d_precomputed_gso(&basis, &basis_gso, &n, &center, &gaussian_parameter).unwrap();
     }
 
-    /// Ensures that `sample_d` works properly for a non-zero center
+    /// Ensures that `sample_d` works properly for a non-zero center.
     #[test]
     fn non_zero_center() {
         let basis = MatZ::identity(5, 5);
@@ -453,7 +454,7 @@ mod test_sample_d {
             sample_d_precomputed_gso(&basis, &basis_gso, &n, &center, &gaussian_parameter).unwrap();
     }
 
-    /// Ensures that `sample_d` works properly for a different basis
+    /// Ensures that `sample_d` works properly for a different basis.
     #[test]
     fn non_identity_basis() {
         let basis = MatZ::from_str("[[2,1],[1,2]]").unwrap();
@@ -467,7 +468,7 @@ mod test_sample_d {
             sample_d_precomputed_gso(&basis, &basis_gso, &n, &center, &gaussian_parameter).unwrap();
     }
 
-    /// Ensures that `sample_d` outputs a vector that's part of the specified lattice
+    /// Ensures that `sample_d` outputs a vector that's part of the specified lattice.
     ///
     /// Checks whether the Hermite Normal Form HNF of the basis is equal to the HNF of
     /// the basis concatenated with the sampled vector. If it is part of the lattice, it
@@ -527,7 +528,7 @@ mod test_sample_d {
             .is_zero());
     }
 
-    /// Checks whether `sample_d` returns an error if the gaussian parameter `s <= 0`
+    /// Checks whether `sample_d` returns an error if the gaussian parameter `s <= 0`.
     #[test]
     fn invalid_gaussian_parameter() {
         let basis = MatZ::identity(5, 5);
@@ -546,7 +547,7 @@ mod test_sample_d {
         );
     }
 
-    /// Checks whether `sample_d` returns an error if `n <= 1`
+    /// Checks whether `sample_d` returns an error if `n <= 1`.
     #[test]
     fn invalid_n() {
         let basis = MatZ::identity(5, 5);
@@ -592,7 +593,7 @@ mod test_sample_d {
         .is_err());
     }
 
-    /// Checks whether `sample_d` returns an error if the basis and center number of rows differs
+    /// Checks whether `sample_d` returns an error if the basis and center number of rows differs.
     #[test]
     fn mismatching_matrix_dimensions() {
         let basis = MatZ::identity(3, 5);
@@ -609,7 +610,7 @@ mod test_sample_d {
         assert!(res_prec.is_err());
     }
 
-    /// Checks whether `sample_d` returns an error if center isn't a column vector
+    /// Checks whether `sample_d` returns an error if center isn't a column vector.
     #[test]
     fn center_not_column_vector() {
         let basis = MatZ::identity(2, 2);

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -415,6 +415,7 @@ mod test_gaussian_function {
 
 #[cfg(test)]
 mod test_sample_d {
+    use super::sample_d_precomputed_gso;
     use crate::traits::{Concatenate, GetNumColumns, GetNumRows, Pow};
     use crate::utils::sample::discrete_gauss::sample_d;
     use crate::{
@@ -423,7 +424,6 @@ mod test_sample_d {
     };
     use flint_sys::fmpz_mat::fmpz_mat_hnf;
     use std::str::FromStr;
-    use super::sample_d_precomputed_gso;
 
     /// Ensures that the doc-test compiles and runs properly.
     #[test]

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -170,7 +170,7 @@ pub(crate) fn sample_d(basis: &MatZ, n: &Z, center: &MatQ, s: &Q) -> Result<MatZ
 ///
 /// Parameters:
 /// - `basis`: specifies a basis for the lattice from which is sampled
-/// - `basis_gso`: specifies the precomputed gso for basis
+/// - `basis_gso`: specifies the precomputed gso for `basis`
 /// - `n`: specifies the range from which [`sample_z`] samples
 /// - `center`: specifies the positions of the center with peak probability
 /// - `s`: specifies the Gaussian parameter, which is proportional


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Experiments in the crypto crate have shown that one of the main running time issues with current implementations using sample_d lies within the computation of the gso of a basis.
An intuitive approach is to precompute the gso and reuse it. In order to do this, we require that there is a sampleD algorithm that can take as input a precomputed gso of the base.
This PR makes it possible for
- [x] MatZ
- [x] MatZq  

I intentionally left out MatPolyOverZ and MatPolynomialRingZq, as the way the gso would be provided needs some consideration, but I added a corresponding task in the Kanboard.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

I decided to simply add a version using a precomputed gso to every existing test, as otherwise we would only have a lot of copied code.
<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
