### PR TITLE
Add Struct descriptions to PolynomialRings + fix bug

### DIFF
--- a/src/integer_mod_q/mat_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq.rs
@@ -32,8 +32,58 @@ mod vector;
 /// - `modulus` : holds the [`ModulusPolynomialRingZq`](crate::integer_mod_q::ModulusPolynomialRingZq)
 /// modulus of the matrix
 ///
-/// TODO: Add Examples
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Display)]
+/// # Examples
+/// ## Matrix usage
+/// ```
+/// use qfall_math::{
+///     integer::{PolyOverZ, MatPolyOverZ},
+///     integer_mod_q::{MatPolynomialRingZq, PolyOverZq},
+///     traits::{GetEntry, SetEntry},
+/// };
+/// use std::str::FromStr;
+///
+/// // instantiate new matrix
+/// let id_mat = MatPolyOverZ::identity(2, 2);
+/// // instantiate modulus_object
+/// let modulus = PolyOverZq::from_str("5  1 0 0 0 1 mod 17").unwrap();
+///
+/// let poly_mat = MatPolynomialRingZq::from((id_mat, modulus));
+///
+/// // clone object, set and get entry
+/// let mut clone = poly_mat.clone();
+/// clone.set_entry(0, 0, PolyOverZ::from(-16));
+///
+/// let entry: PolyOverZ = clone.get_entry(0,0).unwrap();
+/// assert_eq!(
+///     entry,
+///     PolyOverZ::from(1),
+/// );
+///
+/// // to_string
+/// assert_eq!("[[1  1, 0],[0, 1  1]] / 5  1 0 0 0 1 mod 17", &poly_mat.to_string());
+/// ```
+///
+/// ## Vector usage
+/// ```
+/// use qfall_math::{
+///     integer::{PolyOverZ, MatPolyOverZ},
+///     integer_mod_q::{MatPolynomialRingZq, PolyOverZq},
+/// };
+/// use std::str::FromStr;
+///
+/// let row_vec = MatPolyOverZ::from_str("[[1  1, 0, 1  1]]").unwrap();
+/// let col_vec = MatPolyOverZ::from_str("[[1  -5],[1  -1],[0]]").unwrap();
+///
+/// let modulus = PolyOverZq::from_str("5  1 0 0 0 1 mod 17").unwrap();
+///
+/// let row_vec = MatPolynomialRingZq::from((row_vec, modulus));
+/// let col_vec = MatPolynomialRingZq::from((col_vec, row_vec.get_mod()));
+///
+/// // check if matrix instance is vector
+/// assert!(row_vec.is_row_vector());
+/// assert!(col_vec.is_column_vector());
+/// ```
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Display, Clone)]
 #[display(fmt = "{matrix} / {modulus}")]
 pub struct MatPolynomialRingZq {
     pub(crate) matrix: MatPolyOverZ,

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -59,14 +59,9 @@ impl SetEntry<&PolyOverZ> for MatPolynomialRingZq {
         column: impl TryInto<i64> + Display,
         value: &PolyOverZ,
     ) -> Result<(), MathError> {
-        let (row_i64, column_i64) = evaluate_indices_for_matrix(self, row, column)?;
+        let value = PolynomialRingZq::from((value, self.get_mod()));
 
-        unsafe {
-            let entry = fmpz_poly_mat_entry(&self.matrix.matrix, row_i64, column_i64);
-            fmpz_poly_set(entry, &value.poly)
-        };
-
-        Ok(())
+        self.set_entry(row, column, value)
     }
 }
 
@@ -141,7 +136,9 @@ implement_for_owned!(PolynomialRingZq, MatPolynomialRingZq, SetEntry);
 mod test_setter {
     use crate::{
         integer::{MatPolyOverZ, PolyOverZ},
-        integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq, PolynomialRingZq},
+        integer_mod_q::{
+            MatPolynomialRingZq, ModulusPolynomialRingZq, PolyOverZq, PolynomialRingZq,
+        },
         traits::{GetEntry, SetEntry},
     };
     use std::str::FromStr;
@@ -164,6 +161,23 @@ mod test_setter {
         assert_eq!("0", entry_z.to_string());
         assert_eq!("0", entry_zq.poly.to_string());
         assert_eq!("4  1 0 0 1 mod 17", entry_zq.modulus.to_string());
+    }
+
+    /// Ensure that when using a [`PolyOverZ`] the set entry is actually reduced by the
+    /// modulus
+    #[test]
+    fn set_entry_reduced() {
+        let id_mat = MatPolyOverZ::identity(2, 2);
+        let modulus = PolyOverZq::from_str("5  1 0 0 0 1 mod 17").unwrap();
+
+        let mut poly_mat = MatPolynomialRingZq::from((id_mat, modulus));
+
+        poly_mat
+            .set_entry(0, 0, PolyOverZ::from_str("5  -1 0 0 0 16").unwrap())
+            .unwrap();
+
+        let entry: PolyOverZ = poly_mat.get_entry(0, 0).unwrap();
+        assert_eq!(entry, PolyOverZ::from(0));
     }
 
     /// Ensure that setting entries works with large numbers.

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -177,7 +177,7 @@ mod test_setter {
             .unwrap();
 
         let entry: PolyOverZ = poly_mat.get_entry(0, 0).unwrap();
-        assert_eq!(entry, PolyOverZ::from(0));
+        assert!(entry.is_zero());
     }
 
     /// Ensure that setting entries works with large numbers.

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -164,7 +164,7 @@ mod test_setter {
     }
 
     /// Ensure that when using a [`PolyOverZ`] the set entry is actually reduced by the
-    /// modulus
+    /// modulus.
     #[test]
     fn set_entry_reduced() {
         let id_mat = MatPolyOverZ::identity(2, 2);

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -247,8 +247,14 @@ mod test_setter {
         let entry_z: PolyOverZ = poly_ring_mat.get_entry(0, 1).unwrap();
         let entry_zq: PolynomialRingZq = poly_ring_mat.get_entry(0, 1).unwrap();
 
-        assert_eq!(format!("3  1 {} 1", i64::MIN), entry_z.to_string());
-        assert_eq!(format!("3  1 {} 1", i64::MIN), entry_zq.poly.to_string());
+        assert_eq!(
+            format!("3  1 {} 1", LARGE_PRIME - i64::MIN as u64),
+            entry_z.to_string()
+        );
+        assert_eq!(
+            format!("3  1 {} 1", LARGE_PRIME - i64::MIN as u64),
+            entry_zq.poly.to_string()
+        );
         assert_eq!(
             format!("4  1 0 0 1 mod {LARGE_PRIME}"),
             entry_zq.modulus.to_string()

--- a/src/integer_mod_q/modulus_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq.rs
@@ -35,7 +35,7 @@ mod to_string;
 ///
 /// // initialize X^2 + 1 mod 17, i.e. a polynomial with modulus
 /// let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
-/// let modulus = ModulusPolynomialRingZq::try_from(&poly_mod);
+/// let modulus = ModulusPolynomialRingZq::from(poly_mod);
 /// ```
 #[derive(Debug)]
 pub struct ModulusPolynomialRingZq {

--- a/src/integer_mod_q/polynomial_ring_zq.rs
+++ b/src/integer_mod_q/polynomial_ring_zq.rs
@@ -36,7 +36,33 @@ mod set;
 /// - `modulus`: holds the modulus q and f(X)
 ///
 /// # Examples
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Display)]
+/// ```
+/// # use qfall_math::error::MathError;
+/// use qfall_math::integer::PolyOverZ;
+/// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
+/// use qfall_math::integer_mod_q::PolyOverZq;
+/// use qfall_math::integer_mod_q::PolynomialRingZq;
+/// use std::str::FromStr;
+///
+/// let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
+/// let modulus = ModulusPolynomialRingZq::from(poly_mod);
+///
+/// // instantiation
+/// let a = PolynomialRingZq::from((PolyOverZ::from(5), &modulus));
+/// let b = PolynomialRingZq::from((PolyOverZ::from_str("2  1 5").unwrap(), &modulus));
+/// let _ = a.clone();
+///
+/// // arithmetics
+/// let _ = &a + &b;
+/// let _ = &a * &b;
+///
+/// // to_string incl. (de-)serialization
+/// assert_eq!("1  5 / 3  1 0 1 mod 17", &a.to_string());
+/// let _ = serde_json::to_string(&a).unwrap();
+///
+/// # Ok::<(), MathError>(())
+/// ```
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Display, Clone)]
 #[display(fmt = "{poly} / {modulus}")]
 pub struct PolynomialRingZq {
     pub(crate) poly: PolyOverZ,


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

The PolynomialRing structs did not have any examples yet. This PR adds the corresponding examples to the structs and fixes an error in the implementation of set for matPolynomialRingZq.
- [x] examples for MatPolynomialRingZq, PolynomialRingZq
- [x] fix set in MatPolynomialRingZq

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
