### PR TITLE
Implement Into<String> for MatZq

### DIFF
--- a/src/integer_mod_q/mat_zq/to_string.rs
+++ b/src/integer_mod_q/mat_zq/to_string.rs
@@ -16,6 +16,18 @@ use crate::{integer::Z, utils::parse::matrix_to_string};
 use super::MatZq;
 use core::fmt;
 
+impl From<&MatZq> for String {
+    fn from(value: &MatZq) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<MatZq> for String {
+    fn from(value: MatZq) -> Self {
+        value.to_string()
+    }
+}
+
 impl fmt::Display for MatZq {
     /// Allows to convert a matrix of type [`MatZq`] into a [`String`].
     ///

--- a/src/integer_mod_q/mat_zq/to_string.rs
+++ b/src/integer_mod_q/mat_zq/to_string.rs
@@ -18,18 +18,18 @@ use core::fmt;
 
 impl From<&MatZq> for String {
     /// Converts a [`MatZq`] into its [`String`] representation.
-    /// 
+    ///
     /// Parameters:
     /// - `value`: specifies the matrix that will be represented as a [`String`]
-    /// 
+    ///
     /// Returns a [`String`] of the form `[[row_0],[row_1],...[row_n]] mod q`.
-    /// 
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     /// use std::str::FromStr;
     /// let matrix = MatZq::from_str("[[6, 1],[5, 2]] mod 4").unwrap();
-    /// 
+    ///
     /// let string: String = matrix.into();
     /// ```
     fn from(value: &MatZq) -> Self {
@@ -39,18 +39,18 @@ impl From<&MatZq> for String {
 
 impl From<MatZq> for String {
     /// Converts a [`MatZq`] into its [`String`] representation.
-    /// 
+    ///
     /// Parameters:
     /// - `value`: specifies the matrix that will be represented as a [`String`]
-    /// 
+    ///
     /// Returns a [`String`] of the form `[[row_0],[row_1],...[row_n]] mod q`.
-    /// 
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
     /// use std::str::FromStr;
     /// let matrix = MatZq::from_str("[[6, 1],[5, 2]] mod 4").unwrap();
-    /// 
+    ///
     /// let string: String = matrix.into();
     /// ```
     fn from(value: MatZq) -> Self {

--- a/src/integer_mod_q/mat_zq/to_string.rs
+++ b/src/integer_mod_q/mat_zq/to_string.rs
@@ -17,14 +17,44 @@ use super::MatZq;
 use core::fmt;
 
 impl From<&MatZq> for String {
+    /// Converts a [`MatZq`] into its [`String`] representation.
+    /// 
+    /// Parameters:
+    /// - `value`: specifies the matrix that will be represented as a [`String`]
+    /// 
+    /// Returns a [`String`] of the form `[[row_0],[row_1],...[row_n]] mod q`.
+    /// 
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::MatZq;
+    /// use std::str::FromStr;
+    /// let matrix = MatZq::from_str("[[6, 1],[5, 2]] mod 4").unwrap();
+    /// 
+    /// let string: String = matrix.into();
+    /// ```
     fn from(value: &MatZq) -> Self {
         value.to_string()
     }
 }
 
 impl From<MatZq> for String {
+    /// Converts a [`MatZq`] into its [`String`] representation.
+    /// 
+    /// Parameters:
+    /// - `value`: specifies the matrix that will be represented as a [`String`]
+    /// 
+    /// Returns a [`String`] of the form `[[row_0],[row_1],...[row_n]] mod q`.
+    /// 
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::MatZq;
+    /// use std::str::FromStr;
+    /// let matrix = MatZq::from_str("[[6, 1],[5, 2]] mod 4").unwrap();
+    /// 
+    /// let string: String = matrix.into();
+    /// ```
     fn from(value: MatZq) -> Self {
-        value.to_string()
+        String::from(&value)
     }
 }
 
@@ -148,5 +178,18 @@ mod test_to_string {
         let cmp_str_2 = cmp.to_string();
 
         assert!(MatZq::from_str(&cmp_str_2).is_ok());
+    }
+
+    /// Ensures that the `Into<String>` trait works properly.
+    #[test]
+    fn into_works_properly() {
+        let cmp = "[[6, 1, 3],[5, 2, 7]] mod 8";
+        let matrix = MatZq::from_str(cmp).unwrap();
+
+        let string: String = matrix.clone().into();
+        let borrowed_string: String = (&matrix).into();
+
+        assert_eq!(cmp, string);
+        assert_eq!(cmp, borrowed_string);
     }
 }


### PR DESCRIPTION
**Description**
This PR implements...
- [x] Into < String > 

for/ of `MatZq`.

This is needed for the CCSfromIBE scheme in the crypto-crate s.t. it works properly for DualRegevIBE and PFDH together.
As the functionality is clear and it is already tested by the Display trait, I believe not more documentation/tests are necessary as already provided.