### PR TITLE
Different parameter types for `Z::div_(floor, ceil, exact)`

### DIFF
--- a/src/integer/z/arithmetic/div.rs
+++ b/src/integer/z/arithmetic/div.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright © 2023 Niklas Siemer and Sven Moog
 //
 // This file is part of qFALL-math.
 //
@@ -33,13 +33,16 @@ impl Z {
     /// let b: Z = Z::from(20);
     ///
     /// let c = a.div_floor(&b);
+    /// let d = a.div_floor(20);
     ///
     /// assert_eq!(Z::from(2), c);
+    /// assert_eq!(Z::from(2), d);
     /// ```
     ///
     /// # Panics ...
     /// - if the divisor is `0`.
-    pub fn div_floor(&self, other: &Self) -> Self {
+    pub fn div_floor(&self, other: impl Into<Z>) -> Self {
+        let other: Z = other.into();
         assert!(!other.is_zero(), "Tried to divide {self} by zero.");
         let mut out = Z::default();
         unsafe {
@@ -63,13 +66,16 @@ impl Z {
     /// let b: Z = Z::from(20);
     ///
     /// let c = a.div_ceil(&b);
+    /// let d = a.div_ceil(20);
     ///
     /// assert_eq!(Z::from(3), c);
+    /// assert_eq!(Z::from(3), d);
     /// ```
     ///
     /// # Panics ...
     /// - if the divisor is `0`.
-    pub fn div_ceil(&self, other: &Self) -> Self {
+    pub fn div_ceil(&self, other: impl Into<Z>) -> Self {
+        let other: Z = other.into();
         assert!(!other.is_zero(), "Tried to divide {self} by zero.");
         let mut out = Z::default();
         unsafe {
@@ -103,7 +109,8 @@ impl Z {
     ///
     /// # Panics ...
     /// - if the divisor is `0`.
-    pub fn div_exact(&self, other: &Self) -> Option<Self> {
+    pub fn div_exact(&self, other: impl Into<Z>) -> Option<Self> {
+        let other: Z = other.into();
         assert!(!other.is_zero(), "Tried to divide {self} by zero.");
 
         let mut quotient = Z::default();
@@ -164,6 +171,35 @@ arithmetic_between_types!(Div, div, Z, Q, i64 i32 i16 i8 u64 u32 u16 u8);
 #[cfg(test)]
 mod test_div_floor {
     use super::Z;
+    use crate::integer_mod_q::Modulus;
+
+    /// Tests that `div_floor` is available for other types.
+    #[test]
+    fn availability() {
+        let value = Z::from(100);
+
+        value.div_floor(3_u8);
+        value.div_floor(3_u16);
+        value.div_floor(3_u32);
+        value.div_floor(3_u64);
+        value.div_floor(3_i8);
+        value.div_floor(3_i16);
+        value.div_floor(3_i32);
+        value.div_floor(3_i64);
+        value.div_floor(Z::from(10));
+        value.div_floor(Modulus::from(10));
+
+        value.div_floor(&3_u8);
+        value.div_floor(&3_u16);
+        value.div_floor(&3_u32);
+        value.div_floor(&3_u64);
+        value.div_floor(&3_i8);
+        value.div_floor(&3_i16);
+        value.div_floor(&3_i32);
+        value.div_floor(&3_i64);
+        value.div_floor(&Z::from(10));
+        value.div_floor(&Modulus::from(10));
+    }
 
     /// Checks whether `div_floor` correctly rounds non-exact quotients down
     #[test]
@@ -245,6 +281,35 @@ arithmetic_trait_mixed_borrowed_owned!(Div, div, Z, Q, Q);
 #[cfg(test)]
 mod test_div_ceil {
     use super::Z;
+    use crate::integer_mod_q::Modulus;
+
+    /// Tests that `div_ceil` is available for other types.
+    #[test]
+    fn availability() {
+        let value = Z::from(100);
+
+        value.div_ceil(3_u8);
+        value.div_ceil(3_u16);
+        value.div_ceil(3_u32);
+        value.div_ceil(3_u64);
+        value.div_ceil(3_i8);
+        value.div_ceil(3_i16);
+        value.div_ceil(3_i32);
+        value.div_ceil(3_i64);
+        value.div_ceil(Z::from(10));
+        value.div_ceil(Modulus::from(10));
+
+        value.div_ceil(&3_u8);
+        value.div_ceil(&3_u16);
+        value.div_ceil(&3_u32);
+        value.div_ceil(&3_u64);
+        value.div_ceil(&3_i8);
+        value.div_ceil(&3_i16);
+        value.div_ceil(&3_i32);
+        value.div_ceil(&3_i64);
+        value.div_ceil(&Z::from(10));
+        value.div_ceil(&Modulus::from(10));
+    }
 
     /// Checks whether `div_ceil` correctly rounds non-exact quotients down
     #[test]
@@ -289,6 +354,35 @@ mod test_div_ceil {
 #[cfg(test)]
 mod test_div_exact {
     use super::Z;
+    use crate::integer_mod_q::Modulus;
+
+    /// Tests that `div_exact` is available for other types.
+    #[test]
+    fn availability() {
+        let value = Z::from(100);
+
+        value.div_exact(3_u8);
+        value.div_exact(3_u16);
+        value.div_exact(3_u32);
+        value.div_exact(3_u64);
+        value.div_exact(3_i8);
+        value.div_exact(3_i16);
+        value.div_exact(3_i32);
+        value.div_exact(3_i64);
+        value.div_exact(Z::from(10));
+        value.div_exact(Modulus::from(10));
+
+        value.div_exact(&3_u8);
+        value.div_exact(&3_u16);
+        value.div_exact(&3_u32);
+        value.div_exact(&3_u64);
+        value.div_exact(&3_i8);
+        value.div_exact(&3_i16);
+        value.div_exact(&3_i32);
+        value.div_exact(&3_i64);
+        value.div_exact(&Z::from(10));
+        value.div_exact(&Modulus::from(10));
+    }
 
     /// Checks whether `div_exact` outputs [`None`] if the quotient is not integer
     #[test]


### PR DESCRIPTION
**Description**
just small addition quality of live improvement for another PR. 

This PR implements...
- Into<Z> parameters for div_floor, div_ceil, and div_exact

for/ of `Component`.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
