### PR TITLE
Refactor Errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -171,6 +171,21 @@ pub enum MathError {
 /// is thrown if an invalid string is given to construct a [`Z`](crate::integer::Z).
 /// - [`InvalidStringToZqInput`](StringConversionError::InvalidStringToZqInput)
 /// is thrown if an invalid string is given to construct a [`Zq`](crate::integer_mod_q::Zq).
+///
+/// # Examples
+/// ```
+/// use qfall_math::error::StringConversionError;
+///
+/// fn throws_error() -> Result<(), StringConversionError> {
+///     return Err(
+///         StringConversionError::InvalidMatrix(String::from(
+///             "Some silly mistake was made",
+///         )),
+///     );
+///
+///     Ok(())
+/// }
+/// ```
 #[derive(Error, Debug)]
 pub enum StringConversionError {
     /// Invalid Matrix input error.

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -64,13 +64,11 @@ impl FromStr for MatPolyOverZ {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::InvalidStringToPolyInput`],
-    /// [`InvalidStringToPolyMissingWhitespace`](MathError::InvalidStringToPolyMissingWhitespace) or
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
-    /// if the entries are not formatted correctly. For further details see [`PolyOverZ::from_str`]
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+    /// - Returns a [`MathError`] of type [`MathError::StringConversionError`],
+    /// if the entries are not formatted correctly,
     /// if the matrix is not formatted in a suitable way, or
     /// if the number of entries in rows is unequal.
+    /// For further details see [`PolyOverZ::from_str`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.

--- a/src/integer/mat_poly_over_z/vector/dot_product.rs
+++ b/src/integer/mat_poly_over_z/vector/dot_product.rs
@@ -38,7 +38,7 @@ impl MatPolyOverZ {
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
     /// the given [`MatPolyOverZ`] instance is not a (row or column) vector.
-    /// - Returns a [`MathError`] of type [`MathError::MismatchingVectorDimensions`] if
+    /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`] if
     /// the given vectors have different lengths.
     pub fn dot_product(&self, other: &Self) -> Result<PolyOverZ, MathError> {
         if !self.is_vector() {
@@ -59,7 +59,7 @@ impl MatPolyOverZ {
         let other_entries = other.collect_entries();
 
         if self_entries.len() != other_entries.len() {
-            return Err(MathError::MismatchingVectorDimensions(format!(
+            return Err(MathError::MismatchingMatrixDimension(format!(
                 "You called the function 'dot_product' for vectors of different lengths: {} and {}",
                 self_entries.len(),
                 other_entries.len()

--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -78,14 +78,10 @@ impl FromStr for MatZ {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the matrix is not formatted in a suitable way or
-    /// if the number of entries in rows is unequal.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
-    /// if an entry contains a Nul byte.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
+    /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
+    /// if the matrix is not formatted in a suitable way,
+    /// if the number of entries in rows is unequal,
+    /// if an entry contains a Nul byte, or
     /// if an entry is not formatted correctly.
     ///
     /// # Panics ...

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -97,7 +97,7 @@ impl MatZ {
     /// if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
     /// if the number of rows of the `basis` and `center` differ.
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+    /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
     /// if `center` is not a column vector.
     ///
     /// This function implements SampleD according to:
@@ -175,7 +175,7 @@ impl MatZ {
     /// if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
     /// if the number of rows of the `basis` and `center` differ.
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+    /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
     /// if `center` is not a column vector.
     ///
     /// # Panics ...

--- a/src/integer/mat_z/sort.rs
+++ b/src/integer/mat_z/sort.rs
@@ -158,11 +158,9 @@ mod test_sort_by_length {
     /// it should always return an error if used as `cond_func` for these two functions
     fn failing_func(matrix: &MatZ) -> Result<(), MathError> {
         if matrix.is_vector() {
-            Err(MathError::StringConversionError(
-                StringConversionError::InvalidMatrix(String::from(
-                    "Some silly mistake was made - on purpose",
-                )),
-            ))
+            Err(StringConversionError::InvalidMatrix(String::from(
+                "Some silly mistake was made - on purpose",
+            )))?
         } else {
             Ok(())
         }

--- a/src/integer/mat_z/sort.rs
+++ b/src/integer/mat_z/sort.rs
@@ -150,7 +150,7 @@ impl MatZ {
 #[cfg(test)]
 mod test_sort_by_length {
     use super::MatZ;
-    use crate::error::MathError;
+    use crate::error::{MathError, StringConversionError};
     use std::str::FromStr;
 
     /// This function should fail in any case a vector is provided to it.
@@ -158,9 +158,11 @@ mod test_sort_by_length {
     /// it should always return an error if used as `cond_func` for these two functions
     fn failing_func(matrix: &MatZ) -> Result<(), MathError> {
         if matrix.is_vector() {
-            Err(MathError::InvalidMatrix(String::from(
-                "Some silly mistake was made - on purpose",
-            )))
+            Err(MathError::StringConversionError(
+                StringConversionError::InvalidMatrix(String::from(
+                    "Some silly mistake was made - on purpose",
+                )),
+            ))
         } else {
             Ok(())
         }

--- a/src/integer/mat_z/vector/dot_product.rs
+++ b/src/integer/mat_z/vector/dot_product.rs
@@ -41,7 +41,7 @@ impl MatZ {
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
     /// the given [`MatZ`] instance is not a (row or column) vector.
-    /// - Returns a [`MathError`] of type [`MathError::MismatchingVectorDimensions`] if
+    /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`] if
     /// the given vectors have different lengths.
     pub fn dot_product(&self, other: &Self) -> Result<Z, MathError> {
         if !self.is_vector() {
@@ -62,7 +62,7 @@ impl MatZ {
         let other_entries = other.collect_entries();
 
         if self_entries.len() != other_entries.len() {
-            return Err(MathError::MismatchingVectorDimensions(format!(
+            return Err(MathError::MismatchingMatrixDimension(format!(
                 "You called the function 'dot_product' for vectors of different lengths: {} and {}",
                 self_entries.len(),
                 other_entries.len()

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -70,9 +70,9 @@ impl FromStr for PolyOverZ {
         // We only have to check it once, because for every other position it checks
         // whether there is only one space.
         if !s_trimmed.contains("  ") {
-            return Err(MathError::StringConversionError(
-                StringConversionError::InvalidStringToPolyMissingWhitespace(s.to_owned()),
-            ));
+            return Err(StringConversionError::InvalidStringToPolyMissingWhitespace(
+                s.to_owned(),
+            ))?;
         };
 
         let mut res = Self::default();
@@ -81,9 +81,9 @@ impl FromStr for PolyOverZ {
 
         match unsafe { fmpz_poly_set_str(&mut res.poly, c_string.as_ptr()) } {
             0 => Ok(res),
-            _ => Err(MathError::StringConversionError(
-                StringConversionError::InvalidStringToPolyInput(s.to_owned()),
-            )),
+            _ => Err(StringConversionError::InvalidStringToPolyInput(
+                s.to_owned(),
+            ))?,
         }
     }
 }

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -14,7 +14,11 @@
 
 use super::PolyOverZ;
 use crate::integer_mod_q::PolyOverZq;
-use crate::{error::MathError, integer::Z, traits::AsInteger};
+use crate::{
+    error::{MathError, StringConversionError},
+    integer::Z,
+    traits::AsInteger,
+};
 use flint_sys::fmpz_mod_poly::fmpz_mod_poly_get_fmpz_poly;
 use flint_sys::fmpz_poly::{fmpz_poly_set_fmpz, fmpz_poly_set_str};
 use std::{ffi::CString, str::FromStr};
@@ -44,15 +48,13 @@ impl FromStr for PolyOverZ {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::InvalidStringToPolyInput`]
+    /// - Returns a [`MathError`] of type [`MathError::StringConversionError`]
     /// if the provided string was not formatted correctly or the number of
     /// coefficients was smaller than the number provided at the start of the
-    /// provided string.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToPolyMissingWhitespace`](MathError::InvalidStringToPolyMissingWhitespace)
+    /// provided string, or
     /// if the provided value did not contain two whitespaces.
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
+    /// [`StringConversionError`](MathError::StringConversionError)
     /// if the provided string contains a Null Byte.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // remove whitespaces at the start and at the end
@@ -68,8 +70,8 @@ impl FromStr for PolyOverZ {
         // We only have to check it once, because for every other position it checks
         // whether there is only one space.
         if !s_trimmed.contains("  ") {
-            return Err(MathError::InvalidStringToPolyMissingWhitespace(
-                s.to_owned(),
+            return Err(MathError::StringConversionError(
+                StringConversionError::InvalidStringToPolyMissingWhitespace(s.to_owned()),
             ));
         };
 
@@ -79,7 +81,9 @@ impl FromStr for PolyOverZ {
 
         match unsafe { fmpz_poly_set_str(&mut res.poly, c_string.as_ptr()) } {
             0 => Ok(res),
-            _ => Err(MathError::InvalidStringToPolyInput(s.to_owned())),
+            _ => Err(MathError::StringConversionError(
+                StringConversionError::InvalidStringToPolyInput(s.to_owned()),
+            )),
         }
     }
 }

--- a/src/integer/z/arithmetic/logarithm.rs
+++ b/src/integer/z/arithmetic/logarithm.rs
@@ -35,18 +35,18 @@ impl Z {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidBase`](MathError::InvalidBase) if the `base` is not greater than `1`.
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput) if the `base` is not greater than `1`.
     /// - Returns a [`MathError`] of type
-    /// [`NotPositiveNumber`](MathError::NotPositiveNumber) if `self` is not
+    /// [`NonPositive`](MathError::NonPositive) if `self` is not
     ///  greater than `0`.
     pub fn log_ceil(&self, base: impl Into<Z>) -> Result<Z, MathError> {
         let base: Z = base.into();
         if base <= Z::ONE {
-            Err(MathError::InvalidBase(format!(
+            Err(MathError::InvalidIntegerInput(format!(
                 "The base must be greater than 1, but the provided is {base}"
             )))
         } else if self <= &Z::ZERO {
-            Err(MathError::NotPositiveNumber(self.to_string()))
+            Err(MathError::NonPositive(self.to_string()))
         } else {
             Ok(Z::from(unsafe { fmpz_clog(&self.value, &base.value) }))
         }
@@ -75,18 +75,18 @@ impl Z {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidBase`](MathError::InvalidBase) if the `base` is not greater than `1`.
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput) if the `base` is not greater than `1`.
     /// - Returns a [`MathError`] of type
-    /// [`NotPositiveNumber`](MathError::NotPositiveNumber) if `self` is not
+    /// [`NonPositive`](MathError::NonPositive) if `self` is not
     ///  greater than `0`.
     pub fn log_floor(&self, base: impl Into<Z>) -> Result<Z, MathError> {
         let base: Z = base.into();
         if base <= Z::ONE {
-            Err(MathError::InvalidBase(format!(
+            Err(MathError::InvalidIntegerInput(format!(
                 "The base must be greater than 1, but the provided is {base}"
             )))
         } else if self <= &Z::ZERO {
-            Err(MathError::NotPositiveNumber(self.to_string()))
+            Err(MathError::NonPositive(self.to_string()))
         } else {
             Ok(Z::from(unsafe { fmpz_flog(&self.value, &base.value) }))
         }
@@ -113,11 +113,11 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`NotPositiveNumber`](MathError::NotPositiveNumber) if `self` is not
+    /// [`NonPositive`](MathError::NonPositive) if `self` is not
     ///  greater than `0`.
     pub fn ln(&self) -> Result<Q, MathError> {
         if self <= &Z::ZERO {
-            Err(MathError::NotPositiveNumber(self.to_string()))
+            Err(MathError::NonPositive(self.to_string()))
         } else {
             Ok(Q::from(unsafe { fmpz_dlog(&self.value) }))
         }
@@ -147,15 +147,15 @@ impl Z {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidBase`](MathError::InvalidBase)
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
     /// if the `base` is not greater than `1`.
     /// - Returns a [`MathError`] of type
-    /// [`NotPositiveNumber`](MathError::NotPositiveNumber) if `self` is not
+    /// [`NonPositive`](MathError::NonPositive) if `self` is not
     ///  greater than `0`.
     pub fn log(&self, base: impl Into<Z>) -> Result<Q, MathError> {
         let base: Z = base.into();
         if base <= Z::ONE {
-            return Err(MathError::InvalidBase(format!(
+            return Err(MathError::InvalidIntegerInput(format!(
                 "The base must be greater than 1, but the provided is {base}"
             )));
         }

--- a/src/integer/z/arithmetic/root.rs
+++ b/src/integer/z/arithmetic/root.rs
@@ -59,16 +59,16 @@ impl Z {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::PrecisionNotPositive`]
+    /// - Returns a [`MathError`] of type [`MathError::NonPositive`]
     ///   if the precision is not larger than zero.
-    /// - Returns a [`MathError`] of type [`MathError::NegativeRootParameter`]
+    /// - Returns a [`MathError`] of type [`MathError::NonPositive`]
     ///   if the parameter of the square root is negative.
     pub fn sqrt_precision(&self, precision: &Z) -> Result<Q, MathError> {
         if self < &Z::ZERO {
-            return Err(MathError::NegativeRootParameter(format!("{self}")));
+            return Err(MathError::NonPositive(format!("{self}")));
         }
         if precision <= &Z::ZERO {
-            return Err(MathError::PrecisionNotPositive(format!("{precision}")));
+            return Err(MathError::NonPositive(format!("{precision}")));
         }
 
         let mut integer_result = Q::default();

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -121,9 +121,7 @@ impl Z {
         }
 
         if s.contains(char::is_whitespace) {
-            return Err(MathError::StringConversionError(
-                StringConversionError::InvalidStringToZInput(s.to_owned()),
-            ));
+            return Err(StringConversionError::InvalidStringToZInput(s.to_owned()))?;
         }
 
         // since |value| = |0| < 62 bits, we do not need to free the allocated space manually
@@ -137,9 +135,7 @@ impl Z {
         // For reading more look at the documentation of `.as_ptr()`.
         match unsafe { fmpz_set_str(&mut value, c_string.as_ptr(), base) } {
             0 => Ok(Z { value }),
-            _ => Err(MathError::StringConversionError(
-                StringConversionError::InvalidStringToZInput(s.to_owned()),
-            )),
+            _ => Err(StringConversionError::InvalidStringToZInput(s.to_owned()))?,
         }
     }
 

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -14,7 +14,9 @@
 
 use super::Z;
 use crate::{
-    error::MathError, integer_mod_q::Modulus, macros::for_others::implement_empty_trait_owned_ref,
+    error::{MathError, StringConversionError},
+    integer_mod_q::Modulus,
+    macros::for_others::implement_empty_trait_owned_ref,
     traits::AsInteger,
 };
 use flint_sys::fmpz::{fmpz, fmpz_combit, fmpz_get_si, fmpz_set, fmpz_set_str};
@@ -107,10 +109,8 @@ impl Z {
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if the
     /// base is not between `2` and `62`.
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
-    /// if the provided string contains a Nul byte.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
+    /// [`StringConversionError`](MathError::StringConversionError)
+    /// if the provided string contains a Nul byte, or
     /// if the provided string was not formatted correctly.
     pub fn from_str_b(s: &str, base: i32) -> Result<Self, MathError> {
         if !(2..=62).contains(&base) {
@@ -121,7 +121,9 @@ impl Z {
         }
 
         if s.contains(char::is_whitespace) {
-            return Err(MathError::InvalidStringToZInput(s.to_owned()));
+            return Err(MathError::StringConversionError(
+                StringConversionError::InvalidStringToZInput(s.to_owned()),
+            ));
         }
 
         // since |value| = |0| < 62 bits, we do not need to free the allocated space manually
@@ -135,7 +137,9 @@ impl Z {
         // For reading more look at the documentation of `.as_ptr()`.
         match unsafe { fmpz_set_str(&mut value, c_string.as_ptr(), base) } {
             0 => Ok(Z { value }),
-            _ => Err(MathError::InvalidStringToZInput(s.to_owned())),
+            _ => Err(MathError::StringConversionError(
+                StringConversionError::InvalidStringToZInput(s.to_owned()),
+            )),
         }
     }
 
@@ -258,10 +262,8 @@ impl FromStr for Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
-    /// if the provided string contains a Nul byte.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
+    /// [`StringConversionError`](MathError::StringConversionError)
+    /// if the provided string contains a Nul byte, or
     /// if the provided string was not formatted correctly.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Z::from_str_b(s, 10)

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector/dot_product.rs
@@ -43,7 +43,7 @@ impl MatPolynomialRingZq {
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
     /// the given [`MatPolynomialRingZq`] instance is not a (row or column) vector.
-    /// - Returns a [`MathError`] of type [`MathError::MismatchingVectorDimensions`] if
+    /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`] if
     /// the given vectors have different lengths.
     pub fn dot_product(&self, other: &Self) -> Result<PolynomialRingZq, MathError> {
         if !self.is_vector() {
@@ -64,7 +64,7 @@ impl MatPolynomialRingZq {
         let other_entries = other.collect_entries();
 
         if self_entries.len() != other_entries.len() {
-            return Err(MathError::MismatchingVectorDimensions(format!(
+            return Err(MathError::MismatchingMatrixDimension(format!(
                 "You called the function 'dot_product' for vectors of different lengths: {} and {}",
                 self_entries.len(),
                 other_entries.len()

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -15,7 +15,7 @@
 
 use super::MatZq;
 use crate::{
-    error::MathError,
+    error::{MathError, StringConversionError},
     integer::{MatZ, Z},
     integer_mod_q::Modulus,
     traits::{GetNumColumns, GetNumRows, SetEntry},
@@ -93,14 +93,10 @@ impl FromStr for MatZq {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the matrix is not formatted in a suitable way or
-    /// if the number of entries in rows is unequal.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
-    /// if an entry contains a Nul byte.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
+    /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
+    /// if the matrix is not formatted in a suitable way,
+    /// if the number of entries in rows is unequal,
+    /// if an entry contains a Nul byte, or
     /// if the modulus or an entry is not formatted correctly.
     ///
     /// # Panics ...
@@ -110,9 +106,11 @@ impl FromStr for MatZq {
         let (matrix, modulus) = match string.split_once("mod") {
             Some((matrix, modulus)) => (matrix, modulus),
             None => {
-                return Err(MathError::InvalidStringToMatZqInput(format!(
-                    "The word 'mod' could not be found: {string}"
-                )))
+                return Err(MathError::StringConversionError(
+                    StringConversionError::InvalidMatrix(format!(
+                        "The word 'mod' could not be found: {string}"
+                    )),
+                ))
             }
         };
 

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -106,11 +106,9 @@ impl FromStr for MatZq {
         let (matrix, modulus) = match string.split_once("mod") {
             Some((matrix, modulus)) => (matrix, modulus),
             None => {
-                return Err(MathError::StringConversionError(
-                    StringConversionError::InvalidMatrix(format!(
-                        "The word 'mod' could not be found: {string}"
-                    )),
-                ))
+                return Err(StringConversionError::InvalidMatrix(format!(
+                    "The word 'mod' could not be found: {string}"
+                )))?
             }
         };
 

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -100,7 +100,7 @@ impl MatZq {
     /// if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
     /// if the number of rows of the `basis` and `center` differ.
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+    /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
     /// if `center` is not a column vector.
     ///
     /// This function implements SampleD according to:
@@ -179,7 +179,7 @@ impl MatZq {
     /// if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
     /// if the number of rows of the `basis` and `center` differ.
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+    /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
     /// if `center` is not a column vector.
     ///
     /// # Panics ...

--- a/src/integer_mod_q/mat_zq/sort.rs
+++ b/src/integer_mod_q/mat_zq/sort.rs
@@ -152,7 +152,7 @@ impl MatZq {
 #[cfg(test)]
 mod test_sort_by_length {
     use super::MatZq;
-    use crate::error::MathError;
+    use crate::error::{MathError, StringConversionError};
     use std::str::FromStr;
 
     /// This function should fail in any case a vector is provided to it.
@@ -160,9 +160,11 @@ mod test_sort_by_length {
     /// it should always return an error if used as `cond_func` for these two functions
     fn failing_func(matrix: &MatZq) -> Result<(), MathError> {
         if matrix.is_vector() {
-            Err(MathError::InvalidMatrix(String::from(
-                "Some silly mistake was made - on purpose",
-            )))
+            Err(MathError::StringConversionError(
+                StringConversionError::InvalidMatrix(String::from(
+                    "Some silly mistake was made - on purpose",
+                )),
+            ))
         } else {
             Ok(())
         }

--- a/src/integer_mod_q/mat_zq/sort.rs
+++ b/src/integer_mod_q/mat_zq/sort.rs
@@ -160,11 +160,9 @@ mod test_sort_by_length {
     /// it should always return an error if used as `cond_func` for these two functions
     fn failing_func(matrix: &MatZq) -> Result<(), MathError> {
         if matrix.is_vector() {
-            Err(MathError::StringConversionError(
-                StringConversionError::InvalidMatrix(String::from(
-                    "Some silly mistake was made - on purpose",
-                )),
-            ))
+            Err(StringConversionError::InvalidMatrix(String::from(
+                "Some silly mistake was made - on purpose",
+            )))?
         } else {
             Ok(())
         }

--- a/src/integer_mod_q/mat_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_zq/vector/dot_product.rs
@@ -46,7 +46,7 @@ impl MatZq {
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`VectorFunctionCalledOnNonVector`](MathError::VectorFunctionCalledOnNonVector)
     /// if the given [`MatZq`] instance is not a (row or column) vector.
-    /// - Returns a [`MathError`] of type [`MismatchingVectorDimensions`](MathError::MismatchingVectorDimensions)
+    /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
     /// if the given vectors have different lengths.
     /// - Returns a [`MathError`] of type [`MismatchingModulus`](MathError::MismatchingModulus)
     /// if the provided matrices have different moduli.
@@ -76,7 +76,7 @@ impl MatZq {
         let other_entries = other.collect_entries();
 
         if self_entries.len() != other_entries.len() {
-            return Err(MathError::MismatchingVectorDimensions(format!(
+            return Err(MathError::MismatchingMatrixDimension(format!(
                 "You called the function 'dot_product' for vectors of different lengths: {} and {}",
                 self_entries.len(),
                 other_entries.len()

--- a/src/integer_mod_q/modulus/from.rs
+++ b/src/integer_mod_q/modulus/from.rs
@@ -138,7 +138,7 @@ impl FromStr for Modulus {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput) if the
+    /// [`StringConversionError`](MathError::StringConversionError) if the
     /// provided string was not formatted correctly, e.g. not a correctly
     /// formatted [`Z`].
     /// - Returns a [`MathError`] of type

--- a/src/integer_mod_q/modulus/from.rs
+++ b/src/integer_mod_q/modulus/from.rs
@@ -47,12 +47,12 @@ impl Modulus {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
+    /// - Returns a [`MathError`] of type [`InvalidModulus`](MathError::InvalidModulus)
     /// if the provided value is not greater than `1`.
     pub(crate) fn from_fmpz_ref(value: &fmpz) -> Result<Self, MathError> {
         if (unsafe { fmpz_cmp_si(value, 1) } <= 0) {
             let z = Z::from(value);
-            return Err(MathError::InvalidIntToModulus(z.to_string()));
+            return Err(MathError::InvalidModulus(z.to_string()));
         }
 
         let mut ctx = MaybeUninit::uninit();
@@ -142,7 +142,7 @@ impl FromStr for Modulus {
     /// provided string was not formatted correctly, e.g. not a correctly
     /// formatted [`Z`].
     /// - Returns a [`MathError`] of type
-    /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
+    /// [`InvalidModulus`](MathError::InvalidModulus)
     /// if the provided value is not greater than `1`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let z = Z::from_str(s)?;

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -158,9 +158,9 @@ impl FromStr for PolyOverZq {
         let (poly_s, modulus) = match s.split_once("mod") {
             Some((poly_s, modulus)) => (poly_s, modulus.trim()),
             None => {
-                return Err(MathError::StringConversionError(
-                    StringConversionError::InvalidStringToPolyModulusInput(s.to_owned()),
-                ))
+                return Err(StringConversionError::InvalidStringToPolyModulusInput(
+                    s.to_owned(),
+                ))?
             }
         };
 

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -152,7 +152,7 @@ impl FromStr for PolyOverZq {
     /// if the provided half of the
     /// string was not formatted correctly to create a [`Z`](crate::integer::Z).
     /// - Returns a [`MathError`] of type
-    /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
+    /// [`InvalidModulus`](MathError::InvalidModulus)
     /// if the provided modulus is not greater than `1`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (poly_s, modulus) = match s.split_once("mod") {

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -13,7 +13,7 @@
 //! The explicit functions contain the documentation.
 
 use crate::{
-    error::MathError,
+    error::{MathError, StringConversionError},
     integer::PolyOverZ,
     integer_mod_q::{modulus::Modulus, ModulusPolynomialRingZq, PolyOverZq, Zq},
 };
@@ -144,17 +144,11 @@ impl FromStr for PolyOverZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToPolyModulusInput`](MathError::InvalidStringToPolyModulusInput)
-    /// if the provided string was not formatted correctly to create a [`Modulus`].
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToPolyMissingWhitespace`](`MathError::InvalidStringToPolyMissingWhitespace`)
-    /// if the provided value did not contain two whitespaces.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToPolyInput`](MathError::InvalidStringToPolyInput)
+    /// [`StringConversionError`](MathError::StringConversionError)
+    /// if the provided string was not formatted correctly to create a [`Modulus`],
+    /// if the provided value did not contain two whitespaces,
     /// if the provided half of the string was not formatted correctly to
-    /// create a polynomial.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
+    /// create a polynomial, or
     /// if the provided half of the
     /// string was not formatted correctly to create a [`Z`](crate::integer::Z).
     /// - Returns a [`MathError`] of type
@@ -163,7 +157,11 @@ impl FromStr for PolyOverZq {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (poly_s, modulus) = match s.split_once("mod") {
             Some((poly_s, modulus)) => (poly_s, modulus.trim()),
-            None => return Err(MathError::InvalidStringToPolyModulusInput(s.to_owned())),
+            None => {
+                return Err(MathError::StringConversionError(
+                    StringConversionError::InvalidStringToPolyModulusInput(s.to_owned()),
+                ))
+            }
         };
 
         let poly_over_z = PolyOverZ::from_str(poly_s)?;

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -9,7 +9,11 @@
 //! Implementations to create a [`Zq`] value from other types.
 
 use super::Zq;
-use crate::{error::MathError, integer::Z, integer_mod_q::Modulus};
+use crate::{
+    error::{MathError, StringConversionError},
+    integer::Z,
+    integer_mod_q::Modulus,
+};
 use flint_sys::fmpz_mod::fmpz_mod_set_fmpz;
 use std::str::FromStr;
 
@@ -115,24 +119,20 @@ impl FromStr for Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
-    /// if the provided string contains a Nul byte.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZqInput`](MathError::InvalidStringToZqInput)
-    /// if the provided string was not formatted correctly.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
-    /// if the provided modulus was not formatted correctly to create a [`Z`]
+    /// [`StringConversionError`](MathError::StringConversionError)
+    /// if the provided string contains a Nul byte,
+    /// if the provided string was not formatted correctly, or
+    /// if the provided modulus was not formatted correctly to create a [`Z`].
     /// - Returns a [`MathError`] of type
     /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
     /// if the provided value is not greater than `1`.
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
-    /// if the provided string contains a Nul byte.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let input_split: Vec<&str> = s.split("mod").collect();
         if input_split.len() != 2 {
-            return Err(MathError::InvalidStringToZqInput(s.to_owned()));
+            return Err(MathError::StringConversionError(
+                StringConversionError::InvalidStringToZqInput(s.to_owned()),
+            ));
         }
 
         // instantiate both parts of Zq element

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -124,7 +124,7 @@ impl FromStr for Zq {
     /// if the provided string was not formatted correctly, or
     /// if the provided modulus was not formatted correctly to create a [`Z`].
     /// - Returns a [`MathError`] of type
-    /// [`InvalidIntToModulus`](MathError::InvalidIntToModulus)
+    /// [`InvalidModulus`](MathError::InvalidModulus)
     /// if the provided value is not greater than `1`.
     /// - Returns a [`MathError`] of type
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -130,9 +130,7 @@ impl FromStr for Zq {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let input_split: Vec<&str> = s.split("mod").collect();
         if input_split.len() != 2 {
-            return Err(MathError::StringConversionError(
-                StringConversionError::InvalidStringToZqInput(s.to_owned()),
-            ));
+            return Err(StringConversionError::InvalidStringToZqInput(s.to_owned()))?;
         }
 
         // instantiate both parts of Zq element

--- a/src/rational/mat_q/from.rs
+++ b/src/rational/mat_q/from.rs
@@ -90,14 +90,10 @@ impl FromStr for MatQ {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
-    /// if the matrix is not formatted in a suitable way, or
-    /// if the number of entries in rows is unequal.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
-    /// if an entry contains a Nul byte.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToZInput`](MathError::InvalidStringToZInput)
+    /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
+    /// if the matrix is not formatted in a suitable way,
+    /// if the number of entries in rows is unequal,
+    /// if an entry contains a Nul byte, or
     /// if an entry is not formatted correctly.
     ///
     /// # Panics ...

--- a/src/rational/mat_q/sort.rs
+++ b/src/rational/mat_q/sort.rs
@@ -150,7 +150,7 @@ impl MatQ {
 #[cfg(test)]
 mod test_sort_by_length {
     use super::MatQ;
-    use crate::error::MathError;
+    use crate::error::{MathError, StringConversionError};
     use std::str::FromStr;
 
     /// This function should fail in any case a vector is provided to it.
@@ -158,9 +158,11 @@ mod test_sort_by_length {
     /// it should always return an error if used as `cond_func` for these two functions
     fn failing_func(matrix: &MatQ) -> Result<(), MathError> {
         if matrix.is_vector() {
-            Err(MathError::InvalidMatrix(String::from(
-                "Some silly mistake was made - on purpose",
-            )))
+            Err(MathError::StringConversionError(
+                StringConversionError::InvalidMatrix(String::from(
+                    "Some silly mistake was made - on purpose",
+                )),
+            ))
         } else {
             Ok(())
         }

--- a/src/rational/mat_q/sort.rs
+++ b/src/rational/mat_q/sort.rs
@@ -158,11 +158,9 @@ mod test_sort_by_length {
     /// it should always return an error if used as `cond_func` for these two functions
     fn failing_func(matrix: &MatQ) -> Result<(), MathError> {
         if matrix.is_vector() {
-            Err(MathError::StringConversionError(
-                StringConversionError::InvalidMatrix(String::from(
-                    "Some silly mistake was made - on purpose",
-                )),
-            ))
+            Err(StringConversionError::InvalidMatrix(String::from(
+                "Some silly mistake was made - on purpose",
+            )))?
         } else {
             Ok(())
         }

--- a/src/rational/mat_q/vector/dot_product.rs
+++ b/src/rational/mat_q/vector/dot_product.rs
@@ -40,7 +40,7 @@ impl MatQ {
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
     /// the given [`MatQ`] instance is not a (row or column) vector.
-    /// - Returns a [`MathError`] of type [`MathError::MismatchingVectorDimensions`] if
+    /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`] if
     /// the given vectors have different lengths.
     pub fn dot_product(&self, other: &Self) -> Result<Q, MathError> {
         if !self.is_vector() {
@@ -61,7 +61,7 @@ impl MatQ {
         let other_entries = other.collect_entries();
 
         if self_entries.len() != other_entries.len() {
-            return Err(MathError::MismatchingVectorDimensions(format!(
+            return Err(MathError::MismatchingMatrixDimension(format!(
                 "You called the function 'dot_product' for vectors of different lengths: {} and {}",
                 self_entries.len(),
                 other_entries.len()

--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -13,7 +13,11 @@
 //! The explicit functions contain the documentation.
 
 use super::PolyOverQ;
-use crate::{error::MathError, integer::PolyOverZ, rational::Q};
+use crate::{
+    error::{MathError, StringConversionError},
+    integer::PolyOverZ,
+    rational::Q,
+};
 use flint_sys::fmpq_poly::{
     fmpq_poly_canonicalise, fmpq_poly_set_fmpq, fmpq_poly_set_fmpz_poly, fmpq_poly_set_str,
 };
@@ -43,16 +47,13 @@ impl FromStr for PolyOverQ {
     /// let poly = PolyOverQ::from_str("5  0 1/3 2/10 -3/2 1").unwrap();
     /// ```
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidStringToPolyInput`](MathError::InvalidStringToPolyInput)
+    /// - Returns a [`MathError`] of type
+    /// [`StringConversionError`](MathError::StringConversionError)
+    /// if the provided string contains a Null Byte,
+    /// if the provided value did not contain two whitespaces, or
     /// if the provided string was not formatted correctly or the number of
     /// coefficients was smaller than the number provided at the start of the
     /// provided string.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToPolyMissingWhitespace`](`MathError::InvalidStringToPolyMissingWhitespace`)
-    /// if the provided value did not contain two whitespaces.
-    /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToCStringInput`](MathError::InvalidStringToCStringInput)
-    /// if the provided string contains a Null Byte.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut res = Self::default();
 
@@ -68,10 +69,12 @@ impl FromStr for PolyOverQ {
                 fmpq_poly_canonicalise(&mut res.poly);
                 Ok(res)
             },
-            _ if !s.contains("  ") => Err(MathError::InvalidStringToPolyMissingWhitespace(
-                s.to_owned(),
+            _ if !s.contains("  ") => Err(MathError::StringConversionError(
+                StringConversionError::InvalidStringToPolyMissingWhitespace(s.to_owned()),
             )),
-            _ => Err(MathError::InvalidStringToPolyInput(s.to_owned())),
+            _ => Err(MathError::StringConversionError(
+                StringConversionError::InvalidStringToPolyInput(s.to_owned()),
+            )),
         }
     }
 }

--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -69,12 +69,12 @@ impl FromStr for PolyOverQ {
                 fmpq_poly_canonicalise(&mut res.poly);
                 Ok(res)
             },
-            _ if !s.contains("  ") => Err(MathError::StringConversionError(
+            _ if !s.contains("  ") => Err(
                 StringConversionError::InvalidStringToPolyMissingWhitespace(s.to_owned()),
-            )),
-            _ => Err(MathError::StringConversionError(
-                StringConversionError::InvalidStringToPolyInput(s.to_owned()),
-            )),
+            )?,
+            _ => Err(StringConversionError::InvalidStringToPolyInput(
+                s.to_owned(),
+            ))?,
         }
     }
 }

--- a/src/rational/q/arithmetic/logarithm.rs
+++ b/src/rational/q/arithmetic/logarithm.rs
@@ -31,11 +31,11 @@ impl Q {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`NotPositiveNumber`](MathError::NotPositiveNumber) if `self` is not
+    /// [`NonPositive`](MathError::NonPositive) if `self` is not
     ///  greater than `0`.
     pub fn ln(&self) -> Result<Self, MathError> {
         if self <= &Q::ZERO {
-            Err(MathError::NotPositiveNumber(self.to_string()))
+            Err(MathError::NonPositive(self.to_string()))
         } else {
             Ok(Q::from(
                 unsafe { fmpz_dlog(&self.value.num) } - unsafe { fmpz_dlog(&self.value.den) },
@@ -66,15 +66,15 @@ impl Q {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidBase`](MathError::InvalidBase)
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
     /// if the `base` is not greater than `1`.
     /// - Returns a [`MathError`] of type
-    /// [`NotPositiveNumber`](MathError::NotPositiveNumber) if `self` is not
+    /// [`NonPositive`](MathError::NonPositive) if `self` is not
     ///  greater than `0`.
     pub fn log(&self, base: impl Into<Z>) -> Result<Q, MathError> {
         let base: Z = base.into();
         if base <= Z::ONE {
-            return Err(MathError::InvalidBase(format!(
+            return Err(MathError::InvalidIntegerInput(format!(
                 "The base must be greater than 1, but the provided is {base}"
             )));
         }

--- a/src/rational/q/arithmetic/root.rs
+++ b/src/rational/q/arithmetic/root.rs
@@ -75,9 +75,9 @@ impl Q {
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::PrecisionNotPositive`]
+    /// - Returns a [`MathError`] of type [`MathError::NonPositive`]
     ///   if the precision is not larger than zero.
-    /// - Returns a [`MathError`] of type [`MathError::NegativeRootParameter`]
+    /// - Returns a [`MathError`] of type [`MathError::NonPositive`]
     ///   if the parameter of the square root is negative.
     pub fn sqrt_precision(&self, precision: &Z) -> Result<Q, MathError> {
         let root_numerator = self.get_numerator().sqrt_precision(precision)?;

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -77,9 +77,7 @@ impl FromStr for Q {
     /// if the provided string has `0` as the denominator.
     fn from_str(s: &str) -> Result<Self, MathError> {
         if s.contains(char::is_whitespace) {
-            return Err(MathError::StringConversionError(
-                StringConversionError::InvalidStringToQInput(s.to_owned()),
-            ));
+            return Err(StringConversionError::InvalidStringToQInput(s.to_owned()))?;
         }
 
         // `fmpq::default()` returns the value `0/0`
@@ -96,9 +94,7 @@ impl FromStr for Q {
         // since value is set to `0`, if an error occurs, we do not need to free
         // the allocated space manually
         if -1 == unsafe { fmpq_set_str(&mut value, c_string.as_ptr(), 10) } {
-            return Err(MathError::StringConversionError(
-                StringConversionError::InvalidStringToQInput(s.to_owned()),
-            ));
+            return Err(StringConversionError::InvalidStringToQInput(s.to_owned()))?;
         };
 
         // canonical form is expected by other functions

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -14,7 +14,7 @@
 
 use super::Q;
 use crate::{
-    error::MathError,
+    error::{MathError, StringConversionError},
     integer::Z,
     macros::from::{from_trait, from_type},
     traits::{AsInteger, Pow},
@@ -70,14 +70,16 @@ impl FromStr for Q {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`InvalidStringToQInput`](MathError::InvalidStringToQInput)
+    /// [`StringConversionError`](MathError::StringConversionError)
     /// if the provided string was not formatted correctly.
     /// - Returns a [`MathError`] of type
     /// [`DivisionByZeroError`](MathError::DivisionByZeroError)
     /// if the provided string has `0` as the denominator.
     fn from_str(s: &str) -> Result<Self, MathError> {
         if s.contains(char::is_whitespace) {
-            return Err(MathError::InvalidStringToQInput(s.to_owned()));
+            return Err(MathError::StringConversionError(
+                StringConversionError::InvalidStringToQInput(s.to_owned()),
+            ));
         }
 
         // `fmpq::default()` returns the value `0/0`
@@ -94,7 +96,9 @@ impl FromStr for Q {
         // since value is set to `0`, if an error occurs, we do not need to free
         // the allocated space manually
         if -1 == unsafe { fmpq_set_str(&mut value, c_string.as_ptr(), 10) } {
-            return Err(MathError::InvalidStringToQInput(s.to_owned()));
+            return Err(MathError::StringConversionError(
+                StringConversionError::InvalidStringToQInput(s.to_owned()),
+            ));
         };
 
         // canonical form is expected by other functions

--- a/src/utils/dimensions.rs
+++ b/src/utils/dimensions.rs
@@ -30,11 +30,9 @@ pub(crate) fn find_matrix_dimensions<T>(matrix: &Vec<Vec<T>>) -> Result<(i64, i6
     let num_rows: i64 = match num_rows.try_into() {
         Ok(num_rows) => num_rows,
         _ => {
-            return Err(MathError::StringConversionError(
-                StringConversionError::InvalidMatrix(
-                    "Number of rows is too large (must fit into [`i64`]).".to_owned(),
-                ),
-            ))
+            return Err(StringConversionError::InvalidMatrix(
+                "Number of rows is too large (must fit into [`i64`]).".to_owned(),
+            ))?
         }
     };
 
@@ -43,20 +41,16 @@ pub(crate) fn find_matrix_dimensions<T>(matrix: &Vec<Vec<T>>) -> Result<(i64, i6
         if num_cols == 0 {
             num_cols = row.len();
         } else if num_cols != row.len() {
-            return Err(MathError::StringConversionError(
-                StringConversionError::InvalidMatrix(
-                    "Number of entries in rows is unequal.".to_owned(),
-                ),
-            ));
+            return Err(StringConversionError::InvalidMatrix(
+                "Number of entries in rows is unequal.".to_owned(),
+            ))?;
         }
     }
     match num_cols.try_into() {
         Ok(num_cols) => Ok((num_rows, num_cols)),
-        _ => Err(MathError::StringConversionError(
-            StringConversionError::InvalidMatrix(
-                "Number of columns is too large (must fit into [`i64`]).".to_owned(),
-            ),
-        )),
+        _ => Err(StringConversionError::InvalidMatrix(
+            "Number of columns is too large (must fit into [`i64`]).".to_owned(),
+        ))?,
     }
 }
 

--- a/src/utils/dimensions.rs
+++ b/src/utils/dimensions.rs
@@ -8,7 +8,7 @@
 
 //! Implements methods for finding matrix dimensions and enums for detecting vector directions.
 
-use crate::error::MathError;
+use crate::error::{MathError, StringConversionError};
 
 /// Returns the dimensions of a matrix.
 /// Takes `[[1, 2, 3],[4, 5, 6]]` as input and outputs `(2, 3)` accordingly.
@@ -20,7 +20,7 @@ use crate::error::MathError;
 /// (must fit into [`i64`]) or if the number of entries in rows is unequal.
 ///
 /// # Errors and Failures
-/// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+/// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
 /// if the number of rows or columns is too large (must fit into [`i64`]) or
 /// if the number of entries in rows is unequal.
 #[allow(dead_code)]
@@ -30,8 +30,10 @@ pub(crate) fn find_matrix_dimensions<T>(matrix: &Vec<Vec<T>>) -> Result<(i64, i6
     let num_rows: i64 = match num_rows.try_into() {
         Ok(num_rows) => num_rows,
         _ => {
-            return Err(MathError::InvalidMatrix(
-                "Number of rows is too large (must fit into [`i64`]).".to_owned(),
+            return Err(MathError::StringConversionError(
+                StringConversionError::InvalidMatrix(
+                    "Number of rows is too large (must fit into [`i64`]).".to_owned(),
+                ),
             ))
         }
     };
@@ -41,15 +43,19 @@ pub(crate) fn find_matrix_dimensions<T>(matrix: &Vec<Vec<T>>) -> Result<(i64, i6
         if num_cols == 0 {
             num_cols = row.len();
         } else if num_cols != row.len() {
-            return Err(MathError::InvalidMatrix(
-                "Number of entries in rows is unequal.".to_owned(),
+            return Err(MathError::StringConversionError(
+                StringConversionError::InvalidMatrix(
+                    "Number of entries in rows is unequal.".to_owned(),
+                ),
             ));
         }
     }
     match num_cols.try_into() {
         Ok(num_cols) => Ok((num_rows, num_cols)),
-        _ => Err(MathError::InvalidMatrix(
-            "Number of columns is too large (must fit into [`i64`]).".to_owned(),
+        _ => Err(MathError::StringConversionError(
+            StringConversionError::InvalidMatrix(
+                "Number of columns is too large (must fit into [`i64`]).".to_owned(),
+            ),
         )),
     }
 }

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -9,7 +9,7 @@
 //! Implements methods to parse a [`String`] e.g. matrix strings.
 
 use crate::{
-    error::MathError,
+    error::{MathError, StringConversionError},
     traits::{GetEntry, GetNumColumns, GetNumRows},
 };
 use regex::Regex;
@@ -29,7 +29,7 @@ use string_builder::Builder;
 /// stored as strings or an error, if the matrix is not formatted correctly.
 ///
 /// # Errors and Failures
-/// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+/// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
 /// if the matrix is not formatted in a suitable way.
 pub(crate) fn parse_matrix_string(string: &str) -> Result<Vec<Vec<String>>, MathError> {
     // check if the matrix format is correct
@@ -45,8 +45,10 @@ pub(crate) fn parse_matrix_string(string: &str) -> Result<Vec<Vec<String>>, Math
     // we differ between the first/several and the last entry in each row (as there is no comma after the last entry)
     // each entry can contain any symbol but `[`, `]` and `,`. It needs to have at least one symbol.
     if !regex.is_match(string) {
-        return Err(MathError::InvalidMatrix(
-            "The matrix is not formatted in a suitable way.".to_owned(),
+        return Err(MathError::StringConversionError(
+            StringConversionError::InvalidMatrix(
+                "The matrix is not formatted in a suitable way.".to_owned(),
+            ),
         ));
     }
 

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -45,11 +45,9 @@ pub(crate) fn parse_matrix_string(string: &str) -> Result<Vec<Vec<String>>, Math
     // we differ between the first/several and the last entry in each row (as there is no comma after the last entry)
     // each entry can contain any symbol but `[`, `]` and `,`. It needs to have at least one symbol.
     if !regex.is_match(string) {
-        return Err(MathError::StringConversionError(
-            StringConversionError::InvalidMatrix(
-                "The matrix is not formatted in a suitable way.".to_owned(),
-            ),
-        ));
+        return Err(StringConversionError::InvalidMatrix(
+            "The matrix is not formatted in a suitable way.".to_owned(),
+        ))?;
     }
 
     // delete `[[` in front and `]]` in the end and split the matrix into rows

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -18,7 +18,7 @@
 
 use super::uniform::sample_uniform_rejection;
 use crate::{
-    error::MathError,
+    error::{MathError, StringConversionError},
     integer::{MatZ, Z},
     rational::{MatQ, Q},
     traits::{GetNumColumns, GetNumRows, Pow},
@@ -154,7 +154,7 @@ fn gaussian_function(x: &Z, c: &Q, s: &Q) -> Q {
 /// if the `n <= 1` or `s <= 0`.
 /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
 /// if the number of rows of the `basis` and `center` differ.
-/// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+/// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
 /// if `center` is not a column vector.
 pub(crate) fn sample_d(basis: &MatZ, n: &Z, center: &MatQ, s: &Q) -> Result<MatZ, MathError> {
     let basis_gso = MatQ::from(basis).gso();
@@ -197,7 +197,7 @@ pub(crate) fn sample_d(basis: &MatZ, n: &Z, center: &MatQ, s: &Q) -> Result<MatZ
 /// if the `n <= 1` or `s <= 0`.
 /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
 /// if the number of rows of the `basis` and `center` differ.
-/// - Returns a [`MathError`] of type [`InvalidMatrix`](MathError::InvalidMatrix)
+/// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
 /// if `center` is not a column vector.
 ///
 /// # Panics...
@@ -230,11 +230,13 @@ pub(crate) fn sample_d_precomputed_gso(
         ));
     }
     if !center.is_column_vector() {
-        return Err(MathError::InvalidMatrix(format!(
-            "sample_d expects center to be a column vector, but it has dimensions {}x{}.",
-            center.get_num_rows(),
-            center.get_num_columns()
-        )));
+        return Err(MathError::StringConversionError(
+            StringConversionError::InvalidMatrix(format!(
+                "sample_d expects center to be a column vector, but it has dimensions {}x{}.",
+                center.get_num_rows(),
+                center.get_num_columns()
+            )),
+        ));
     }
     if s < &Q::ZERO {
         return Err(MathError::InvalidIntegerInput(format!(

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -230,13 +230,11 @@ pub(crate) fn sample_d_precomputed_gso(
         ));
     }
     if !center.is_column_vector() {
-        return Err(MathError::StringConversionError(
-            StringConversionError::InvalidMatrix(format!(
-                "sample_d expects center to be a column vector, but it has dimensions {}x{}.",
-                center.get_num_rows(),
-                center.get_num_columns()
-            )),
-        ));
+        return Err(StringConversionError::InvalidMatrix(format!(
+            "sample_d expects center to be a column vector, but it has dimensions {}x{}.",
+            center.get_num_rows(),
+            center.get_num_columns()
+        )))?;
     }
     if s < &Q::ZERO {
         return Err(MathError::InvalidIntegerInput(format!(


### PR DESCRIPTION
**Description**
The `error` module was refactored in this PR.
The main steps taken are:
- [x] giving `InputStringTo...` a new error enum, which itself can be converted to a MathError
- [x] generalising several few used error types s.t. some of them could be completely removed, while some of them were renamed and converted to a generalized version
- [x] an introduction on how to add errors and what to look out for was given in the module description
- [x] overall revised according our guidelines for doc comments and comments further in the error module

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide