### PR TITLE
Patch Clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 string-builder = "0.2.0"
 thiserror = "1.0"
 lazy_static = "1.4"
-derive_more = "0.99.17"
+derive_more = { version = "1", features = ["display"] }
 
 [profile.bench]
 debug = true

--- a/benches/classic_crypto.rs
+++ b/benches/classic_crypto.rs
@@ -81,11 +81,11 @@ mod rsa_textbook {
     ///
     /// The following steps are made:
     /// 1. Generate two unequal primes `p` and `q` roughly of bit size `security_lvl / 2`
-    /// (s.t. `N` is roughly of bit size `security_lvl`).
+    ///     (s.t. `N` is roughly of bit size `security_lvl`).
     /// 2. Compute `N = p * q`.
     /// 3. Compute Euler's Phi function `phi(N) = (p-1) * (q-1)`.
     /// 4. Choose `pk = 65537 = 0x10000000000000001` statically as public key (common as `enc` is very
-    /// efficient with this key, has sufficient size, and guarantees to have an inverse).
+    ///    efficient with this key, has sufficient size, and guarantees to have an inverse).
     /// 5. Calculate `sk = pk^(-1) mod phi(N)`.
     /// 6. Output `(N, pk, sk)`.
     pub fn gen(security_lvl: u32) -> (Modulus, Z, Z) {
@@ -139,7 +139,7 @@ mod rsa_textbook {
     /// Run textbook RSA encryption with 1024 bit security.
     /// 1. get (N, pk, sk) from a previously generated key pair with `gen(1024)`
     /// 2. run cycle of `dec(sk, enc(pk, msg)) == msg`,
-    /// where `msg` is sampled uniformly at random in `[0, u64::MAX)`
+    ///     where `msg` is sampled uniformly at random in `[0, u64::MAX)`
     pub fn rsa_run_enc_dec() {
         let (modulus, pk, sk) = static_gen();
         let msg = Z::sample_uniform(0, u64::MAX).unwrap();
@@ -197,7 +197,7 @@ mod dh_ke {
     /// Run a Diffie-Hellman key exchange with precomputed public parameters with 1024 bit security.
     /// 1. get (p, g) from previously generated public parameters
     /// 2. run one cycle of `gen_key_pair` and `combine_to_shared_sk` on each end (2 times),
-    /// i.e. one key exchange at both ends and compare the computed shared secrets
+    ///     i.e. one key exchange at both ends and compare the computed shared secrets
     pub fn dh_run() {
         let (modulus, generator) = static_gen_pp();
 
@@ -246,7 +246,7 @@ mod el_gamal_enc {
     /// Encrypts a message `m` according to ElGamal's encryption scheme by outputting
     /// `(c_0, c_1) = (g^r, pk^r * m) mod p`
     pub fn enc(generator: &Zq, pk: &Zq, msg: &Zq) -> (Zq, Zq) {
-        let r = Z::sample_uniform(0, &generator.get_mod()).unwrap();
+        let r = Z::sample_uniform(0, generator.get_mod()).unwrap();
         let c_0 = generator.pow(&r).unwrap();
         let c_1 = pk.pow(&r).unwrap() * msg;
         (c_0, c_1)

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,19 +15,19 @@
 //!
 //! **For developers:**
 //! - How to add an error to an `enum`? First of all, find a name
-//! that is not too specific for your current case s.t. it could be used in other
-//! contexts afterwards as well. Then, find the spot according to your chosen error
-//! name in a alphanumerically sorted way in the list of supported errors in the doc
-//! comment and inside the `enum` itself.
-//! Afterwards, add the error to the list of implemented error
-//! types in the doc comment of the `enum` with a short description when it is thrown.
-//! Probably use this description for the doc comment above the implementation of
-//! error in the `enum`. Then, add `#[error(<error msg>)]` to define the error message
-//! output once your error is thrown. Below, write down `<error name>(<input>),` to
-//! define the error with its name and possibly several inputs. The input can be of the
-//! form [`String`], but also another error, whose conversion must be declared via
-//! `#[from] OtherError`. It is best to use the existing structure as a guide. For any
-//! further information, check out the here used [`thiserror`]-crate.
+//!     that is not too specific for your current case s.t. it could be used in other
+//!     contexts afterwards as well. Then, find the spot according to your chosen error
+//!     name in a alphanumerically sorted way in the list of supported errors in the doc
+//!     comment and inside the `enum` itself.
+//!     Afterwards, add the error to the list of implemented error
+//!     types in the doc comment of the `enum` with a short description when it is thrown.
+//!     Probably use this description for the doc comment above the implementation of
+//!     error in the `enum`. Then, add `#[error(<error msg>)]` to define the error message
+//!     output once your error is thrown. Below, write down `<error name>(<input>),` to
+//!     define the error with its name and possibly some inputs. The input can be of the
+//!     form [`String`], but also another error, whose conversion must be declared via
+//!     `#[from] OtherError`. It is best to use the existing structure as a guide. For any
+//!     further information, check out the here used [`thiserror`]-crate.
 
 use std::ffi::NulError;
 use thiserror::Error;
@@ -37,35 +37,35 @@ use thiserror::Error;
 ///
 /// Implemented error types:
 /// -  [`ConversionError`](MathError::ConversionError) is thrown if a conversion
-/// between types is not possible.
+///     between types is not possible.
 /// - [`DivisionByZeroError`](MathError::DivisionByZeroError) is thrown if it is
-/// tried to perform a division by `0`.
+///     tried to perform a division by `0`.
 /// - [`InvalidExponent`](MathError::InvalidExponent) is thrown if an invalid
-/// exponent is used for a `pow` function.
+///     exponent is used for a `pow` function.
 /// - [`InvalidIntegerInput`](MathError::InvalidIntegerInput) is thrown if an
-/// integer input is provided as parameter that does not meet the conditions
-/// of that function.
+///     integer input is provided as parameter that does not meet the conditions
+///     of that function.
 /// - [`InvalidInterval`](MathError::InvalidInterval) is thrown if an invalid
-/// interval, e.g. of negative size, is provided.
+///     interval, e.g. of negative size, is provided.
 /// - [`InvalidModulus`](MathError::InvalidModulus) is thrown if an integer is
-/// provided, which is not greater than `1`.
+///     provided, which is not greater than `1`.
 /// - [`NulError`](MathError::NulError) is thrown if a [`NulError`] is thrown,
-/// which currently only happens if an invalid string is given to construct
-/// a [`CString`](std::ffi::CString).
+///     which currently only happens if an invalid string is given to construct
+///     a [`CString`](std::ffi::CString).
 /// - [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension) is
-/// thrown if arithmetic is done with matrices of mismatching dimensions.
+///     thrown if arithmetic is done with matrices of mismatching dimensions.
 /// - [`MismatchingModulus`](MathError::MismatchingModulus) is thrown if any
-/// function is called on two objects with different modulus where equal
-/// modulus is required.
+///     function is called on two objects with different modulus where equal
+///     modulus is required.
 /// - [`NonPositive`](MathError::NonPositive) is thrown if the function expects
-/// a positive number, but a number smaller than `1` is provided.
+///     a positive number, but a number smaller than `1` is provided.
 /// - [`NoSquareMatrix`](MathError::NoSquareMatrix) is thrown if a matrix is
-/// not square.
+///     not square.
 /// - [`OutOfBounds`](MathError::OutOfBounds) is thrown if a provided index
-/// is not in a desired range.
+///     is not in a desired range.
 /// - [`VectorFunctionCalledOnNonVector`](MathError::VectorFunctionCalledOnNonVector)
-/// is thrown if a function defined on vectors was called on a matrix instance
-/// that is not a vector.
+///     is thrown if a function defined on vectors was called on a matrix instance
+///     that is not a vector.
 ///
 /// # Examples
 /// ```
@@ -155,22 +155,22 @@ pub enum MathError {
 ///
 /// Implemented error types:
 /// - [`InvalidMatrix`](StringConversionError::InvalidMatrix) is thrown if an
-/// invalid string input of a matrix is given.
+///     invalid string input of a matrix is given.
 /// - [`InvalidStringToPolyInput`](StringConversionError::InvalidStringToPolyInput)
-/// is thrown if an invalid string is given to construct a polynomial.
+///     is thrown if an invalid string is given to construct a polynomial.
 /// - [`InvalidStringToPolyMissingWhitespace`](StringConversionError::InvalidStringToPolyMissingWhitespace)
-/// is thrown if an invalid string is given to construct a polynomial which
-/// did not contain two whitespaces.
+///     is thrown if an invalid string is given to construct a polynomial which
+///     did not contain two whitespaces.
 /// - [`InvalidStringToPolyModulusInput`](StringConversionError::InvalidStringToPolyModulusInput)
-/// is thrown if an invalid string is given
-/// to construct a [`PolyOverZq`](crate::integer_mod_q::PolyOverZq), i.e. it is
-/// not formatted correctly.
+///     is thrown if an invalid string is given
+///     to construct a [`PolyOverZq`](crate::integer_mod_q::PolyOverZq), i.e. it is
+///     not formatted correctly.
 /// - [`InvalidStringToQInput`](StringConversionError::InvalidStringToQInput)
-/// is thrown if an invalid string is given to construct a [`Q`](crate::rational::Q).
+///     is thrown if an invalid string is given to construct a [`Q`](crate::rational::Q).
 /// - [`InvalidStringToZInput`](StringConversionError::InvalidStringToZInput)
-/// is thrown if an invalid string is given to construct a [`Z`](crate::integer::Z).
+///     is thrown if an invalid string is given to construct a [`Z`](crate::integer::Z).
 /// - [`InvalidStringToZqInput`](StringConversionError::InvalidStringToZqInput)
-/// is thrown if an invalid string is given to construct a [`Zq`](crate::integer_mod_q::Zq).
+///     is thrown if an invalid string is given to construct a [`Zq`](crate::integer_mod_q::Zq).
 ///
 /// # Examples
 /// ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ use thiserror::Error;
 /// errors occurring in this crate.
 ///
 /// Implemented error types:
-/// -  [`ConversionError`](MathError::ConversionError) is thrown if a conversion
+/// - [`ConversionError`](MathError::ConversionError) is thrown if a conversion
 ///     between types is not possible.
 /// - [`DivisionByZeroError`](MathError::DivisionByZeroError) is thrown if it is
 ///     tried to perform a division by `0`.

--- a/src/integer/mat_poly_over_z/arithmetic/mul.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/mul.rs
@@ -72,8 +72,8 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
-    ///  and `other` do not match for multiplication.
+    ///     [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
+    ///     and `other` do not match for multiplication.
     pub fn mul_safe(&self, other: &Self) -> Result<Self, MathError> {
         if self.get_num_columns() != other.get_num_rows() {
             return Err(MathError::MismatchingMatrixDimension(format!(

--- a/src/integer/mat_poly_over_z/coefficient_embedding.rs
+++ b/src/integer/mat_poly_over_z/coefficient_embedding.rs
@@ -27,7 +27,7 @@ impl MatPolyOverZ {
     ///
     /// Parameters:
     /// - `size`: determines the number of rows each polynomial is embedded in.
-    /// It has to be larger than the degree of all polynomials.
+    ///     It has to be larger than the degree of all polynomials.
     ///
     /// Returns a coefficient embedding as a matrix if `size` is large enough.
     ///
@@ -46,7 +46,7 @@ impl MatPolyOverZ {
     ///
     /// # Panics ...
     /// - if `size` is not larger than the degree of the polynomial, i.e.
-    /// not all coefficients can be embedded.
+    ///     not all coefficients can be embedded.
     pub fn into_coefficient_embedding_from_matrix(&self, size: impl Into<i64>) -> MatZ {
         let size = size.into();
         let mut embedded = self.get_row(0).unwrap().into_coefficient_embedding(size);
@@ -123,7 +123,7 @@ impl IntoCoefficientEmbedding<MatZ> for &MatPolyOverZ {
     ///
     /// Parameters:
     /// - `size`: determines the number of rows of the embedding. It has to be larger
-    /// than the degree of the polynomial.
+    ///     than the degree of the polynomial.
     ///
     /// Returns a coefficient embedding as a matrix if `size` is large enough.
     ///
@@ -143,7 +143,7 @@ impl IntoCoefficientEmbedding<MatZ> for &MatPolyOverZ {
     ///
     /// # Panics ...
     /// - if `size` is not larger than the degree of the polynomial, i.e.
-    /// not all coefficients can be embedded.
+    ///     not all coefficients can be embedded.
     /// - if `self` is not a row vector
     fn into_coefficient_embedding(self, size: impl Into<i64>) -> MatZ {
         assert!(self.is_row_vector());

--- a/src/integer/mat_poly_over_z/concat.rs
+++ b/src/integer/mat_poly_over_z/concat.rs
@@ -39,8 +39,8 @@ impl Concatenate for &MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the matrices can not be concatenated due to mismatching dimensions.
+    ///     [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    ///     if the matrices can not be concatenated due to mismatching dimensions.
     fn concat_vertical(self, other: Self) -> Result<Self::Output, crate::error::MathError> {
         if self.get_num_columns() != other.get_num_columns() {
             return Err(MathError::MismatchingMatrixDimension(format!(
@@ -82,8 +82,8 @@ impl Concatenate for &MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the matrices can not be concatenated due to mismatching dimensions.
+    ///     [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    ///     if the matrices can not be concatenated due to mismatching dimensions.
     fn concat_horizontal(self, other: Self) -> Result<Self::Output, crate::error::MathError> {
         if self.get_num_rows() != other.get_num_rows() {
             return Err(MathError::MismatchingMatrixDimension(format!(

--- a/src/integer/mat_poly_over_z/default.rs
+++ b/src/integer/mat_poly_over_z/default.rs
@@ -74,7 +74,7 @@ impl MatPolyOverZ {
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatPolyOverZ::new`].
+    ///     For further information see [`MatPolyOverZ::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -65,14 +65,14 @@ impl FromStr for MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::StringConversionError`],
-    /// if the entries are not formatted correctly,
-    /// if the matrix is not formatted in a suitable way, or
-    /// if the number of entries in rows is unequal.
-    /// For further details see [`PolyOverZ::from_str`].
+    ///     - if the entries are not formatted correctly,
+    ///     - if the matrix is not formatted in a suitable way, or
+    ///     - if the number of entries in rows is unequal.
+    ///       For further details see [`PolyOverZ::from_str`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatPolyOverZ::new`].
+    ///     For further information see [`MatPolyOverZ::new`].
     fn from_str(string: &str) -> Result<Self, MathError> {
         let string_matrix = parse_matrix_string(string)?;
         let (num_rows, num_cols) = find_matrix_dimensions(&string_matrix)?;

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -68,7 +68,7 @@ impl FromStr for MatPolyOverZ {
     ///     - if the entries are not formatted correctly,
     ///     - if the matrix is not formatted in a suitable way, or
     ///     - if the number of entries in rows is unequal.
-    ///       For further details see [`PolyOverZ::from_str`].
+    ///     - For further details see [`PolyOverZ::from_str`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -84,7 +84,7 @@ impl GetEntry<PolyOverZ> for MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -128,7 +128,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the row is greater than the matrix or negative.
+    ///     if the number of the row is greater than the matrix or negative.
     pub fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let row_i64 = evaluate_index(row)?;
 
@@ -164,7 +164,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the column is greater than the matrix or negative.
+    ///     if the number of the column is greater than the matrix or negative.
     pub fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let column_i64 = evaluate_index(column)?;
 
@@ -212,7 +212,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if any provided row or column is greater than the matrix.
+    ///     if any provided row or column is greater than the matrix.
     ///
     /// # Panics ...
     /// - if `col_1 > col_2` or `row_1 > row_2`.

--- a/src/integer/mat_poly_over_z/sample/binomial.rs
+++ b/src/integer/mat_poly_over_z/sample/binomial.rs
@@ -26,7 +26,7 @@ impl MatPolyOverZ {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `max_degree`: specifies the maximum length of all polynomials in the matrix,
-    /// i.e. the maximum number of coefficients any polynomial in the matrix can have
+    ///     i.e. the maximum number of coefficients any polynomial in the matrix can have
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
@@ -44,13 +44,13 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1` or `p ∉ (0,1)`.
+    ///     if `n < 1` or `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatPolyOverZ::new`].
+    ///     For further information see [`MatPolyOverZ::new`].
     pub fn sample_binomial(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
@@ -68,9 +68,9 @@ impl MatPolyOverZ {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `max_degree`: specifies the maximum length of all polynomials in the matrix,
-    /// i.e. the maximum number of coefficients any polynomial in the matrix can have
+    ///     i.e. the maximum number of coefficients any polynomial in the matrix can have
     /// - `offset`: specifies an offset applied to each sample
-    /// collected from the binomial distribution
+    ///     collected from the binomial distribution
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
@@ -88,15 +88,15 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1` or `p ∉ (0,1)`.
+    ///     if `n < 1` or `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// the `max_degree` is negative or it does not fit into an [`i64`].
+    ///     the `max_degree` is negative or it does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatPolyOverZ::new`].
+    ///     For further information see [`MatPolyOverZ::new`].
     pub fn sample_binomial_with_offset(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
@@ -27,7 +27,7 @@ impl MatPolyOverZ {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///   to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a vector of polynomials sampled according to the
     /// discrete Gaussian distribution.
@@ -49,15 +49,15 @@ impl MatPolyOverZ {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`VectorFunctionCalledOnNonVector`](MathError::VectorFunctionCalledOnNonVector), if the basis is not a row vector
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `n <= 1` or `s <= 0`.
+    ///     if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of the `basis` and `center` differ.
+    ///     if the number of rows of the `basis` and `center` differ.
     ///
     /// This function implements SampleD according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-    /// Trapdoors for hard lattices and new cryptographic constructions.
-    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    ///     Trapdoors for hard lattices and new cryptographic constructions.
+    ///     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    ///     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
     ///
     /// # Panics ...
     /// - if the polynomials have higher length than the provided upper bound `k`

--- a/src/integer/mat_poly_over_z/sample/uniform.rs
+++ b/src/integer/mat_poly_over_z/sample/uniform.rs
@@ -28,11 +28,11 @@ impl MatPolyOverZ {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `max_degree`: specifies the maximum length of all polynomials in the matrix,
-    /// i.e. the maximum number of coefficients any polynomial in the matrix can have
+    ///     i.e. the maximum number of coefficients any polynomial in the matrix can have
     /// - `lower_bound`: specifies the included lower bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     /// - `upper_bound`: specifies the excluded upper bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     ///
     /// Returns a new [`MatPolyOverZ`] instance with polynomials as entries,
     /// whose coefficients were chosen uniformly at random in
@@ -49,14 +49,14 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    /// i.e. the interval size is at most `1`.
+    ///     if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
+    ///     i.e. the interval size is at most `1`.
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// the `max_degree` is negative or it does not fit into an [`i64`].
+    ///     the `max_degree` is negative or it does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatPolyOverZ::new`].
+    ///     For further information see [`MatPolyOverZ::new`].
     pub fn sample_uniform(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer/mat_poly_over_z/set.rs
+++ b/src/integer/mat_poly_over_z/set.rs
@@ -56,7 +56,7 @@ impl SetEntry<&PolyOverZ> for MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,
@@ -87,7 +87,7 @@ impl MatPolyOverZ {
     /// - `col_0`: specifies the column of `self` that should be modified
     /// - `other`: specifies the matrix providing the column replacing the column in `self`
     /// - `col_1`: specifies the column of `other` providing
-    /// the values replacing the original column in `self`
+    ///     the values replacing the original column in `self`
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if one of the specified columns is not part of its matrix
@@ -105,9 +105,9 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of columns is greater than the matrix dimensions or negative.
+    ///     if the number of columns is greater than the matrix dimensions or negative.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of `self` and `other` differ.
+    ///     if the number of rows of `self` and `other` differ.
     pub fn set_column(
         &mut self,
         col_0: impl TryInto<i64> + Display,
@@ -145,7 +145,7 @@ impl MatPolyOverZ {
     /// - `row_0`: specifies the row of `self` that should be modified
     /// - `other`: specifies the matrix providing the row replacing the row in `self`
     /// - `row_1`: specifies the row of `other` providing
-    /// the values replacing the original row in `self`
+    ///     the values replacing the original row in `self`
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if one of the specified rows is not part of its matrix
@@ -163,9 +163,9 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows is greater than the matrix dimensions or negative.
+    ///     if the number of rows is greater than the matrix dimensions or negative.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of columns of `self` and `other` differ.
+    ///     if the number of columns of `self` and `other` differ.
     pub fn set_row(
         &mut self,
         row_0: impl TryInto<i64> + Display,
@@ -221,7 +221,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if row or column are greater than the matrix size.
+    ///     if row or column are greater than the matrix size.
     pub fn swap_entries(
         &mut self,
         row_0: impl TryInto<i64> + Display,
@@ -260,7 +260,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if one of the given columns is greater than the matrix or negative.
+    ///     if one of the given columns is greater than the matrix or negative.
     pub fn swap_columns(
         &mut self,
         col_0: impl TryInto<i64> + Display,
@@ -307,7 +307,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if one of the given rows is greater than the matrix or negative.
+    ///     if one of the given rows is greater than the matrix or negative.
     pub fn swap_rows(
         &mut self,
         row_0: impl TryInto<i64> + Display,

--- a/src/integer/mat_poly_over_z/tensor.rs
+++ b/src/integer/mat_poly_over_z/tensor.rs
@@ -71,9 +71,9 @@ impl Tensor for MatPolyOverZ {
 /// - `row_left`: defines the leftmost row of the set window
 /// - `column_upper`: defines the highest column of the set window
 /// - `scalar`: defines the value with which the part of the tensor product
-/// is calculated
+///     is calculated
 /// - `matrix`: the matrix with which the scalar is multiplied
-/// before setting the entries in `out`
+///     before setting the entries in `out`
 ///
 /// Implicitly sets the entries of the matrix according to the definition
 /// of the tensor product.

--- a/src/integer/mat_poly_over_z/vector/dot_product.rs
+++ b/src/integer/mat_poly_over_z/vector/dot_product.rs
@@ -37,9 +37,9 @@ impl MatPolyOverZ {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatPolyOverZ`] instance is not a (row or column) vector.
+    ///     the given [`MatPolyOverZ`] instance is not a (row or column) vector.
     /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`] if
-    /// the given vectors have different lengths.
+    ///     the given vectors have different lengths.
     pub fn dot_product(&self, other: &Self) -> Result<PolyOverZ, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(

--- a/src/integer/mat_z/arithmetic/div.rs
+++ b/src/integer/mat_z/arithmetic/div.rs
@@ -140,6 +140,7 @@ mod test_div_exact {
 
     /// Tests that division is available for other types.
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn availability() {
         let mat = MatZ::from_str("[[6, 3],[3, 6]]").unwrap();
 

--- a/src/integer/mat_z/arithmetic/mul.rs
+++ b/src/integer/mat_z/arithmetic/mul.rs
@@ -71,8 +71,8 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
-    ///  and `other` do not match for multiplication.
+    ///     [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
+    ///     and `other` do not match for multiplication.
     pub fn mul_safe(&self, other: &Self) -> Result<Self, MathError> {
         if self.get_num_columns() != other.get_num_rows() {
             return Err(MathError::MismatchingMatrixDimension(format!(

--- a/src/integer/mat_z/default.rs
+++ b/src/integer/mat_z/default.rs
@@ -74,7 +74,7 @@ impl MatZ {
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatZ::new`].
+    ///     For further information see [`MatZ::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer/mat_z/determinant.rs
+++ b/src/integer/mat_z/determinant.rs
@@ -30,7 +30,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows and columns is not equal.
+    ///     if the number of rows and columns is not equal.
     pub fn det(&self) -> Result<Z, MathError> {
         if self.get_num_rows() != self.get_num_columns() {
             return Err(MathError::MismatchingMatrixDimension(

--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -79,14 +79,14 @@ impl FromStr for MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-    /// if the matrix is not formatted in a suitable way,
-    /// if the number of entries in rows is unequal,
-    /// if an entry contains a Nul byte, or
-    /// if an entry is not formatted correctly.
+    ///     - if the matrix is not formatted in a suitable way,
+    ///     - if the number of entries in rows is unequal,
+    ///     - if an entry contains a Nul byte, or
+    ///     - if an entry is not formatted correctly.
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatZ::new`].
+    ///     For further information see [`MatZ::new`].
     fn from_str(string: &str) -> Result<Self, MathError> {
         let string_matrix = parse_matrix_string(string)?;
         let (num_rows, num_cols) = find_matrix_dimensions(&string_matrix)?;

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -82,7 +82,7 @@ impl GetEntry<Z> for MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -125,7 +125,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the row is greater than the matrix or negative.
+    ///     if the number of the row is greater than the matrix or negative.
     pub fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let row_i64 = evaluate_index(row)?;
 
@@ -162,7 +162,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the column is greater than the matrix or negative.
+    ///     if the number of the column is greater than the matrix or negative.
     pub fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let column_i64 = evaluate_index(column)?;
 
@@ -210,7 +210,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if any provided row or column is greater than the matrix.
+    ///     if any provided row or column is greater than the matrix.
     ///
     /// # Panics ...
     /// - if `col_1 > col_2` or `row_1 > row_2`.

--- a/src/integer/mat_z/sample/binomial.rs
+++ b/src/integer/mat_z/sample/binomial.rs
@@ -42,15 +42,15 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatZ::new`].
+    ///     For further information see [`MatZ::new`].
     pub fn sample_binomial(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
@@ -67,7 +67,7 @@ impl MatZ {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `offset`: specifies an offset applied to each sample
-    /// collected from the binomial distribution
+    ///     collected from the binomial distribution
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
@@ -85,15 +85,15 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatZ::new`].
+    ///     For further information see [`MatZ::new`].
     pub fn sample_binomial_with_offset(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -28,7 +28,7 @@ impl MatZ {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a matrix with each entry sampled independently from the
     /// specified discrete Gaussian distribution.
@@ -42,11 +42,11 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `n <= 1` or `s <= 0`.
+    ///     if the `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatZ::new`].
+    ///     For further information see [`MatZ::new`].
     pub fn sample_discrete_gauss(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,
@@ -79,7 +79,7 @@ impl MatZ {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a lattice vector sampled according to the discrete Gaussian distribution.
     ///
@@ -94,17 +94,17 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `n <= 1` or `s <= 0`.
+    ///     if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of the `basis` and `center` differ.
+    ///     if the number of rows of the `basis` and `center` differ.
     /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-    /// if `center` is not a column vector.
+    ///     if `center` is not a column vector.
     ///
     /// This function implements SampleD according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-    /// Trapdoors for hard lattices and new cryptographic constructions.
-    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    ///     Trapdoors for hard lattices and new cryptographic constructions.
+    ///     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    ///     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
     pub fn sample_d(
         basis: &MatZ,
         n: impl Into<Z>,
@@ -122,17 +122,17 @@ impl MatZ {
     ///
     /// Parameters:
     /// - `dimension`: specifies the number of rows and columns
-    /// that the identity basis should have
+    ///     that the identity basis should have
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a lattice vector sampled according to the discrete Gaussian distribution.
     /// The lattice specified as `Z^m` for `m = dimension` and its center fixed to `0^m`.
     ///
     /// # Panics ...
     /// - if the provided `dimension` is not suited to create a matrix.
-    /// For further information see [`MatZ::new`].
+    ///     For further information see [`MatZ::new`].
     pub fn sample_d_common(
         dimension: impl TryInto<i64> + Display + Clone,
         n: impl Into<Z>,
@@ -156,7 +156,7 @@ impl MatZ {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a lattice vector sampled according to the discrete Gaussian distribution.
     ///
@@ -172,20 +172,20 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `n <= 1` or `s <= 0`.
+    ///     if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of the `basis` and `center` differ.
+    ///     if the number of rows of the `basis` and `center` differ.
     /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-    /// if `center` is not a column vector.
+    ///     if `center` is not a column vector.
     ///
     /// # Panics ...
     /// - if the number of rows/columns of `basis_gso` and `basis` mismatch.
     ///
     /// This function implements SampleD according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-    /// Trapdoors for hard lattices and new cryptographic constructions.
-    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    ///     Trapdoors for hard lattices and new cryptographic constructions.
+    ///     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    ///     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
     pub fn sample_d_precomputed_gso(
         basis: &MatZ,
         basis_gso: &MatQ,

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -28,9 +28,9 @@ impl MatZ {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `lower_bound`: specifies the included lower bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     /// - `upper_bound`: specifies the excluded upper bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     ///
     /// Returns a new [`MatZ`] instance with entries chosen
     /// uniformly at random in `[lower_bound, upper_bound)` or a [`MathError`]
@@ -45,12 +45,12 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    /// i.e. the interval size is at most `1`.
+    ///     if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
+    ///     i.e. the interval size is at most `1`.
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatZ::new`].
+    ///     For further information see [`MatZ::new`].
     pub fn sample_uniform(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer/mat_z/set.rs
+++ b/src/integer/mat_z/set.rs
@@ -59,7 +59,7 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,
@@ -89,7 +89,7 @@ impl MatZ {
     /// - `col_0`: specifies the column of `self` that should be modified
     /// - `other`: specifies the matrix providing the column replacing the column in `self`
     /// - `col_1`: specifies the column of `other` providing
-    /// the values replacing the original column in `self`
+    ///     the values replacing the original column in `self`
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if one of the specified columns is not part of its matrix
@@ -107,9 +107,9 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of columns is greater than the matrix dimensions or negative.
+    ///     if the number of columns is greater than the matrix dimensions or negative.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of `self` and `other` differ.
+    ///     if the number of rows of `self` and `other` differ.
     pub fn set_column(
         &mut self,
         col_0: impl TryInto<i64> + Display,
@@ -147,7 +147,7 @@ impl MatZ {
     /// - `row_0`: specifies the row of `self` that should be modified
     /// - `other`: specifies the matrix providing the row replacing the row in `self`
     /// - `row_1`: specifies the row of `other` providing
-    /// the values replacing the original row in `self`
+    ///     the values replacing the original row in `self`
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if one of the specified rows is not part of its matrix
@@ -165,9 +165,9 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows is greater than the matrix dimensions or negative.
+    ///     if the number of rows is greater than the matrix dimensions or negative.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of columns of `self` and `other` differ.
+    ///     if the number of columns of `self` and `other` differ.
     pub fn set_row(
         &mut self,
         row_0: impl TryInto<i64> + Display,
@@ -223,7 +223,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if row or column are greater than the matrix size.
+    ///     if row or column are greater than the matrix size.
     pub fn swap_entries(
         &mut self,
         row_0: impl TryInto<i64> + Display,
@@ -262,7 +262,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if one of the given columns is greater than the matrix or negative.
+    ///     if one of the given columns is greater than the matrix or negative.
     pub fn swap_columns(
         &mut self,
         col_0: impl TryInto<i64> + Display,
@@ -303,7 +303,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if one of the given rows is greater than the matrix or negative.
+    ///     if one of the given rows is greater than the matrix or negative.
     pub fn swap_rows(
         &mut self,
         row_0: impl TryInto<i64> + Display,

--- a/src/integer/mat_z/sort.rs
+++ b/src/integer/mat_z/sort.rs
@@ -21,7 +21,7 @@ impl MatZ {
     ///
     /// Parameters:
     /// - `cond_func`: computes values implementing [`Ord`] over the columns of the specified matrix.
-    /// These values are then used to re-order / sort the rows of the matrix.
+    ///     These values are then used to re-order / sort the rows of the matrix.
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// A [`MathError`] is returned if the execution of `cond_func` returned an error.
@@ -87,7 +87,7 @@ impl MatZ {
     ///
     /// Parameters:
     /// - `cond_func`: computes values implementing [`Ord`] over the columns of the specified matrix.
-    /// These values are then used to re-order / sort the columns of the matrix.
+    ///     These values are then used to re-order / sort the columns of the matrix.
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// A [`MathError`] is returned if the execution of `cond_func` returned an error.

--- a/src/integer/mat_z/vector/dot_product.rs
+++ b/src/integer/mat_z/vector/dot_product.rs
@@ -40,9 +40,9 @@ impl MatZ {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatZ`] instance is not a (row or column) vector.
+    ///     the given [`MatZ`] instance is not a (row or column) vector.
     /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`] if
-    /// the given vectors have different lengths.
+    ///     the given vectors have different lengths.
     pub fn dot_product(&self, other: &Self) -> Result<Z, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(

--- a/src/integer/mat_z/vector/norm.rs
+++ b/src/integer/mat_z/vector/norm.rs
@@ -35,7 +35,7 @@ impl MatZ {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatZ`] instance is not a (row or column) vector.
+    ///     the given [`MatZ`] instance is not a (row or column) vector.
     pub fn norm_eucl_sqrd(&self) -> Result<Z, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(
@@ -74,7 +74,7 @@ impl MatZ {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatZ`] instance is not a (row or column) vector.
+    ///     the given [`MatZ`] instance is not a (row or column) vector.
     pub fn norm_infty(&self) -> Result<Z, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(

--- a/src/integer/poly_over_z/coefficient_embedding.rs
+++ b/src/integer/poly_over_z/coefficient_embedding.rs
@@ -25,7 +25,7 @@ impl IntoCoefficientEmbedding<MatZ> for &PolyOverZ {
     ///
     /// Parameters:
     /// - `size`: determines the number of rows of the embedding. It has to be larger
-    /// than the degree of the polynomial.
+    ///     than the degree of the polynomial.
     ///
     /// Returns a coefficient embedding as a column vector if `size` is large enough.
     ///
@@ -45,7 +45,7 @@ impl IntoCoefficientEmbedding<MatZ> for &PolyOverZ {
     ///
     /// # Panics ...
     /// - if `size` is not larger than the degree of the polynomial, i.e.
-    /// not all coefficients can be embedded.
+    ///     not all coefficients can be embedded.
     fn into_coefficient_embedding(self, size: impl Into<i64>) -> MatZ {
         let size = size.into();
         let length = self.get_degree() + 1;

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -49,13 +49,13 @@ impl FromStr for PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::StringConversionError`]
-    /// if the provided string was not formatted correctly or the number of
-    /// coefficients was smaller than the number provided at the start of the
-    /// provided string, or
-    /// if the provided value did not contain two whitespaces.
+    ///     if the provided string was not formatted correctly or the number of
+    ///     coefficients was smaller than the number provided at the start of the
+    ///     provided string, or
+    ///     if the provided value did not contain two whitespaces.
     /// - Returns a [`MathError`] of type
-    /// [`StringConversionError`](MathError::StringConversionError)
-    /// if the provided string contains a `Null` Byte.
+    ///     [`StringConversionError`](MathError::StringConversionError)
+    ///     if the provided string contains a `Null` Byte.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // remove whitespaces at the start and at the end
         let s_trimmed = s.trim();

--- a/src/integer/poly_over_z/get.rs
+++ b/src/integer/poly_over_z/get.rs
@@ -43,7 +43,7 @@ impl GetCoefficient<Z> for PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     fn get_coeff(&self, index: impl TryInto<i64> + Display) -> Result<Z, MathError> {
         let mut out = Z::default();
         let index = evaluate_index(index)?;

--- a/src/integer/poly_over_z/sample/binomial.rs
+++ b/src/integer/poly_over_z/sample/binomial.rs
@@ -25,7 +25,7 @@ impl PolyOverZ {
     ///
     /// Parameters:
     /// - `max_degree`: specifies the length of the polynomial,
-    /// i.e. the number of coefficients
+    ///     i.e. the number of coefficients
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
@@ -43,13 +43,13 @@ impl PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// the `max_degree` is negative or it does not fit into an [`i64`].
+    ///     the `max_degree` is negative or it does not fit into an [`i64`].
     pub fn sample_binomial(
         max_degree: impl TryInto<i64> + Display,
         n: impl Into<Z>,
@@ -64,9 +64,9 @@ impl PolyOverZ {
     ///
     /// Parameters:
     /// - `max_degree`: specifies the length of the polynomial,
-    /// i.e. the number of coefficients
+    ///     i.e. the number of coefficients
     /// - `offset`: specifies an offset applied to each sample
-    /// collected from the binomial distribution
+    ///     collected from the binomial distribution
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
@@ -84,13 +84,13 @@ impl PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// the `max_degree` is negative or it does not fit into an [`i64`].
+    ///     the `max_degree` is negative or it does not fit into an [`i64`].
     pub fn sample_binomial_with_offset(
         max_degree: impl TryInto<i64> + Display,
         offset: impl Into<Z>,

--- a/src/integer/poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/poly_over_z/sample/discrete_gauss.rs
@@ -28,7 +28,7 @@ impl PolyOverZ {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a fresh [`PolyOverZ`] instance of maximum degree `max_degree`
     /// with coefficients chosen independently according the discrete Gaussian distribution or
@@ -43,7 +43,7 @@ impl PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n <= 1` or `s <= 0`.
+    ///     if `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if `max_degree` is negative, or does not fit into an [`i64`].

--- a/src/integer/poly_over_z/sample/uniform.rs
+++ b/src/integer/poly_over_z/sample/uniform.rs
@@ -26,11 +26,11 @@ impl PolyOverZ {
     ///
     /// Parameters:
     /// - `max_degree`: specifies the length of the polynomial,
-    /// i.e. the number of coefficients
+    ///     i.e. the number of coefficients
     /// - `lower_bound`: specifies the included lower bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     /// - `upper_bound`: specifies the excluded upper bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     ///
     /// Returns a fresh [`PolyOverZ`] instance of length `max_degree` with coefficients
     /// chosen uniform at random in `[lower_bound, upper_bound)` or a [`MathError`]
@@ -45,10 +45,10 @@ impl PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    /// i.e. the interval size is at most `1`.
+    ///     if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
+    ///     i.e. the interval size is at most `1`.
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// the `max_degree` is negative or it does not fit into an [`i64`].
+    ///     the `max_degree` is negative or it does not fit into an [`i64`].
     pub fn sample_uniform(
         max_degree: impl TryInto<i64> + Display,
         lower_bound: impl Into<Z>,

--- a/src/integer/poly_over_z/set.rs
+++ b/src/integer/poly_over_z/set.rs
@@ -41,7 +41,7 @@ impl<Integer: Into<Z>> SetCoefficient<Integer> for PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     fn set_coeff(
         &mut self,
         index: impl TryInto<i64> + Display,

--- a/src/integer/z/arithmetic/div.rs
+++ b/src/integer/z/arithmetic/div.rs
@@ -175,7 +175,7 @@ mod test_div_floor {
 
     /// Tests that `div_floor` is available for other types.
     #[test]
-    #[allow(clippy::needless_borrow)]
+    #[allow(clippy::needless_borrow, clippy::needless_borrows_for_generic_args)]
     fn availability() {
         let value = Z::from(100);
 
@@ -286,7 +286,7 @@ mod test_div_ceil {
 
     /// Tests that `div_ceil` is available for other types.
     #[test]
-    #[allow(clippy::needless_borrow)]
+    #[allow(clippy::needless_borrow, clippy::needless_borrows_for_generic_args)]
     fn availability() {
         let value = Z::from(100);
 
@@ -360,7 +360,7 @@ mod test_div_exact {
 
     /// Tests that `div_exact` is available for other types.
     #[test]
-    #[allow(clippy::needless_borrow)]
+    #[allow(clippy::needless_borrow, clippy::needless_borrows_for_generic_args)]
     fn availability() {
         let value = Z::from(100);
 

--- a/src/integer/z/arithmetic/exp.rs
+++ b/src/integer/z/arithmetic/exp.rs
@@ -19,7 +19,7 @@ impl Z {
     ///
     /// Parameters:
     /// - `length_taylor_polynomial`: the length of the taylor series
-    /// approximation of the exponential function
+    ///     approximation of the exponential function
     ///
     /// Returns `e^self`.
     ///

--- a/src/integer/z/arithmetic/logarithm.rs
+++ b/src/integer/z/arithmetic/logarithm.rs
@@ -37,8 +37,8 @@ impl Z {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput) if the `base` is not greater than `1`.
     /// - Returns a [`MathError`] of type
-    /// [`NonPositive`](MathError::NonPositive) if `self` is not
-    ///  greater than `0`.
+    ///     [`NonPositive`](MathError::NonPositive) if `self` is not
+    ///     greater than `0`.
     pub fn log_ceil(&self, base: impl Into<Z>) -> Result<Z, MathError> {
         let base: Z = base.into();
         if base <= Z::ONE {
@@ -77,8 +77,8 @@ impl Z {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput) if the `base` is not greater than `1`.
     /// - Returns a [`MathError`] of type
-    /// [`NonPositive`](MathError::NonPositive) if `self` is not
-    ///  greater than `0`.
+    ///     [`NonPositive`](MathError::NonPositive) if `self` is not
+    ///     greater than `0`.
     pub fn log_floor(&self, base: impl Into<Z>) -> Result<Z, MathError> {
         let base: Z = base.into();
         if base <= Z::ONE {
@@ -113,8 +113,8 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`NonPositive`](MathError::NonPositive) if `self` is not
-    ///  greater than `0`.
+    ///     [`NonPositive`](MathError::NonPositive) if `self` is not
+    ///     greater than `0`.
     pub fn ln(&self) -> Result<Q, MathError> {
         if self <= &Z::ZERO {
             Err(MathError::NonPositive(self.to_string()))
@@ -148,10 +148,10 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `base` is not greater than `1`.
+    ///     if the `base` is not greater than `1`.
     /// - Returns a [`MathError`] of type
-    /// [`NonPositive`](MathError::NonPositive) if `self` is not
-    ///  greater than `0`.
+    ///     [`NonPositive`](MathError::NonPositive) if `self` is not
+    ///     greater than `0`.
     pub fn log(&self, base: impl Into<Z>) -> Result<Q, MathError> {
         let base: Z = base.into();
         if base <= Z::ONE {
@@ -169,6 +169,7 @@ impl Z {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_borrows_for_generic_args)]
 mod test_log_ceil {
     use crate::integer::Z;
 
@@ -203,10 +204,7 @@ mod test_log_ceil {
         assert_eq!(Z::from(2), Z::from(3).log_ceil(&base).unwrap());
         assert_eq!(Z::from(2), Z::from(4).log_ceil(&base).unwrap());
         assert_eq!(Z::from(64), Z::from(u64::MAX).log_ceil(&base).unwrap());
-        assert_eq!(
-            Z::from(32),
-            Z::from(u64::MAX).log_ceil(&Z::from(4)).unwrap()
-        );
+        assert_eq!(Z::from(32), Z::from(u64::MAX).log_ceil(Z::from(4)).unwrap());
     }
 
     /// Ensures that `log_ceil` is available for all important types
@@ -239,7 +237,7 @@ mod test_log_floor {
         assert!(value.log_floor(&Z::ZERO).is_err());
         assert!(value.log_floor(&Z::ONE).is_err());
         assert!(value.log_floor(&Z::MINUS_ONE).is_err());
-        assert!(value.log_floor(&Z::from(i64::MIN)).is_err());
+        assert!(value.log_floor(Z::from(i64::MIN)).is_err());
     }
 
     /// Ensure that an error is returned if `self` is too small
@@ -264,7 +262,7 @@ mod test_log_floor {
         assert_eq!(Z::from(63), Z::from(u64::MAX).log_floor(&base).unwrap());
         assert_eq!(
             Z::from(31),
-            Z::from(u64::MAX).log_floor(&Z::from(4)).unwrap()
+            Z::from(u64::MAX).log_floor(Z::from(4)).unwrap()
         );
     }
 
@@ -321,7 +319,7 @@ mod test_log {
         assert!(value.log(&Z::ZERO).is_err());
         assert!(value.log(&Z::ONE).is_err());
         assert!(value.log(&Z::MINUS_ONE).is_err());
-        assert!(value.log(&Z::from(i64::MIN)).is_err());
+        assert!(value.log(Z::from(i64::MIN)).is_err());
     }
 
     /// Ensure that an error is returned if `self` is too small

--- a/src/integer/z/arithmetic/pow.rs
+++ b/src/integer/z/arithmetic/pow.rs
@@ -35,7 +35,7 @@ impl<Integer: Into<Z>> Pow<Integer> for Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidExponent`](MathError::InvalidExponent)
-    /// if the provided exponent is negative and the base value of `self` is not invertible.
+    ///     if the provided exponent is negative and the base value of `self` is not invertible.
     fn pow(&self, exp: Integer) -> Result<Self::Output, MathError> {
         let exp = exp.into();
         let mut out = Z::ZERO;

--- a/src/integer/z/distance.rs
+++ b/src/integer/z/distance.rs
@@ -18,7 +18,7 @@ impl<Integer: Into<Z>> Distance<Integer> for Z {
     ///
     /// Parameters:
     /// - `other`: specifies one of the [`Z`] values whose distance
-    /// is calculated to `self`
+    ///     is calculated to `self`
     ///
     /// Returns the absolute difference, i.e. distance between the two given [`Z`]
     /// instances as a new [`Z`] instance.

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -53,7 +53,7 @@ pub(crate) fn find_max_abs(fmpz_vector: &Vec<fmpz>) -> Z {
 ///
 /// Parameters:
 /// - `other`: specifies the [`fmpz`] value whose distance
-/// is calculated to `self`
+///     is calculated to `self`
 ///
 /// Returns the absolute difference, i.e. distance between the two given [`fmpz`]
 /// instances as a new [`fmpz`] instance.

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -106,11 +106,11 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if the
-    /// base is not between `2` and `62`.
+    ///     base is not between `2` and `62`.
     /// - Returns a [`MathError`] of type
-    /// [`StringConversionError`](MathError::StringConversionError)
-    /// if the provided string contains a Nul byte, or
-    /// if the provided string was not formatted correctly.
+    ///     [`StringConversionError`](MathError::StringConversionError)
+    ///     - if the provided string contains a Nul byte, or
+    ///     - if the provided string was not formatted correctly.
     pub fn from_str_b(s: &str, base: i32) -> Result<Self, MathError> {
         if !(2..=62).contains(&base) {
             return Err(MathError::OutOfBounds(
@@ -142,8 +142,8 @@ impl Z {
     ///
     /// Parameters:
     /// - `bytes`: specifies an iterable of bytes that should be set in the new [`Z`] instance.
-    /// The first byte should be the least significant byte, i.e. its first bit the
-    /// least significant bit.
+    ///     The first byte should be the least significant byte, i.e. its first bit the
+    ///     least significant bit.
     ///
     /// Returns a [`Z`] with the value provided by the byte iterable.
     ///
@@ -175,7 +175,7 @@ impl Z {
     ///
     /// Parameters:
     /// - `bits`: specifies an iterable of bits that should be set in the new [`Z`] instance.
-    /// The first bit should be the least significant bit.
+    ///     The first bit should be the least significant bit.
     ///
     /// Returns a [`Z`] with the value provided by the bit iterable.
     ///
@@ -255,9 +255,9 @@ impl FromStr for Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`StringConversionError`](MathError::StringConversionError)
-    /// if the provided string contains a Nul byte, or
-    /// if the provided string was not formatted correctly.
+    ///     [`StringConversionError`](MathError::StringConversionError)
+    ///     - if the provided string contains a Nul byte, or
+    ///     - if the provided string was not formatted correctly.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Z::from_str_b(s, 10)
     }
@@ -288,7 +288,7 @@ impl TryFrom<&Z> for i64 {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if the value does not fit into an [`i64`]
+    ///     if the value does not fit into an [`i64`]
     fn try_from(value: &Z) -> Result<Self, Self::Error> {
         // fmpz_get_si returns the i64::MAX or respectively i64::MIN
         // if the value is too large/small to fit into an [`i64`].
@@ -330,7 +330,7 @@ impl TryFrom<Z> for i64 {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if the value does not fit into an [`i64`]
+    ///     if the value does not fit into an [`i64`]
     fn try_from(value: Z) -> Result<Self, Self::Error> {
         i64::try_from(&value)
     }

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -687,7 +687,7 @@ mod test_from_fmpz_ref {
 mod test_try_from_into_i64 {
     use crate::integer::Z;
 
-    //// ensure that an error is returned, if the value of the [`Z`]
+    /// ensure that an error is returned, if the value of the [`Z`]
     /// does not fit into an [`i64`]
     #[test]
     fn overflow() {

--- a/src/integer/z/properties.rs
+++ b/src/integer/z/properties.rs
@@ -169,7 +169,7 @@ impl Z {
     ///
     /// Parameters:
     /// - `modulus`: specifies a non-zero integer
-    /// over which the positive remainder is computed
+    ///     over which the positive remainder is computed
     ///
     /// Returns `self` mod `modulus` as a [`Z`] instance.
     ///

--- a/src/integer/z/sample/binomial.rs
+++ b/src/integer/z/sample/binomial.rs
@@ -32,11 +32,11 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     pub fn sample_binomial(n: impl Into<Z>, p: impl Into<Q>) -> Result<Self, MathError> {
         let n: Z = n.into();
         let p: Q = p.into();

--- a/src/integer/z/sample/discrete_gauss.rs
+++ b/src/integer/z/sample/discrete_gauss.rs
@@ -21,7 +21,7 @@ impl Z {
     /// - `n`: specifies the range from which is sampled
     /// - `center`: specifies the position of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns new [`Z`] sample chosen according to the specified discrete Gaussian
     /// distribution or a [`MathError`] if the specified parameters were not chosen
@@ -36,13 +36,13 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `n <= 1` or `s <= 0`.
+    ///     if the `n <= 1` or `s <= 0`.
     ///
     /// This function implements SampleZ according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-    /// Trapdoors for hard lattices and new cryptographic constructions.
-    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    ///     Trapdoors for hard lattices and new cryptographic constructions.
+    ///     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    ///     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
     pub fn sample_discrete_gauss(
         n: impl Into<Z>,
         center: impl Into<Q>,

--- a/src/integer/z/sample/uniform.rs
+++ b/src/integer/z/sample/uniform.rs
@@ -20,9 +20,9 @@ impl Z {
     ///
     /// Parameters:
     /// - `lower_bound`: specifies the included lower bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     /// - `upper_bound`: specifies the excluded upper bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     ///
     /// Returns a fresh [`Z`] instance with a
     /// uniform random value in `[lower_bound, upper_bound)` or a [`MathError`]
@@ -37,8 +37,8 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    /// i.e. the interval size is at most `1`.
+    ///     if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
+    ///     i.e. the interval size is at most `1`.
     pub fn sample_uniform(
         lower_bound: impl Into<Z>,
         upper_bound: impl Into<Z>,
@@ -61,9 +61,9 @@ impl Z {
     ///
     /// Parameters:
     /// - `lower_bound`: specifies the included lower bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     /// - `upper_bound`: specifies the excluded upper bound of the
-    /// interval over which is sampled
+    ///     interval over which is sampled
     ///
     /// Returns a fresh [`Z`] instance with a
     /// uniform random value in `[lower_bound, upper_bound)`. Otherwise, a [`MathError`]
@@ -79,10 +79,10 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    /// i.e. the interval size is at most `1`, or if no prime could be found in the specified interval.
+    ///     if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
+    ///     i.e. the interval size is at most `1`, or if no prime could be found in the specified interval.
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `lower_bound` is negative as primes are always positive.
+    ///     if `lower_bound` is negative as primes are always positive.
     pub fn sample_prime_uniform(
         lower_bound: impl Into<Z>,
         upper_bound: impl Into<Z>,

--- a/src/integer/z/to_string.rs
+++ b/src/integer/z/to_string.rs
@@ -71,7 +71,7 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if the
-    /// base is not between `2` and `62`.
+    ///     base is not between `2` and `62`.
     pub fn to_string_b(&self, base: i32) -> Result<String, MathError> {
         if !(2..=62).contains(&base) {
             return Err(MathError::OutOfBounds(

--- a/src/integer_mod_q.rs
+++ b/src/integer_mod_q.rs
@@ -16,8 +16,8 @@
 //! [`Zq`], [`MatZq`] and [`PolyOverZq`] instances with efficient memory usage.
 //!
 //! - \[1\] John D. Dixon.
-//! "Exact Solution of Linear Equations Using P-Adic Expansions"
-//! <https://link.springer.com/article/10.1007/BF01459082>
+//!     "Exact Solution of Linear Equations Using P-Adic Expansions"
+//!     <https://link.springer.com/article/10.1007/BF01459082>
 
 mod mat_polynomial_ring_zq;
 mod mat_zq;

--- a/src/integer_mod_q/mat_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq.rs
@@ -31,7 +31,7 @@ mod vector;
 /// Attributes:
 /// - `matrix`: holds the [`MatPolyOverZ`](crate::integer::MatPolyOverZ) matrix
 /// - `modulus` : holds the [`ModulusPolynomialRingZq`](crate::integer_mod_q::ModulusPolynomialRingZq)
-/// modulus of the matrix
+///     modulus of the matrix
 ///
 /// # Examples
 /// ## Matrix usage

--- a/src/integer_mod_q/mat_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq.rs
@@ -85,7 +85,7 @@ mod vector;
 /// assert!(col_vec.is_column_vector());
 /// ```
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Display, Clone)]
-#[display(fmt = "{matrix} / {modulus}")]
+#[display("{matrix} / {modulus}")]
 pub struct MatPolynomialRingZq {
     pub(crate) matrix: MatPolyOverZ,
     pub(crate) modulus: ModulusPolynomialRingZq,

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
@@ -80,9 +80,9 @@ impl MatPolynomialRingZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`] if the moduli of
-    /// both [`MatPolynomialRingZq`] mismatch.
+    ///     both [`MatPolynomialRingZq`] mismatch.
     /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`]
-    /// if the dimensions of both [`MatPolynomialRingZq`] mismatch.
+    ///     if the dimensions of both [`MatPolynomialRingZq`] mismatch.
     pub fn add_safe(&self, other: &Self) -> Result<MatPolynomialRingZq, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
@@ -95,10 +95,10 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
-    ///  and `other` do not match for multiplication.
+    ///     [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
+    ///      and `other` do not match for multiplication.
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingModulus`] if the moduli mismatch.
+    ///     [`MathError::MismatchingModulus`] if the moduli mismatch.
     pub fn mul_safe(&self, other: &Self) -> Result<Self, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
@@ -96,7 +96,7 @@ impl MatPolynomialRingZq {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
     ///     [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
-    ///      and `other` do not match for multiplication.
+    ///     and `other` do not match for multiplication.
     /// - Returns a [`MathError`] of type
     ///     [`MathError::MismatchingModulus`] if the moduli mismatch.
     pub fn mul_safe(&self, other: &Self) -> Result<Self, MathError> {

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
@@ -300,7 +300,7 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingModulus`] if the moduli mismatch.
+    ///     [`MathError::MismatchingModulus`] if the moduli mismatch.
     pub fn mul_scalar_poly_over_zq_safe(&self, scalar: &PolyOverZq) -> Result<Self, MathError> {
         if self.modulus.get_q() != Z::from(&scalar.modulus) {
             return Err(MathError::MismatchingModulus(format!(
@@ -337,7 +337,7 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingModulus`] if the moduli mismatch.
+    ///     [`MathError::MismatchingModulus`] if the moduli mismatch.
     pub fn mul_scalar_poly_ring_zq_safe(
         &self,
         scalar: &PolynomialRingZq,

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/sub.rs
@@ -80,9 +80,9 @@ impl MatPolynomialRingZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`] if the moduli of
-    /// both [`MatPolynomialRingZq`] mismatch.
+    ///     both [`MatPolynomialRingZq`] mismatch.
     /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`]
-    /// if the dimensions of both [`MatPolynomialRingZq`] mismatch.
+    ///     if the dimensions of both [`MatPolynomialRingZq`] mismatch.
     pub fn sub_safe(&self, other: &Self) -> Result<MatPolynomialRingZq, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
@@ -102,7 +102,7 @@ mod test_new {
     #[test]
     fn initialization() {
         let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
-        let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
+        let modulus = ModulusPolynomialRingZq::from(&poly_mod);
 
         let _ = MatPolynomialRingZq::new(2, 2, &modulus);
     }
@@ -131,7 +131,7 @@ mod test_new {
     #[test]
     fn error_zero_num_cols() {
         let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
-        let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
+        let modulus = ModulusPolynomialRingZq::from(&poly_mod);
 
         let _ = MatPolynomialRingZq::new(1, 0, &modulus);
     }
@@ -141,7 +141,7 @@ mod test_new {
     #[test]
     fn error_zero_num_rows() {
         let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
-        let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
+        let modulus = ModulusPolynomialRingZq::from(&poly_mod);
 
         let _ = MatPolynomialRingZq::new(0, 1, &modulus);
     }
@@ -151,7 +151,7 @@ mod test_new {
     fn large_modulus() {
         let poly_mod =
             PolyOverZq::from_str(&format!("3  1 {} 1 mod {LARGE_PRIME}", i64::MAX)).unwrap();
-        let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
+        let modulus = ModulusPolynomialRingZq::from(&poly_mod);
 
         let _ = MatPolynomialRingZq::new(2, 2, &modulus);
     }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
@@ -76,7 +76,7 @@ impl MatPolynomialRingZq {
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatPolyOverZ::new`].
+    ///     For further information see [`MatPolyOverZ::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -143,7 +143,7 @@ impl GetEntry<PolyOverZ> for MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -188,7 +188,7 @@ impl GetEntry<PolynomialRingZq> for MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -228,7 +228,7 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the row is greater than the matrix or negative.
+    ///     if the number of the row is greater than the matrix or negative.
     pub fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let row_i64 = evaluate_index(row)?;
 
@@ -268,7 +268,7 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the column is greater than the matrix or negative.
+    ///     if the number of the column is greater than the matrix or negative.
     pub fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let column_i64 = evaluate_index(column)?;
 
@@ -320,7 +320,7 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if any provided row or column is greater than the matrix.
+    ///     if any provided row or column is greater than the matrix.
     ///
     /// # Panics ...
     /// - if `col_1 > col_2` or `row_1 > row_2`.

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/binomial.rs
@@ -25,7 +25,7 @@ impl MatPolynomialRingZq {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `modulus`: specifies the [`ModulusPolynomialRingZq`] over which the
-    /// ring of polynomials modulo `modulus.get_q()` is defined
+    ///     ring of polynomials modulo `modulus.get_q()` is defined
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
@@ -45,13 +45,13 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1` or `p ∉ (0,1)`.
+    ///     if `n < 1` or `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatPolynomialRingZq::new`].
+    ///     For further information see [`MatPolynomialRingZq::new`].
     /// - if the provided [`ModulusPolynomialRingZq`] has degree `0` or smaller.
     pub fn sample_binomial(
         num_rows: impl TryInto<i64> + Display,
@@ -70,9 +70,9 @@ impl MatPolynomialRingZq {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `modulus`: specifies the [`ModulusPolynomialRingZq`] over which the
-    /// ring of polynomials modulo `modulus.get_q()` is defined
+    ///     ring of polynomials modulo `modulus.get_q()` is defined
     /// - `offset`: specifies an offset applied to each sample
-    /// collected from the binomial distribution
+    ///     collected from the binomial distribution
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
@@ -92,13 +92,13 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1` or `p ∉ (0,1)`.
+    ///     if `n < 1` or `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatPolynomialRingZq::new`].
+    ///     For further information see [`MatPolynomialRingZq::new`].
     /// - if the provided [`ModulusPolynomialRingZq`] has degree `0`.
     pub fn sample_binomial_with_offset(
         num_rows: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
@@ -27,7 +27,7 @@ impl MatPolynomialRingZq {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a vector of polynomials sampled according to the
     /// discrete Gaussian distribution.
@@ -57,15 +57,15 @@ impl MatPolynomialRingZq {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`VectorFunctionCalledOnNonVector`](MathError::VectorFunctionCalledOnNonVector), if the basis is not a row vector
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `n <= 1` or `s <= 0`.
+    ///     if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of the `basis` and `center` differ.
+    ///     if the number of rows of the `basis` and `center` differ.
     ///
     /// This function implements SampleD according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-    /// Trapdoors for hard lattices and new cryptographic constructions.
-    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    ///     Trapdoors for hard lattices and new cryptographic constructions.
+    ///     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    ///     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
     ///
     /// # Panics ...
     /// - if the polynomials have higher length than the provided upper bound `k`

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/uniform.rs
@@ -26,7 +26,7 @@ impl MatPolynomialRingZq {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `modulus`: specifies the [`ModulusPolynomialRingZq`] over which the
-    /// ring of polynomials modulo `modulus.get_q()` is defined
+    ///     ring of polynomials modulo `modulus.get_q()` is defined
     ///
     /// Returns a fresh [`MatPolynomialRingZq`] instance of length `modulus.get_degree() - 1`
     /// with coefficients chosen uniform at random in `[0, modulus.get_q())`.
@@ -42,7 +42,7 @@ impl MatPolynomialRingZq {
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatPolynomialRingZq::new`].
+    ///     For further information see [`MatPolynomialRingZq::new`].
     /// - if the provided [`ModulusPolynomialRingZq`] has degree `0`.
     pub fn sample_uniform(
         num_rows: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -52,7 +52,7 @@ impl SetEntry<&PolyOverZ> for MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,
@@ -101,9 +101,9 @@ impl SetEntry<&PolynomialRingZq> for MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`]
-    /// if the moduli are different.
+    ///     if the moduli are different.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector/dot_product.rs
@@ -42,9 +42,9 @@ impl MatPolynomialRingZq {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatPolynomialRingZq`] instance is not a (row or column) vector.
+    ///     the given [`MatPolynomialRingZq`] instance is not a (row or column) vector.
     /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`] if
-    /// the given vectors have different lengths.
+    ///     the given vectors have different lengths.
     pub fn dot_product(&self, other: &Self) -> Result<PolynomialRingZq, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(

--- a/src/integer_mod_q/mat_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/mul.rs
@@ -130,10 +130,10 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
-    ///  and `other` do not match for multiplication.
+    ///     [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
+    ///     and `other` do not match for multiplication.
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingModulus`] if the moduli mismatch.
+    ///     [`MathError::MismatchingModulus`] if the moduli mismatch.
     pub fn mul_safe(&self, other: &Self) -> Result<Self, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/mat_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/mul_scalar.rs
@@ -114,7 +114,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingModulus`](MathError::MismatchingModulus) if the moduli mismatch.
+    ///     [`MismatchingModulus`](MathError::MismatchingModulus) if the moduli mismatch.
     pub fn mul_scalar_safe(&self, scalar: &Zq) -> Result<Self, MathError> {
         if self.modulus != scalar.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/mat_zq/concat.rs
+++ b/src/integer_mod_q/mat_zq/concat.rs
@@ -39,11 +39,11 @@ impl Concatenate for &MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the matrices can not be concatenated due to mismatching dimensions.
+    ///     [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    ///     if the matrices can not be concatenated due to mismatching dimensions.
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingModulus`](MathError::MismatchingModulus)
-    /// if the matrices can not be concatenated due to mismatching moduli.
+    ///     [`MismatchingModulus`](MathError::MismatchingModulus)
+    ///     if the matrices can not be concatenated due to mismatching moduli.
     fn concat_vertical(self, other: Self) -> Result<Self::Output, crate::error::MathError> {
         if self.get_num_columns() != other.get_num_columns() {
             return Err(MathError::MismatchingMatrixDimension(format!(
@@ -95,11 +95,11 @@ impl Concatenate for &MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the matrices can not be concatenated due to mismatching dimensions.
+    ///     [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    ///     if the matrices can not be concatenated due to mismatching dimensions.
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingModulus`](MathError::MismatchingModulus)
-    /// if the matrices can not be concatenated due to mismatching moduli.
+    ///     [`MismatchingModulus`](MathError::MismatchingModulus)
+    ///     if the matrices can not be concatenated due to mismatching moduli.
     fn concat_horizontal(self, other: Self) -> Result<Self::Output, crate::error::MathError> {
         if self.get_num_rows() != other.get_num_rows() {
             return Err(MathError::MismatchingMatrixDimension(format!(

--- a/src/integer_mod_q/mat_zq/default.rs
+++ b/src/integer_mod_q/mat_zq/default.rs
@@ -85,7 +85,7 @@ impl MatZq {
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.
-    /// For further information see [`MatZq::new`].
+    ///     For further information see [`MatZq::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -94,14 +94,14 @@ impl FromStr for MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-    /// if the matrix is not formatted in a suitable way,
-    /// if the number of entries in rows is unequal,
-    /// if an entry contains a Nul byte, or
-    /// if the modulus or an entry is not formatted correctly.
+    ///     - if the matrix is not formatted in a suitable way,
+    ///     - if the number of entries in rows is unequal,
+    ///     - if an entry contains a Nul byte, or
+    ///     - if the modulus or an entry is not formatted correctly.
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.
-    /// For further information see [`MatZq::new`].
+    ///     For further information see [`MatZq::new`].
     fn from_str(string: &str) -> Result<Self, MathError> {
         let (matrix, modulus) = match string.split_once("mod") {
             Some((matrix, modulus)) => (matrix, modulus),

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -102,7 +102,7 @@ impl GetEntry<Z> for MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -146,7 +146,7 @@ impl GetEntry<Zq> for MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -181,7 +181,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the row is greater than the matrix or negative.
+    ///     if the number of the row is greater than the matrix or negative.
     pub fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let row_i64 = evaluate_index(row)?;
 
@@ -218,7 +218,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the column is greater than the matrix or negative.
+    ///     if the number of the column is greater than the matrix or negative.
     pub fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let column_i64 = evaluate_index(column)?;
 
@@ -266,7 +266,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if any provided row or column is greater than the matrix.
+    ///     if any provided row or column is greater than the matrix.
     ///
     /// # Panics ...
     /// - if `col_1 > col_2` or `row_1 > row_2`.

--- a/src/integer_mod_q/mat_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_zq/sample/binomial.rs
@@ -44,15 +44,15 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatZq::new`].
+    ///     For further information see [`MatZq::new`].
     /// - if the modulus is not greater than `1`.
     pub fn sample_binomial(
         num_rows: impl TryInto<i64> + Display,
@@ -71,7 +71,7 @@ impl MatZq {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `offset`: specifies an offset applied to each sample
-    /// collected from the binomial distribution
+    ///     collected from the binomial distribution
     /// - `modulus`: specifies the [`Modulus`] of the new [`MatZq`] instance
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
@@ -90,15 +90,15 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatZq::new`].
+    ///     For further information see [`MatZq::new`].
     /// - if the modulus is not greater than `1`.
     pub fn sample_binomial_with_offset(
         num_rows: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -29,7 +29,7 @@ impl MatZq {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a matrix with each entry sampled independently from the
     /// specified discrete Gaussian distribution.
@@ -43,11 +43,11 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `n <= 1` or `s <= 0`.
+    ///     if the `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.
-    /// For further information see [`MatZq::new`].
+    ///     For further information see [`MatZq::new`].
     /// - if the provided `modulus < 2`.
     pub fn sample_discrete_gauss(
         num_rows: impl TryInto<i64> + Display,
@@ -82,7 +82,7 @@ impl MatZq {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a lattice vector sampled according to the discrete Gaussian distribution.
     ///
@@ -97,17 +97,17 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `n <= 1` or `s <= 0`.
+    ///     if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of the `basis` and `center` differ.
+    ///     if the number of rows of the `basis` and `center` differ.
     /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-    /// if `center` is not a column vector.
+    ///     if `center` is not a column vector.
     ///
     /// This function implements SampleD according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-    /// Trapdoors for hard lattices and new cryptographic constructions.
-    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    ///     Trapdoors for hard lattices and new cryptographic constructions.
+    ///     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    ///     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
     pub fn sample_d(
         basis: &MatZq,
         n: impl Into<Z>,
@@ -119,7 +119,7 @@ impl MatZq {
 
         let sample = sample_d(&MatZ::from(basis), &n, center, &s)?;
 
-        Ok(MatZq::from_mat_z_modulus(&sample, &basis.get_mod()))
+        Ok(MatZq::from_mat_z_modulus(&sample, basis.get_mod()))
     }
 
     /// Runs [`MatZq::sample_d`] with identity basis and center vector `0`.
@@ -127,12 +127,12 @@ impl MatZq {
     ///
     /// Parameters:
     /// - `dimension`: specifies the number of rows and columns
-    /// that the identity basis should have
+    ///     that the identity basis should have
     /// - `modulus`: specifies the modulus of the new matrix
     /// - `n`: specifies the range from which
-    /// [`Zq::sample_discrete_gauss`](crate::integer_mod_q::Zq::sample_discrete_gauss) samples
+    ///     [`Zq::sample_discrete_gauss`](crate::integer_mod_q::Zq::sample_discrete_gauss) samples
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a lattice vector sampled according to the discrete Gaussian distribution.
     /// The lattice specified as `Z^m` for `m = dimension` and its center fixed to `0^m`.
@@ -164,7 +164,7 @@ impl MatZq {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a lattice vector sampled according to the discrete Gaussian distribution.
     ///
@@ -180,20 +180,20 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `n <= 1` or `s <= 0`.
+    ///     if the `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of the `basis` and `center` differ.
+    ///     if the number of rows of the `basis` and `center` differ.
     /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-    /// if `center` is not a column vector.
+    ///     if `center` is not a column vector.
     ///
     /// # Panics ...
     /// - if the number of rows/columns of `basis_gso` and `basis` mismatch.
     ///
     /// This function implements SampleD according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-    /// Trapdoors for hard lattices and new cryptographic constructions.
-    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    ///     Trapdoors for hard lattices and new cryptographic constructions.
+    ///     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    ///     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
     pub fn sample_d_precomputed_gso(
         basis: &MatZq,
         basis_gso: &MatQ,
@@ -206,7 +206,7 @@ impl MatZq {
 
         let sample = sample_d_precomputed_gso(&MatZ::from(basis), basis_gso, &n, center, &s)?;
 
-        Ok(MatZq::from_mat_z_modulus(&sample, &basis.get_mod()))
+        Ok(MatZq::from_mat_z_modulus(&sample, basis.get_mod()))
     }
 }
 

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -28,7 +28,7 @@ impl MatZq {
     /// - `num_rows`: specifies the number of rows the new matrix should have
     /// - `num_cols`: specifies the number of columns the new matrix should have
     /// - `modulus`: specifies the modulus of the matrix and defines the interval
-    /// over which is sampled
+    ///     over which is sampled
     ///
     /// Returns a new [`MatZq`] instance with entries chosen
     /// uniformly at random in `[0, modulus)`.
@@ -42,7 +42,7 @@ impl MatZq {
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.
-    /// For further information see [`MatZq::new`].
+    ///     For further information see [`MatZq::new`].
     pub fn sample_uniform(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_zq/set.rs
+++ b/src/integer_mod_q/mat_zq/set.rs
@@ -61,7 +61,7 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,
@@ -106,9 +106,9 @@ impl SetEntry<&Zq> for MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`]
-    /// if the moduli mismatch.
+    ///     if the moduli mismatch.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,
@@ -144,11 +144,11 @@ impl MatZq {
     /// - `col_0`: specifies the column of `self` that should be modified
     /// - `other`: specifies the matrix providing the column replacing the column in `self`
     /// - `col_1`: specifies the column of `other` providing
-    /// the values replacing the original column in `self`
+    ///     the values replacing the original column in `self`
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
-    /// Otherwise, a [`MathError`] is returned if one of the specified columns is not part of its matrix
-    /// or if the number of rows differs.
+    ///     Otherwise, a [`MathError`] is returned if one of the specified columns is not part of its matrix
+    ///     or if the number of rows differs.
     ///
     /// # Examples
     /// ```
@@ -162,11 +162,11 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of columns is greater than the matrix dimensions or negative.
+    ///     if the number of columns is greater than the matrix dimensions or negative.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of `self` and `other` differ.
+    ///     if the number of rows of `self` and `other` differ.
     /// - Returns a [`MathError`] of type [`MismatchingModulus`](MathError::MismatchingModulus)
-    /// if the moduli of `self` and `other` mismatch.
+    ///     if the moduli of `self` and `other` mismatch.
     pub fn set_column(
         &mut self,
         col_0: impl TryInto<i64> + Display,
@@ -212,7 +212,7 @@ impl MatZq {
     /// - `row_0`: specifies the row of `self` that should be modified
     /// - `other`: specifies the matrix providing the row replacing the row in `self`
     /// - `row_1`: specifies the row of `other` providing
-    /// the values replacing the original row in `self`
+    ///     the values replacing the original row in `self`
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if one of the specified rows is not part of its matrix
@@ -230,11 +230,11 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows is greater than the matrix dimensions or negative.
+    ///     if the number of rows is greater than the matrix dimensions or negative.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of columns of `self` and `other` differ.
+    ///     if the number of columns of `self` and `other` differ.
     /// - Returns a [`MathError`] of type [`MismatchingModulus`](MathError::MismatchingModulus)
-    /// if the moduli of `self` and `other` mismatch.
+    ///     if the moduli of `self` and `other` mismatch.
     pub fn set_row(
         &mut self,
         row_0: impl TryInto<i64> + Display,
@@ -298,7 +298,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if row or column are greater than the matrix size.
+    ///     if row or column are greater than the matrix size.
     pub fn swap_entries(
         &mut self,
         row_0: impl TryInto<i64> + Display,
@@ -337,7 +337,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if one of the given columns is greater than the matrix or negative.
+    ///     if one of the given columns is greater than the matrix or negative.
     pub fn swap_columns(
         &mut self,
         col_0: impl TryInto<i64> + Display,
@@ -378,7 +378,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if one of the given rows is greater than the matrix or negative.
+    ///     if one of the given rows is greater than the matrix or negative.
     pub fn swap_rows(
         &mut self,
         row_0: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -98,7 +98,7 @@ impl MatZq {
         }
 
         // Set the entries of the output vector using the indices vector.
-        let mut out = MatZq::new(self.get_num_columns(), 1, &matrix.get_mod());
+        let mut out = MatZq::new(self.get_num_columns(), 1, matrix.get_mod());
         for (i, j) in indices.iter() {
             let entry: Z = matrix.get_entry(*i, -1).unwrap();
             out.set_entry(*j, 0, entry).unwrap();
@@ -197,7 +197,7 @@ impl MatZq {
     ///
     /// # Panics ...
     /// - if the the number of elements in `solutions` is greater than the number
-    /// of elements in `moduli`.
+    ///     of elements in `moduli`.
     fn crt_mat_zq(&self, mut solutions: Vec<MatZq>, mut moduli: Vec<(Z, u64)>) -> Option<MatZq> {
         while solutions.len() > 1 {
             // Compute Bézout’s identity: a x_1 + b x_2 = 1

--- a/src/integer_mod_q/mat_zq/sort.rs
+++ b/src/integer_mod_q/mat_zq/sort.rs
@@ -21,7 +21,7 @@ impl MatZq {
     ///
     /// Parameters:
     /// - `cond_func`: computes values implementing [`Ord`] over the columns of the specified matrix.
-    /// These values are then used to re-order / sort the rows of the matrix.
+    ///     These values are then used to re-order / sort the rows of the matrix.
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// A [`MathError`] is returned if the execution of `cond_func` returned an error.
@@ -88,7 +88,7 @@ impl MatZq {
     ///
     /// Parameters:
     /// - `cond_func`: computes values implementing [`Ord`] over the columns of the specified matrix.
-    /// These values are then used to re-order / sort the columns of the matrix.
+    ///     These values are then used to re-order / sort the columns of the matrix.
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// A [`MathError`] is returned if the execution of `cond_func` returned an error.

--- a/src/integer_mod_q/mat_zq/tensor.rs
+++ b/src/integer_mod_q/mat_zq/tensor.rs
@@ -44,7 +44,7 @@ impl Tensor for MatZq {
     ///
     /// # Panics ...
     /// - if the moduli of both matrices mismatch.
-    /// Use [`tensor_product_safe`](crate::integer_mod_q::MatZq::tensor_product_safe) to get an error instead.
+    ///     Use [`tensor_product_safe`](crate::integer_mod_q::MatZq::tensor_product_safe) to get an error instead.
     fn tensor_product(&self, other: &Self) -> Self {
         self.tensor_product_safe(other).unwrap()
     }
@@ -78,8 +78,8 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingModulus`](MathError::MismatchingModulus) if the
-    /// moduli of the provided matrices mismatch.
+    ///     [`MismatchingModulus`](MathError::MismatchingModulus) if the
+    ///     moduli of the provided matrices mismatch.
     pub fn tensor_product_safe(&self, other: &Self) -> Result<Self, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/mat_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_zq/vector/dot_product.rs
@@ -45,11 +45,11 @@ impl MatZq {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`VectorFunctionCalledOnNonVector`](MathError::VectorFunctionCalledOnNonVector)
-    /// if the given [`MatZq`] instance is not a (row or column) vector.
+    ///     if the given [`MatZq`] instance is not a (row or column) vector.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the given vectors have different lengths.
+    ///     if the given vectors have different lengths.
     /// - Returns a [`MathError`] of type [`MismatchingModulus`](MathError::MismatchingModulus)
-    /// if the provided matrices have different moduli.
+    ///     if the provided matrices have different moduli.
     pub fn dot_product(&self, other: &Self) -> Result<Zq, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(

--- a/src/integer_mod_q/mat_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_zq/vector/norm.rs
@@ -42,7 +42,7 @@ impl MatZq {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatZq`] instance is not a (row or column) vector.
+    ///     the given [`MatZq`] instance is not a (row or column) vector.
     pub fn norm_eucl_sqrd(&self) -> Result<Z, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(
@@ -88,7 +88,7 @@ impl MatZq {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatZq`] instance is not a (row or column) vector.
+    ///     the given [`MatZq`] instance is not a (row or column) vector.
     pub fn norm_infty(&self) -> Result<Z, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(

--- a/src/integer_mod_q/modulus/from.rs
+++ b/src/integer_mod_q/modulus/from.rs
@@ -48,7 +48,7 @@ impl Modulus {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidModulus`](MathError::InvalidModulus)
-    /// if the provided value is not greater than `1`.
+    ///     if the provided value is not greater than `1`.
     pub(crate) fn from_fmpz_ref(value: &fmpz) -> Result<Self, MathError> {
         if (unsafe { fmpz_cmp_si(value, 1) } <= 0) {
             let z = Z::from(value);
@@ -138,12 +138,12 @@ impl FromStr for Modulus {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`StringConversionError`](MathError::StringConversionError) if the
-    /// provided string was not formatted correctly, e.g. not a correctly
-    /// formatted [`Z`].
+    ///     [`StringConversionError`](MathError::StringConversionError) if the
+    ///     provided string was not formatted correctly, e.g. not a correctly
+    ///     formatted [`Z`].
     /// - Returns a [`MathError`] of type
-    /// [`InvalidModulus`](MathError::InvalidModulus)
-    /// if the provided value is not greater than `1`.
+    ///     [`InvalidModulus`](MathError::InvalidModulus)
+    ///     if the provided value is not greater than `1`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let z = Z::from_str(s)?;
 

--- a/src/integer_mod_q/modulus_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq.rs
@@ -25,7 +25,7 @@ mod to_string;
 ///
 /// Attributes
 /// - `modulus`: holds the specific content, i.e. the modulus `q` and f(X); it
-/// holds [FLINT](https://flintlib.org/)'s [struct](fq_ctx_struct)
+///     holds [FLINT](https://flintlib.org/)'s [struct](fq_ctx_struct)
 ///
 /// # Examples
 /// ```

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
@@ -112,7 +112,7 @@ mod test_try_from_poly_zq {
         let poly_mod =
             PolyOverZq::from_str(&format!("4  0 1 -2 {} mod {}", u64::MAX, 2_i32.pow(16) + 1))
                 .unwrap();
-        let _ = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
+        let _ = ModulusPolynomialRingZq::from(&poly_mod);
     }
 
     /// Ensure that large entries work
@@ -121,7 +121,7 @@ mod test_try_from_poly_zq {
         let in_str = format!("4  0 1 3 {} mod {}", u64::MAX, 2_i32.pow(16) + 1);
         let cmp_str = "3  0 1 3 mod 65537";
         let poly_zq = PolyOverZq::from_str(&in_str).unwrap();
-        let _ = ModulusPolynomialRingZq::try_from(&poly_zq).unwrap();
+        let _ = ModulusPolynomialRingZq::from(&poly_zq);
         assert_eq!(cmp_str, poly_zq.to_string());
     }
 
@@ -129,8 +129,7 @@ mod test_try_from_poly_zq {
     #[test]
     fn poly_zq_non_prime() {
         let in_str = format!("4  0 1 3 {} mod {}", u64::MAX, 2_i32.pow(16));
-        let poly_zq = PolyOverZq::from_str(&in_str).unwrap();
-        assert!(ModulusPolynomialRingZq::try_from(&poly_zq).is_ok());
+        PolyOverZq::from_str(&in_str).unwrap();
     }
 }
 

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
@@ -125,7 +125,7 @@ mod test_try_from_poly_zq {
         assert_eq!(cmp_str, poly_zq.to_string());
     }
 
-    /// Ensure that non-primes yields an error
+    /// Ensure that non-primes work
     #[test]
     fn poly_zq_non_prime() {
         let in_str = format!("4  0 1 3 {} mod {}", u64::MAX, 2_i32.pow(16));
@@ -161,7 +161,7 @@ mod test_from_str {
         .is_ok());
     }
 
-    /// Ensure that non-primes yields an error
+    /// Ensure that non-primes work
     #[test]
     fn poly_zq_non_prime() {
         assert!(ModulusPolynomialRingZq::from_str(&format!(

--- a/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
@@ -70,7 +70,7 @@ impl PolyOverZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`] if the moduli of
-    /// both [`PolyOverZq`] mismatch.
+    ///     both [`PolyOverZq`] mismatch.
     pub fn add_safe(&self, other: &Self) -> Result<PolyOverZq, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/poly_over_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/mul.rs
@@ -70,7 +70,7 @@ impl PolyOverZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`] if the moduli of
-    /// both [`PolyOverZq`] mismatch.
+    ///     both [`PolyOverZq`] mismatch.
     pub fn mul_safe(&self, other: &Self) -> Result<PolyOverZq, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/poly_over_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/sub.rs
@@ -70,7 +70,7 @@ impl PolyOverZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`] if the moduli of
-    /// both [`PolyOverZq`] mismatch.
+    ///     both [`PolyOverZq`] mismatch.
     pub fn sub_safe(&self, other: &Self) -> Result<PolyOverZq, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
@@ -26,7 +26,7 @@ impl IntoCoefficientEmbedding<MatZq> for &PolyOverZq {
     ///
     /// Parameters:
     /// - `size`: determines the number of rows of the embedding. It has to be larger
-    /// than the degree of the polynomial.
+    ///     than the degree of the polynomial.
     ///
     /// Returns a coefficient embedding as a column vector if `size` is large enough.
     ///
@@ -46,7 +46,7 @@ impl IntoCoefficientEmbedding<MatZq> for &PolyOverZq {
     ///
     /// # Panics ...
     /// - if `size` is not larger than the degree of the polynomial, i.e.
-    /// not all coefficients can be embedded.
+    ///     not all coefficients can be embedded.
     fn into_coefficient_embedding(self, size: impl Into<i64>) -> MatZq {
         let size = size.into();
         let length = self.get_degree() + 1;

--- a/src/integer_mod_q/poly_over_zq/dot_product.rs
+++ b/src/integer_mod_q/poly_over_zq/dot_product.rs
@@ -36,7 +36,7 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingModulus`] if the moduli mismatch.
+    ///     [`MathError::MismatchingModulus`] if the moduli mismatch.
     pub fn dot_product(&self, other: &Self) -> Result<Zq, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/poly_over_zq/evaluate.rs
+++ b/src/integer_mod_q/poly_over_zq/evaluate.rs
@@ -110,7 +110,7 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`]
-    /// if the moduli of the polynomial and the input mismatch.
+    ///     if the moduli of the polynomial and the input mismatch.
     pub fn evaluate_safe(&self, value: &Zq) -> Result<Zq, MathError> {
         if self.modulus != value.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -127,10 +127,10 @@ impl FromStr for PolyOverZq {
     ///
     /// Parameters:
     /// - `s`: the polynomial of form:
-    /// "`[#number of coefficients]⌴⌴[0th coefficient]⌴[1st coefficient]⌴...⌴mod⌴[modulus]`".
-    /// Note that the `[#number of coefficients]` and `[0th coefficient]`
-    /// are divided by two spaces and the string for the polynomial is trimmed,
-    /// i.e. all whitespaces before around the polynomial and the modulus are removed.
+    ///     "`[#number of coefficients]⌴⌴[0th coefficient]⌴[1st coefficient]⌴...⌴mod⌴[modulus]`".
+    ///     Note that the `[#number of coefficients]` and `[0th coefficient]`
+    ///     are divided by two spaces and the string for the polynomial is trimmed,
+    ///     i.e. all whitespaces before around the polynomial and the modulus are removed.
     ///
     /// Returns a [`PolyOverZq`] or an error, if the provided string was not
     /// formatted correctly.
@@ -144,16 +144,16 @@ impl FromStr for PolyOverZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`StringConversionError`](MathError::StringConversionError)
-    /// if the provided string was not formatted correctly to create a [`Modulus`],
-    /// if the provided value did not contain two whitespaces,
-    /// if the provided half of the string was not formatted correctly to
-    /// create a polynomial, or
-    /// if the provided half of the
-    /// string was not formatted correctly to create a [`Z`](crate::integer::Z).
+    ///     [`StringConversionError`](MathError::StringConversionError)
+    ///     if the provided string was not formatted correctly to create a [`Modulus`],
+    ///     if the provided value did not contain two whitespaces,
+    ///     if the provided half of the string was not formatted correctly to
+    ///     create a polynomial, or
+    ///     if the provided half of the
+    ///     string was not formatted correctly to create a [`Z`](crate::integer::Z).
     /// - Returns a [`MathError`] of type
-    /// [`InvalidModulus`](MathError::InvalidModulus)
-    /// if the provided modulus is not greater than `1`.
+    ///     [`InvalidModulus`](MathError::InvalidModulus)
+    ///     if the provided modulus is not greater than `1`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (poly_s, modulus) = match s.split_once("mod") {
             Some((poly_s, modulus)) => (poly_s, modulus.trim()),

--- a/src/integer_mod_q/poly_over_zq/get.rs
+++ b/src/integer_mod_q/poly_over_zq/get.rs
@@ -50,7 +50,7 @@ impl GetCoefficient<Zq> for PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     fn get_coeff(&self, index: impl TryInto<i64> + Display) -> Result<Zq, MathError> {
         let out_z: Z = self.get_coeff(index)?;
         Ok(Zq::from((out_z, &self.modulus)))
@@ -88,7 +88,7 @@ impl GetCoefficient<Z> for PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     fn get_coeff(&self, index: impl TryInto<i64> + Display) -> Result<Z, MathError> {
         let index = evaluate_index(index)?;
         let mut out = Z::default();

--- a/src/integer_mod_q/poly_over_zq/sample/binomial.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/binomial.rs
@@ -26,15 +26,15 @@ impl PolyOverZq {
     ///
     /// Parameters:
     /// - `max_degree`: specifies the length of the polynomial,
-    /// i.e. the number of coefficients
+    ///     i.e. the number of coefficients
     /// - `modulus`: specifies the [`Modulus`] of the new [`PolyOverZq`] instance
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
     /// Returns a fresh [`PolyOverZq`] instance with each value sampled
-    /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
-    /// or `max_degree` is negative or does not into an [`i64`].
+    ///     according to the binomial distribution or a [`MathError`]
+    ///     if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    ///     or `max_degree` is negative or does not into an [`i64`].
     ///
     /// # Examples
     /// ```
@@ -45,13 +45,13 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// the `max_degree` is negative or it does not fit into an [`i64`].
+    ///     the `max_degree` is negative or it does not fit into an [`i64`].
     pub fn sample_binomial(
         max_degree: impl TryInto<i64> + Display,
         modulus: impl Into<Modulus>,
@@ -67,9 +67,9 @@ impl PolyOverZq {
     ///
     /// Parameters:
     /// - `max_degree`: specifies the length of the polynomial,
-    /// i.e. the number of coefficients
+    ///     i.e. the number of coefficients
     /// - `offset`: specifies an offset applied to each sample
-    /// collected from the binomial distribution
+    ///     collected from the binomial distribution
     /// - `modulus`: specifies the [`Modulus`] of the new [`PolyOverZq`] instance
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
@@ -88,13 +88,13 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// the `max_degree` is negative or it does not fit into an [`i64`].
+    ///     the `max_degree` is negative or it does not fit into an [`i64`].
     pub fn sample_binomial_with_offset(
         max_degree: impl TryInto<i64> + Display,
         offset: impl Into<Z>,

--- a/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
@@ -30,7 +30,7 @@ impl PolyOverZq {
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a fresh [`PolyOverZq`] instance of maximum degree `max_degree`
     /// with coefficients chosen independently according the discrete Gaussian distribution or
@@ -45,7 +45,7 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n <= 1` or `s <= 0`.
+    ///     if `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if `max_degree` is negative, or does not fit into an [`i64`].

--- a/src/integer_mod_q/poly_over_zq/sample/uniform.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/uniform.rs
@@ -27,9 +27,9 @@ impl PolyOverZq {
     ///
     /// Parameters:
     /// - `max_degree`: specifies the length of the polynomial,
-    /// i.e. the number of coefficients
+    ///     i.e. the number of coefficients
     /// - `modulus`: specifies the modulus of the coefficients and thus,
-    /// the interval size over which is sampled
+    ///     the interval size over which is sampled
     ///
     /// Returns a fresh [`PolyOverZq`] instance of length `max_degree` with coefficients
     /// chosen uniform at random in `[0, modulus)` or a [`MathError`]
@@ -44,9 +44,9 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if the given `modulus` isn't larger than `1`, i.e. the interval size is at most `1`.
+    ///     if the given `modulus` isn't larger than `1`, i.e. the interval size is at most `1`.
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// the `max_degree` is negative or it does not fit into an [`i64`].
+    ///     the `max_degree` is negative or it does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided modulus is not greater than `1`.

--- a/src/integer_mod_q/poly_over_zq/set.rs
+++ b/src/integer_mod_q/poly_over_zq/set.rs
@@ -44,7 +44,7 @@ impl<Integer: Into<Z>> SetCoefficient<Integer> for PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     fn set_coeff(
         &mut self,
         index: impl TryInto<i64> + Display,
@@ -97,10 +97,10 @@ impl SetCoefficient<&Zq> for PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type
-    ///  [`MismatchingModulus`](MathError::MismatchingModulus) the moduli of
-    /// the polynomial and the input mismatch
+    ///     [`MismatchingModulus`](MathError::MismatchingModulus) the moduli of
+    ///     the polynomial and the input mismatch
     fn set_coeff(
         &mut self,
         index: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/polynomial_ring_zq.rs
+++ b/src/integer_mod_q/polynomial_ring_zq.rs
@@ -63,7 +63,7 @@ mod set;
 /// # Ok::<(), MathError>(())
 /// ```
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Display, Clone)]
-#[display(fmt = "{poly} / {modulus}")]
+#[display("{poly} / {modulus}")]
 pub struct PolynomialRingZq {
     pub(crate) poly: PolyOverZ,
     pub(crate) modulus: ModulusPolynomialRingZq,

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/add.rs
@@ -81,7 +81,7 @@ impl PolynomialRingZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`] if the moduli of
-    /// both [`PolynomialRingZq`] mismatch.
+    ///     both [`PolynomialRingZq`] mismatch.
     pub fn add_safe(&self, other: &Self) -> Result<PolynomialRingZq, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/mul.rs
@@ -81,7 +81,7 @@ impl PolynomialRingZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`] if the moduli of
-    /// both [`PolynomialRingZq`] mismatch.
+    ///     both [`PolynomialRingZq`] mismatch.
     pub fn mul_safe(&self, other: &Self) -> Result<PolynomialRingZq, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/sub.rs
@@ -81,7 +81,7 @@ impl PolynomialRingZq {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`] if the moduli of
-    /// both [`PolynomialRingZq`] mismatch.
+    ///     both [`PolynomialRingZq`] mismatch.
     pub fn sub_safe(&self, other: &Self) -> Result<PolynomialRingZq, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(

--- a/src/integer_mod_q/polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/from.rs
@@ -22,7 +22,7 @@ impl<Poly: Into<PolyOverZ>, Mod: Into<ModulusPolynomialRingZq>> From<(Poly, Mod)
     ///
     /// Parameters:
     /// - `(poly, modulus)`: the value of the polynomial ring element, where `poly`
-    /// defines the equivalence class and `modulus` is the corresponding modulus.
+    ///     defines the equivalence class and `modulus` is the corresponding modulus.
     ///
     /// Returns a new element inside the polynomial ring.
     ///

--- a/src/integer_mod_q/polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/get.rs
@@ -53,7 +53,7 @@ impl GetCoefficient<Z> for PolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     fn get_coeff(&self, index: impl TryInto<i64> + Display) -> Result<Z, MathError> {
         let index = evaluate_index(index)?;
         let mut out = Z::default();

--- a/src/integer_mod_q/polynomial_ring_zq/sample/binomial.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/binomial.rs
@@ -23,7 +23,7 @@ impl PolynomialRingZq {
     ///
     /// Parameters:
     /// - `modulus`: specifies the [`ModulusPolynomialRingZq`] over which the
-    /// ring of polynomials modulo `modulus.get_q()` is defined
+    ///     ring of polynomials modulo `modulus.get_q()` is defined
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
@@ -42,11 +42,11 @@ impl PolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided [`ModulusPolynomialRingZq`] has degree `0` or smaller.
@@ -64,9 +64,9 @@ impl PolynomialRingZq {
     ///
     /// Parameters:
     /// - `modulus`: specifies the [`ModulusPolynomialRingZq`] over which the
-    /// ring of polynomials modulo `modulus.get_q()` is defined
+    ///     ring of polynomials modulo `modulus.get_q()` is defined
     /// - `offset`: specifies an offset applied to each sample
-    /// collected from the binomial distribution
+    ///     collected from the binomial distribution
     /// - `n`: specifies the number of trials
     /// - `p`: specifies the probability of success
     ///
@@ -85,11 +85,11 @@ impl PolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the provided [`ModulusPolynomialRingZq`] has degree `0` or smaller.

--- a/src/integer_mod_q/polynomial_ring_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/discrete_gauss.rs
@@ -23,11 +23,11 @@ impl PolynomialRingZq {
     ///
     /// Parameters:
     /// - `modulus`: specifies the [`ModulusPolynomialRingZq`] over which the
-    /// ring of polynomials modulo `modulus.get_q()` is defined
+    ///     ring of polynomials modulo `modulus.get_q()` is defined
     /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
     /// - `center`: specifies the positions of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a fresh [`PolynomialRingZq`] instance of length `modulus.get_degree() - 1`
     /// with coefficients chosen independently according the discrete Gaussian distribution or
@@ -44,7 +44,7 @@ impl PolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n <= 1` or `s <= 0`.
+    ///     if `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if the provided [`ModulusPolynomialRingZq`] has degree `0` or smaller.

--- a/src/integer_mod_q/polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/uniform.rs
@@ -23,7 +23,7 @@ impl PolynomialRingZq {
     ///
     /// Parameters:
     /// - `modulus`: specifies the [`ModulusPolynomialRingZq`] over which the
-    /// ring of polynomials modulo `modulus.get_q()` is defined
+    ///     ring of polynomials modulo `modulus.get_q()` is defined
     ///
     /// Returns a fresh [`PolynomialRingZq`] instance of length `modulus.get_degree() - 1`
     /// with coefficients chosen uniform at random in `[0, modulus.get_q())`.

--- a/src/integer_mod_q/polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/set.rs
@@ -43,7 +43,7 @@ impl<Integer: Into<Z>> SetCoefficient<Integer> for PolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     fn set_coeff(
         &mut self,
         index: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/z_q/arithmetic/pow.rs
+++ b/src/integer_mod_q/z_q/arithmetic/pow.rs
@@ -37,7 +37,7 @@ impl<Integer: Into<Z>> Pow<Integer> for Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidExponent`](MathError::InvalidExponent)
-    /// if the provided exponent is negative and the base value of `self` is not invertible.
+    ///     if the provided exponent is negative and the base value of `self` is not invertible.
     fn pow(&self, exp: Integer) -> Result<Self::Output, MathError> {
         let exp = exp.into();
         let mut out = self.clone();

--- a/src/integer_mod_q/z_q/distance.rs
+++ b/src/integer_mod_q/z_q/distance.rs
@@ -18,7 +18,7 @@ impl Zq {
     ///
     /// Parameters:
     /// - `other`: specifies one of the [`Zq`] values whose distance
-    /// is calculated to `self`
+    ///     is calculated to `self`
     ///
     /// Returns the absolute minimum distance between the two given values as a new
     /// [`Z`] instance or a [`MathError`] if the moduli mismatch.
@@ -40,8 +40,8 @@ impl Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingModulus`](MathError::MismatchingModulus) if the
-    /// provided moduli differ.
+    ///     [`MismatchingModulus`](MathError::MismatchingModulus) if the
+    ///     provided moduli differ.
     pub fn distance_safe(&self, other: &Zq) -> Result<Z, MathError> {
         if self.modulus != other.modulus {
             return Err(MathError::MismatchingModulus(format!(
@@ -66,7 +66,7 @@ impl Distance<&Zq> for Zq {
     ///
     /// Parameters:
     /// - `other`: specifies one of the [`Zq`] values whose distance
-    /// is calculated to `self`.
+    ///     is calculated to `self`.
     ///
     /// Returns the absolute minimum distance between the two given values as a new
     /// [`Z`] instance.
@@ -112,7 +112,7 @@ impl<Integer: Into<Z>> Distance<Integer> for Zq {
     ///
     /// Parameters:
     /// - `other`: specifies one of the [`Zq`] values whose distance
-    /// is calculated to `self`. The modulus from `self` will be used.
+    ///     is calculated to `self`. The modulus from `self` will be used.
     ///
     /// Returns the absolute minimum distance between the two given values as a new
     /// [`Z`] instance.

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -119,13 +119,13 @@ impl FromStr for Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`StringConversionError`](MathError::StringConversionError)
-    /// if the provided string contains a Nul byte,
-    /// if the provided string was not formatted correctly, or
-    /// if the provided modulus was not formatted correctly to create a [`Z`].
+    ///     [`StringConversionError`](MathError::StringConversionError)
+    ///     - if the provided string contains a Nul byte,
+    ///     - if the provided string was not formatted correctly, or
+    ///     - if the provided modulus was not formatted correctly to create a [`Z`].
     /// - Returns a [`MathError`] of type
-    /// [`InvalidModulus`](MathError::InvalidModulus)
-    /// if the provided value is not greater than `1`.
+    ///     [`InvalidModulus`](MathError::InvalidModulus)
+    ///     if the provided value is not greater than `1`.
     /// - Returns a [`MathError`] of type
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let input_split: Vec<&str> = s.split("mod").collect();

--- a/src/integer_mod_q/z_q/sample/binomial.rs
+++ b/src/integer_mod_q/z_q/sample/binomial.rs
@@ -39,11 +39,11 @@ impl Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n < 1`.
+    ///     if `n < 1`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if `p ∉ (0,1)`.
+    ///     if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if `n` does not fit into an [`i64`].
+    ///     if `n` does not fit into an [`i64`].
     ///
     /// # Panics ...
     /// - if the modulus is not greater than `1`.

--- a/src/integer_mod_q/z_q/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/z_q/sample/discrete_gauss.rs
@@ -28,7 +28,7 @@ impl Zq {
     /// - `n`: specifies the range from which is sampled
     /// - `center`: specifies the position of the center with peak probability
     /// - `s`: specifies the Gaussian parameter, which is proportional
-    /// to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns new [`Zq`] sample chosen according to the specified discrete Gaussian
     /// distribution or a [`MathError`] if the modulus is chosen smaller than `2` or the
@@ -43,16 +43,16 @@ impl Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n <= 1` or `s <= 0`.
+    ///     if `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if the modulus is not greater than `1`.
     ///
     /// This function implements SampleZ according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-    /// Trapdoors for hard lattices and new cryptographic constructions.
-    /// In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-    /// <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+    ///     Trapdoors for hard lattices and new cryptographic constructions.
+    ///     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+    ///     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
     pub fn sample_discrete_gauss(
         modulus: impl Into<Modulus>,
         n: impl Into<Z>,

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -22,7 +22,7 @@ impl Zq {
     ///
     /// Parameters:
     /// - `modulus`: specifies the [`Modulus`](crate::integer_mod_q::Modulus)
-    /// of the new [`Zq`] instance and thus the size of the interval over which is sampled
+    ///     of the new [`Zq`] instance and thus the size of the interval over which is sampled
     ///
     /// Returns a new [`Zq`] instance with a value chosen
     /// uniformly at random in `[0, modulus)` or a [`MathError`]
@@ -37,7 +37,7 @@ impl Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    /// if the given modulus is smaller than or equal to `1`.
+    ///     if the given modulus is smaller than or equal to `1`.
     pub fn sample_uniform(modulus: impl Into<Z>) -> Result<Self, MathError> {
         let modulus: Z = modulus.into();
 

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -14,7 +14,7 @@
 /// Parameters:
 /// - `trait`: the trait that is implemented (e.g. [`Add`],[`Sub`], ...).
 /// - `trait_function`: the function the trait implements
-/// (e.g. add for [`Add`], ...).
+///     (e.g. add for [`Add`], ...).
 /// - `type`: the type the trait is implemented for (e.g. [`Z`],[`Q`])
 /// - `other_type`: the type the second part of the computation.
 /// - `output_type`: the type of the result.
@@ -47,7 +47,7 @@ pub(crate) use arithmetic_trait_borrowed_to_owned;
 /// Parameters:
 /// - `trait`: the trait that is implemented (e.g. [`Add`],[`Sub`], ...).
 /// - `trait_function`: the function the trait implements
-/// (e.g. add for [`Add`], ...).
+///     (e.g. add for [`Add`], ...).
 /// - `type`: the type the trait is implemented for (e.g. [`Z`],[`Q`], ...).
 /// - `other_type`: the type the second part of the computation.
 /// - `output_type`: the type of the result.
@@ -93,11 +93,11 @@ pub(crate) use arithmetic_trait_mixed_borrowed_owned;
 /// Parameters:
 /// - `trait`: the trait that is implemented (e.g. [`Add`],[`Sub`], ...).
 /// - `trait_function`: the function the trait implements
-/// (e.g. add for [`Add`], ...).
+///     (e.g. add for [`Add`], ...).
 /// - `output_type`: one type that is part of the computation and it is the
-/// result type (e.g. [`Z`],[`Q`], ...).
+///     result type (e.g. [`Z`],[`Q`], ...).
 /// - `other_type*`: the other types that is part of the computation
-/// (e.g. [`Z`],[`Q`], ...).
+///     (e.g. [`Z`],[`Q`], ...).
 ///
 /// Returns the owned and borrowed Implementation code for the
 /// [`*trait*`] trait with the signatures:
@@ -158,7 +158,7 @@ pub(crate) use arithmetic_between_types;
 /// Parameters:
 /// - `trait`: the trait that is implemented (e.g. [`Add`],[`Sub`], ...).
 /// - `trait_function`: the function the trait implements
-/// (e.g. add for [`Add`], ...).
+///     (e.g. add for [`Add`], ...).
 /// - `type`: the type the trait is implemented for (e.g. [`Z`],[`Q`])
 /// - `other_type`: the type the second part of the computation.
 /// - `output_type`: the type of the result.
@@ -191,11 +191,11 @@ pub(crate) use arithmetic_trait_reverse;
 /// Parameters:
 /// - `trait`: the trait that is implemented (e.g. [`Add`],[`Sub`], ...).
 /// - `trait_function`: the function the trait implements
-/// (e.g. add for [`Add`], ...).
+///     (e.g. add for [`Add`], ...).
 /// - `output_type`: one type that is part of the computation and it is the
-/// result type (e.g. [`Z`],[`Q`], ...).
+///     result type (e.g. [`Z`],[`Q`], ...).
 /// - `other_type*`: the other types that is part of the computation
-/// (e.g. [`Z`],[`Q`], ...).
+///     (e.g. [`Z`],[`Q`], ...).
 ///
 /// Returns the owned and borrowed Implementation code for the
 /// [`*trait*`] trait with the signatures:

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -20,7 +20,7 @@
 /// Implements a specified trait using implicit conversions to a bridge type.
 ///
 /// - ['Mul'](std::ops::Mul) with signature
-/// `($bridge_type, $type, Mul Scalar for $source_type)`
+///     `($bridge_type, $type, Mul Scalar for $source_type)`
 ///
 /// # Examples
 /// ```compile_fail
@@ -81,11 +81,11 @@ pub(crate) use implement_for_others;
 /// Several traits are already supported:
 ///
 /// - [`Evaluate`](crate::traits::Evaluate) with the signature
-/// `($bridge_type, $output_type, $type, Evaluate)`
+///     `($bridge_type, $output_type, $type, Evaluate)`
 /// - [`SetCoefficient`](crate::traits::SetCoefficient) with the signature
-/// `($bridge_type, $type, SetCoefficient)`
+///     `($bridge_type, $type, SetCoefficient)`
 /// - [`SetEntry`](crate::traits::SetEntry) with the signature
-/// `($bridge_type, $type, SetCoefficient)`
+///     `($bridge_type, $type, SetCoefficient)`
 ///
 /// # Examples
 /// ```compile_fail

--- a/src/macros/from.rs
+++ b/src/macros/from.rs
@@ -17,8 +17,9 @@
 ///   (e.g. [`Z`](crate::integer::Z), [`MatZ`](crate::integer::MatZ)).
 /// - `function`: The function that needs to be called for the conversion
 ///   (e.g. [`Z::from_i64()`])
-/// Returns the Implementation code for the [`From`] Trait with the signature:
-/// ```impl From<*source_type*> for *destination_type*```
+///
+///  Returns the Implementation code for the [`From`] Trait with the signature:
+///     ```impl From<*source_type*> for *destination_type*```
 macro_rules! from_trait {
     ($source_type:ident, $destination_type:ident, $( $function:ident )::*) => {
         impl From<$source_type> for $destination_type {
@@ -55,6 +56,7 @@ pub(crate) use from_trait;
 ///   (e.g. [`Z`](crate::integer::Z), [`MatZ`](crate::integer::MatZ)).
 /// - `function`: The function that needs to be called for the conversion
 ///   (e.g. [`Z::from_i64()`]).
+///
 /// Returns the Implementation code for the function `from_<source_type>`.
 ///
 /// # Examples

--- a/src/macros/from.rs
+++ b/src/macros/from.rs
@@ -14,9 +14,9 @@
 /// Input parameters:
 /// - `source_type`: the source identifier (e.g. [`i64`],[`u32`], ...).
 /// - `destination_type`: the destination identifier
-///   (e.g. [`Z`](crate::integer::Z), [`MatZ`](crate::integer::MatZ)).
+///     (e.g. [`Z`](crate::integer::Z), [`MatZ`](crate::integer::MatZ)).
 /// - `function`: The function that needs to be called for the conversion
-///   (e.g. [`Z::from_i64()`])
+///     (e.g. [`Z::from_i64()`])
 ///
 ///  Returns the Implementation code for the [`From`] Trait with the signature:
 ///     ```impl From<*source_type*> for *destination_type*```
@@ -53,9 +53,9 @@ pub(crate) use from_trait;
 /// - `source_type`: The source identifier (e.g. [`i64`],[`u32`], ...).
 /// - `bridge_type`: Type used for casting before calling the function.
 /// - `destination_type`: Return type of the generated function
-///   (e.g. [`Z`](crate::integer::Z), [`MatZ`](crate::integer::MatZ)).
+///     (e.g. [`Z`](crate::integer::Z), [`MatZ`](crate::integer::MatZ)).
 /// - `function`: The function that needs to be called for the conversion
-///   (e.g. [`Z::from_i64()`]).
+///     (e.g. [`Z::from_i64()`]).
 ///
 /// Returns the Implementation code for the function `from_<source_type>`.
 ///

--- a/src/macros/serialize.rs
+++ b/src/macros/serialize.rs
@@ -14,7 +14,7 @@
 /// Parameters:
 /// - `field_identifier`: the name of the field
 /// - `type`: the type for which [`Serialize`](serde::Serialize) is implemented
-/// (e.g. [`Z`](crate::integer::Z))
+///     (e.g. [`Z`](crate::integer::Z))
 ///
 /// ```impl Serialize for *type*```
 macro_rules! serialize {
@@ -40,7 +40,7 @@ macro_rules! serialize {
 /// Parameters:
 /// - `field_identifier`: the name of the field
 /// - `type`: the type for which [`Deserialize`](serde::Deserialize) is implemented
-/// (e.g. [`Z`](crate::integer::Z))
+///     (e.g. [`Z`](crate::integer::Z))
 ///
 /// ```impl Deserialize for *type*```
 macro_rules! deserialize {

--- a/src/rational/mat_q/arithmetic/mul.rs
+++ b/src/rational/mat_q/arithmetic/mul.rs
@@ -125,8 +125,8 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
-    ///  and `other` do not match for multiplication.
+    ///     [`MathError::MismatchingMatrixDimension`] if the dimensions of `self`
+    ///     and `other` do not match for multiplication.
     pub fn mul_safe(&self, other: &Self) -> Result<Self, MathError> {
         if self.get_num_columns() != other.get_num_rows() {
             return Err(MathError::MismatchingMatrixDimension(format!(

--- a/src/rational/mat_q/concat.rs
+++ b/src/rational/mat_q/concat.rs
@@ -39,8 +39,8 @@ impl Concatenate for &MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the matrices can not be concatenated due to mismatching dimensions.
+    ///     [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    ///     if the matrices can not be concatenated due to mismatching dimensions.
     fn concat_vertical(self, other: Self) -> Result<Self::Output, crate::error::MathError> {
         if self.get_num_columns() != other.get_num_columns() {
             return Err(MathError::MismatchingMatrixDimension(format!(
@@ -82,8 +82,8 @@ impl Concatenate for &MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the matrices can not be concatenated due to mismatching dimensions.
+    ///     [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
+    ///     if the matrices can not be concatenated due to mismatching dimensions.
     fn concat_horizontal(self, other: Self) -> Result<Self::Output, crate::error::MathError> {
         if self.get_num_rows() != other.get_num_rows() {
             return Err(MathError::MismatchingMatrixDimension(format!(

--- a/src/rational/mat_q/default.rs
+++ b/src/rational/mat_q/default.rs
@@ -74,7 +74,7 @@ impl MatQ {
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatQ::new`].
+    ///     For further information see [`MatQ::new`].
     pub fn identity(
         num_rows: impl TryInto<i64> + Display,
         num_cols: impl TryInto<i64> + Display,

--- a/src/rational/mat_q/determinant.rs
+++ b/src/rational/mat_q/determinant.rs
@@ -30,7 +30,7 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows and columns is not equal.
+    ///     if the number of rows and columns is not equal.
     pub fn det(&self) -> Result<Q, MathError> {
         if self.get_num_rows() != self.get_num_columns() {
             return Err(MathError::MismatchingMatrixDimension(

--- a/src/rational/mat_q/from.rs
+++ b/src/rational/mat_q/from.rs
@@ -91,14 +91,14 @@ impl FromStr for MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-    /// if the matrix is not formatted in a suitable way,
-    /// if the number of entries in rows is unequal,
-    /// if an entry contains a Nul byte, or
-    /// if an entry is not formatted correctly.
+    ///     - if the matrix is not formatted in a suitable way,
+    ///     - if the number of entries in rows is unequal,
+    ///     - if an entry contains a Nul byte, or
+    ///     - if an entry is not formatted correctly.
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.
-    /// For further information see [`MatQ::new`].
+    ///     For further information see [`MatQ::new`].
     fn from_str(string: &str) -> Result<Self, MathError> {
         let string_matrix = parse_matrix_string(string)?;
         let (num_rows, num_cols) = find_matrix_dimensions(&string_matrix)?;

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -81,7 +81,7 @@ impl GetEntry<Q> for MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn get_entry(
         &self,
         row: impl TryInto<i64> + Display,
@@ -124,7 +124,7 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the row is greater than the matrix or negative.
+    ///     if the number of the row is greater than the matrix or negative.
     pub fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let row_i64 = evaluate_index(row)?;
 
@@ -161,7 +161,7 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if the number of the column is greater than the matrix or negative.
+    ///     if the number of the column is greater than the matrix or negative.
     pub fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
         let column_i64 = evaluate_index(column)?;
 
@@ -209,7 +209,7 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if any provided row or column is greater than the matrix.
+    ///     if any provided row or column is greater than the matrix.
     ///
     /// # Panics ...
     /// - if `col_1 > col_2` or `row_1 > row_2`.

--- a/src/rational/mat_q/set.rs
+++ b/src/rational/mat_q/set.rs
@@ -61,7 +61,7 @@ impl<Rational: Into<Q>> SetEntry<Rational> for MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if `row` or `column` are greater than the matrix size.
+    ///     if `row` or `column` are greater than the matrix size.
     fn set_entry(
         &mut self,
         row: impl TryInto<i64> + Display,
@@ -91,7 +91,7 @@ impl MatQ {
     /// - `col_0`: specifies the column of `self` that should be modified
     /// - `other`: specifies the matrix providing the column replacing the column in `self`
     /// - `col_1`: specifies the column of `other` providing
-    /// the values replacing the original column in `self`
+    ///     the values replacing the original column in `self`
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if one of the specified columns is not part of its matrix
@@ -109,9 +109,9 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of columns is greater than the matrix dimensions or negative.
+    ///     if the number of columns is greater than the matrix dimensions or negative.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of rows of `self` and `other` differ.
+    ///     if the number of rows of `self` and `other` differ.
     pub fn set_column(
         &mut self,
         col_0: impl TryInto<i64> + Display,
@@ -149,7 +149,7 @@ impl MatQ {
     /// - `row_0`: specifies the row of `self` that should be modified
     /// - `other`: specifies the matrix providing the row replacing the row in `self`
     /// - `row_1`: specifies the row of `other` providing
-    /// the values replacing the original row in `self`
+    ///     the values replacing the original row in `self`
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// Otherwise, a [`MathError`] is returned if one of the specified rows is not part of its matrix
@@ -167,9 +167,9 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if the number of rows is greater than the matrix dimensions or negative.
+    ///     if the number of rows is greater than the matrix dimensions or negative.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    /// if the number of columns of `self` and `other` differ.
+    ///     if the number of columns of `self` and `other` differ.
     pub fn set_row(
         &mut self,
         row_0: impl TryInto<i64> + Display,
@@ -226,7 +226,7 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    /// if row or column are greater than the matrix size.
+    ///     if row or column are greater than the matrix size.
     pub fn swap_entries(
         &mut self,
         row_0: impl TryInto<i64> + Display,
@@ -265,7 +265,7 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if one of the given columns is greater than the matrix or negative.
+    ///     if one of the given columns is greater than the matrix or negative.
     pub fn swap_columns(
         &mut self,
         col_0: impl TryInto<i64> + Display,
@@ -306,7 +306,7 @@ impl MatQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    /// if one of the given rows is greater than the matrix or negative.
+    ///     if one of the given rows is greater than the matrix or negative.
     pub fn swap_rows(
         &mut self,
         row_0: impl TryInto<i64> + Display,

--- a/src/rational/mat_q/sort.rs
+++ b/src/rational/mat_q/sort.rs
@@ -21,7 +21,7 @@ impl MatQ {
     ///
     /// Parameters:
     /// - `cond_func`: computes values implementing [`Ord`] over the columns of the specified matrix.
-    /// These values are then used to re-order / sort the rows of the matrix.
+    ///     These values are then used to re-order / sort the rows of the matrix.
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// A [`MathError`] is returned if the execution of `cond_func` returned an error.
@@ -87,7 +87,7 @@ impl MatQ {
     ///
     /// Parameters:
     /// - `cond_func`: computes values implementing [`Ord`] over the columns of the specified matrix.
-    /// These values are then used to re-order / sort the columns of the matrix.
+    ///     These values are then used to re-order / sort the columns of the matrix.
     ///
     /// Returns an empty `Ok` if the action could be performed successfully.
     /// A [`MathError`] is returned if the execution of `cond_func` returned an error.

--- a/src/rational/mat_q/vector/dot_product.rs
+++ b/src/rational/mat_q/vector/dot_product.rs
@@ -39,9 +39,9 @@ impl MatQ {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatQ`] instance is not a (row or column) vector.
+    ///     the given [`MatQ`] instance is not a (row or column) vector.
     /// - Returns a [`MathError`] of type [`MathError::MismatchingMatrixDimension`] if
-    /// the given vectors have different lengths.
+    ///     the given vectors have different lengths.
     pub fn dot_product(&self, other: &Self) -> Result<Q, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(

--- a/src/rational/mat_q/vector/norm.rs
+++ b/src/rational/mat_q/vector/norm.rs
@@ -35,7 +35,7 @@ impl MatQ {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatQ`] instance is not a (row or column) vector.
+    ///     the given [`MatQ`] instance is not a (row or column) vector.
     pub fn norm_eucl_sqrd(&self) -> Result<Q, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(
@@ -74,7 +74,7 @@ impl MatQ {
     ///
     /// Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
-    /// the given [`MatQ`] instance is not a (row or column) vector.
+    ///     the given [`MatQ`] instance is not a (row or column) vector.
     pub fn norm_infty(&self) -> Result<Q, MathError> {
         if !self.is_vector() {
             return Err(MathError::VectorFunctionCalledOnNonVector(

--- a/src/rational/poly_over_q/coefficient_embedding.rs
+++ b/src/rational/poly_over_q/coefficient_embedding.rs
@@ -25,7 +25,7 @@ impl IntoCoefficientEmbedding<MatQ> for &PolyOverQ {
     ///
     /// Parameters:
     /// - `size`: determines the number of rows of the embedding. It has to be larger
-    /// than the degree of the polynomial.
+    ///     than the degree of the polynomial.
     ///
     /// Returns a coefficient embedding as a column vector if `size` is large enough.
     ///
@@ -45,7 +45,7 @@ impl IntoCoefficientEmbedding<MatQ> for &PolyOverQ {
     ///
     /// # Panics ...
     /// - if `size` is not larger than the degree of the polynomial, i.e.
-    /// not all coefficients can be embedded.
+    ///     not all coefficients can be embedded.
     fn into_coefficient_embedding(self, size: impl Into<i64>) -> MatQ {
         let size = size.into();
         let length = self.get_degree() + 1;

--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -48,12 +48,12 @@ impl FromStr for PolyOverQ {
     /// ```
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`StringConversionError`](MathError::StringConversionError)
-    /// if the provided string contains a `Null` Byte,
-    /// if the provided value did not contain two whitespaces, or
-    /// if the provided string was not formatted correctly or the number of
-    /// coefficients was smaller than the number provided at the start of the
-    /// provided string.
+    ///     [`StringConversionError`](MathError::StringConversionError)
+    ///     - if the provided string contains a `Null` Byte,
+    ///     - if the provided value did not contain two whitespaces, or
+    ///     - if the provided string was not formatted correctly or the number of
+    ///         coefficients was smaller than the number provided at the start of the
+    ///         provided string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut res = Self::default();
 

--- a/src/rational/poly_over_q/get.rs
+++ b/src/rational/poly_over_q/get.rs
@@ -43,7 +43,7 @@ impl GetCoefficient<Q> for PolyOverQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     fn get_coeff(&self, index: impl TryInto<i64> + Display) -> Result<Q, MathError> {
         let mut out = Q::default();
         let index = evaluate_index(index)?;

--- a/src/rational/poly_over_q/set.rs
+++ b/src/rational/poly_over_q/set.rs
@@ -42,7 +42,7 @@ impl<Rational: Into<Q>> SetCoefficient<Rational> for PolyOverQ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-    /// either the index is negative or it does not fit into an [`i64`].
+    ///     either the index is negative or it does not fit into an [`i64`].
     fn set_coeff(
         &mut self,
         index: impl TryInto<i64> + Display,

--- a/src/rational/q/arithmetic/div.rs
+++ b/src/rational/q/arithmetic/div.rs
@@ -115,8 +115,7 @@ impl Q {
     ///
     ///  # Errors
     /// - Returns a [`MathError`] of type [`MathError::DivisionByZeroError`] if
-    /// the `divisor` is `0`.
-    ///
+    ///     the `divisor` is `0`.
     pub fn div_safe(&self, divisor: &Q) -> Result<Q, MathError> {
         if 0 != unsafe { fmpq_is_zero(&divisor.value) } {
             return Err(MathError::DivisionByZeroError(format!(

--- a/src/rational/q/arithmetic/exp.rs
+++ b/src/rational/q/arithmetic/exp.rs
@@ -62,7 +62,7 @@ impl Q {
     ///
     /// Parameters:
     /// - `length_taylor_polynomial`: the length of the taylor series
-    /// approximation of the exponential function
+    ///     approximation of the exponential function
     ///
     /// Returns `e^self`.
     ///

--- a/src/rational/q/arithmetic/logarithm.rs
+++ b/src/rational/q/arithmetic/logarithm.rs
@@ -31,8 +31,8 @@ impl Q {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`NonPositive`](MathError::NonPositive) if `self` is not
-    ///  greater than `0`.
+    ///     [`NonPositive`](MathError::NonPositive) if `self` is not
+    ///     greater than `0`.
     pub fn ln(&self) -> Result<Self, MathError> {
         if self <= &Q::ZERO {
             Err(MathError::NonPositive(self.to_string()))
@@ -67,10 +67,10 @@ impl Q {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if the `base` is not greater than `1`.
+    ///     if the `base` is not greater than `1`.
     /// - Returns a [`MathError`] of type
-    /// [`NonPositive`](MathError::NonPositive) if `self` is not
-    ///  greater than `0`.
+    ///     [`NonPositive`](MathError::NonPositive) if `self` is not
+    ///     greater than `0`.
     pub fn log(&self, base: impl Into<Z>) -> Result<Q, MathError> {
         let base: Z = base.into();
         if base <= Z::ONE {

--- a/src/rational/q/arithmetic/logarithm.rs
+++ b/src/rational/q/arithmetic/logarithm.rs
@@ -164,9 +164,9 @@ mod test_log {
         let z_0 = Q::from(i64::MAX as u64 + 1);
         let z_1 = Q::from(f64::MAX);
         let z_2 = Q::from(i32::MAX);
-        let cmp_0 = Q::try_from((&63, &1)).unwrap();
+        let cmp_0 = Q::from((&63, &1));
         let cmp_1 = Q::from(f64::MAX.log2());
-        let max_distance = Q::try_from((&1, &1_000_000_000)).unwrap();
+        let max_distance = Q::from((&1, &1_000_000_000));
 
         let res_0 = z_0.log(2).unwrap();
         let res_1 = z_1.log(2).unwrap();

--- a/src/rational/q/arithmetic/pow.rs
+++ b/src/rational/q/arithmetic/pow.rs
@@ -35,7 +35,7 @@ impl<Integer: Into<Z>> Pow<Integer> for Q {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidExponent`](MathError::InvalidExponent)
-    /// if the provided exponent is negative and the base value of `self` is not invertible.
+    ///     if the provided exponent is negative and the base value of `self` is not invertible.
     fn pow(&self, exp: Integer) -> Result<Self::Output, MathError> {
         let exp = exp.into();
         if self == &Q::ZERO && exp < Z::ZERO {

--- a/src/rational/q/arithmetic/root.rs
+++ b/src/rational/q/arithmetic/root.rs
@@ -13,7 +13,7 @@
 //! - `a/b` is the "correct" result
 //! - `e_a` and `e_b` are the error of `a` and `b` resp.
 //! - `p` is the maximum error of a sqrt on [`Z`] values
-//!  => `|e_a| <= p` and `|e_b| <= p`
+//!     => `|e_a| <= p` and `|e_b| <= p`
 //!
 //! ```Q::sqrt(x/y) = (a+e_a)/(b+e_b) = a/b + (e_a*b - a*e_b)/(b*(b+e_b))```
 //!

--- a/src/rational/q/distance.rs
+++ b/src/rational/q/distance.rs
@@ -18,7 +18,7 @@ impl<Rational: Into<Q>> Distance<Rational> for Q {
     ///
     /// Parameters:
     /// - `other`: specifies one of the [`Q`] values whose distance
-    /// is calculated to `self`
+    ///     is calculated to `self`
     ///
     /// Returns the absolute difference, i.e. distance between the two given [`Q`]
     /// instances as a new [`Q`] instance.

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -70,11 +70,11 @@ impl FromStr for Q {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
-    /// [`StringConversionError`](MathError::StringConversionError)
-    /// if the provided string was not formatted correctly.
+    ///     [`StringConversionError`](MathError::StringConversionError)
+    ///     if the provided string was not formatted correctly.
     /// - Returns a [`MathError`] of type
-    /// [`DivisionByZeroError`](MathError::DivisionByZeroError)
-    /// if the provided string has `0` as the denominator.
+    ///     [`DivisionByZeroError`](MathError::DivisionByZeroError)
+    ///     if the provided string has `0` as the denominator.
     fn from_str(s: &str) -> Result<Self, MathError> {
         if s.contains(char::is_whitespace) {
             return Err(StringConversionError::InvalidStringToQInput(s.to_owned()))?;

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -607,14 +607,14 @@ mod test_try_from_int_int {
         let numerator = 10;
         let denominator = 15;
 
-        let q_1 = Q::try_from((&(numerator as u8), &(denominator as i8))).unwrap();
-        let q_2 = Q::try_from((&(numerator as u16), &(denominator as i16))).unwrap();
-        let q_3 = Q::try_from((&(numerator as u32), &(denominator))).unwrap();
-        let q_4 = Q::try_from((&(numerator as u64), &(denominator as i64))).unwrap();
-        let q_5 = Q::try_from((&Z::from(numerator), &Z::from(denominator))).unwrap();
+        let q_1 = Q::from((&(numerator as u8), &(denominator as i8)));
+        let q_2 = Q::from((&(numerator as u16), &(denominator as i16)));
+        let q_3 = Q::from((&(numerator as u32), &(denominator)));
+        let q_4 = Q::from((&(numerator as u64), &(denominator as i64)));
+        let q_5 = Q::from((&Z::from(numerator), &Z::from(denominator)));
 
-        let q_6 = Q::try_from((&(numerator as i16), &(denominator as u16))).unwrap();
-        let q_7 = Q::try_from((&(numerator as i16), &(denominator as i16))).unwrap();
+        let q_6 = Q::from((&(numerator as i16), &(denominator as u16)));
+        let q_7 = Q::from((&(numerator as i16), &(denominator as i16)));
 
         assert_eq!(q_1, q_2);
         assert_eq!(q_1, q_3);
@@ -632,8 +632,8 @@ mod test_try_from_int_int {
         let numerator_z = Z::from(numerator);
         let denominator_z = Z::from(denominator);
 
-        let q_1 = Q::try_from((&numerator, &denominator)).unwrap();
-        let q_2 = Q::try_from((&numerator_z, &denominator_z)).unwrap();
+        let q_1 = Q::from((&numerator, &denominator));
+        let q_2 = Q::from((&numerator_z, &denominator_z));
 
         assert_eq!(q_1, q_2);
     }
@@ -645,7 +645,7 @@ mod test_try_from_int_int {
         let numerator = 10;
         let denominator = 0;
 
-        let _ = Q::try_from((&numerator, &denominator));
+        let _ = Q::from((&numerator, &denominator));
     }
 
     /// Test with either negative denominator or numerator
@@ -654,8 +654,8 @@ mod test_try_from_int_int {
         let numerator = 10;
         let denominator = -1;
 
-        let q_1 = Q::try_from((&numerator, &denominator)).unwrap();
-        let q_2 = Q::try_from((&-numerator, &-denominator)).unwrap();
+        let q_1 = Q::from((&numerator, &denominator));
+        let q_2 = Q::from((&-numerator, &-denominator));
 
         assert_eq!(q_1, q_2);
     }
@@ -666,12 +666,12 @@ mod test_try_from_int_int {
         let numerator = 10;
         let denominator = 1;
 
-        let q_1 = Q::try_from((&numerator, &denominator)).unwrap();
-        let q_2 = Q::try_from((&-numerator, &-denominator)).unwrap();
-        let q_3 = Q::try_from((&(numerator * 2), &(denominator * 2))).unwrap();
+        let q_1 = Q::from((&numerator, &denominator));
+        let q_2 = Q::from((&-numerator, &-denominator));
+        let q_3 = Q::from((&(numerator * 2), &(denominator * 2)));
 
-        let q_4_negative = Q::try_from((&-numerator, &denominator)).unwrap();
-        let q_5_negative = Q::try_from((&numerator, &-denominator)).unwrap();
+        let q_4_negative = Q::from((&-numerator, &denominator));
+        let q_5_negative = Q::from((&numerator, &-denominator));
 
         assert_eq!(q_1, q_2);
         assert_eq!(q_1, q_3);
@@ -688,13 +688,12 @@ mod test_try_from_int_int {
         let numerator_z = Z::from(numerator);
         let denominator_z = Z::from(denominator);
 
-        let q_1 = Q::try_from((&numerator, &denominator)).unwrap();
-        let q_2 = Q::try_from((&-numerator, &-denominator)).unwrap();
-        let q_3 = Q::try_from((&numerator_z, &denominator_z)).unwrap();
-        let q_4 =
-            Q::try_from((&(&numerator_z * Z::from(2)), &(&denominator_z * Z::from(2)))).unwrap();
-        let q_5_negative = Q::try_from((&(&numerator_z * Z::from(-1)), &denominator_z)).unwrap();
-        let q_6_negative = Q::try_from((&numerator_z, &(&denominator_z * Z::from(-1)))).unwrap();
+        let q_1 = Q::from((&numerator, &denominator));
+        let q_2 = Q::from((&-numerator, &-denominator));
+        let q_3 = Q::from((&numerator_z, &denominator_z));
+        let q_4 = Q::from((&(&numerator_z * Z::from(2)), &(&denominator_z * Z::from(2))));
+        let q_5_negative = Q::from((&(&numerator_z * Z::from(-1)), &denominator_z));
+        let q_6_negative = Q::from((&numerator_z, &(&denominator_z * Z::from(-1))));
 
         assert_eq!(q_1, q_2);
         assert_eq!(q_1, q_3);

--- a/src/rational/q/rounding.rs
+++ b/src/rational/q/rounding.rs
@@ -90,7 +90,7 @@ impl Q {
     ///
     /// Parameters:
     /// - `precision`: the precision the new value can differ from `self`.
-    /// Note that the absolute value is relevant, not the sign.
+    ///     Note that the absolute value is relevant, not the sign.
     ///
     /// Returns the simplest [`Q`] within the defined range.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -245,7 +245,7 @@ pub trait IntoCoefficientEmbedding<T> {
     ///
     /// Parameters:
     /// - `size`: determines the length of the object in which the coefficients are
-    /// embedded, e.g. length of the vector
+    ///     embedded, e.g. length of the vector
     fn into_coefficient_embedding(self, size: impl Into<i64>) -> T;
 }
 

--- a/src/utils/collective_evaluation.rs
+++ b/src/utils/collective_evaluation.rs
@@ -15,7 +15,7 @@ use crate::error::MathError;
 /// in a matrix, and check if the corresponding vectors in the matrix are of equal length.
 /// This function checks whether:
 /// - The `index_vector_0` and `index_vector_1` are both referencing a row/column within the matrix,
-/// i.e. it is smaller than the number of rows/columns of the respective matrix entered by the upper bound.
+///     i.e. it is smaller than the number of rows/columns of the respective matrix entered by the upper bound.
 /// - The referenced vectors are of equal length because replacing the vector is not properly defined otherwise
 ///
 /// Parameters:
@@ -51,9 +51,9 @@ use crate::error::MathError;
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-/// if the number of rows is greater than the matrix dimensions or negative.
+///     if the number of rows is greater than the matrix dimensions or negative.
 /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-/// if the number of columns of `self` and `other` differ.
+///     if the number of columns of `self` and `other` differ.
 pub(crate) fn evaluate_vec_dimensions_set_row_or_col(
     callee: &str,
     index_vector_0: i64,

--- a/src/utils/dimensions.rs
+++ b/src/utils/dimensions.rs
@@ -21,8 +21,8 @@ use crate::error::{MathError, StringConversionError};
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-/// if the number of rows or columns is too large (must fit into [`i64`]) or
-/// if the number of entries in rows is unequal.
+///     - if the number of rows or columns is too large (must fit into [`i64`]) or
+///     - if the number of entries in rows is unequal.
 pub(crate) fn find_matrix_dimensions<T>(matrix: &Vec<Vec<T>>) -> Result<(i64, i64), MathError> {
     let num_rows = matrix.len();
 

--- a/src/utils/index.rs
+++ b/src/utils/index.rs
@@ -30,7 +30,7 @@ use std::fmt::Display;
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-/// either the index is negative or it does not fit into an [`i64`].
+///     either the index is negative or it does not fit into an [`i64`].
 pub fn evaluate_index(index: impl TryInto<i64> + Display) -> Result<i64, MathError> {
     // the index must fit into an [`i64`]
 
@@ -88,7 +88,7 @@ pub fn evaluate_index(index: impl TryInto<i64> + Display) -> Result<i64, MathErr
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-/// either the index is negative or it does not fit into an [`i64`].
+///     either the index is negative or it does not fit into an [`i64`].
 pub fn evaluate_indices(
     index1: impl TryInto<i64> + Display,
     index2: impl TryInto<i64> + Display,
@@ -111,7 +111,7 @@ pub fn evaluate_indices(
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-/// if the number of rows or columns is greater than the matrix or negative.
+///     if the number of rows or columns is greater than the matrix or negative.
 pub fn evaluate_indices_for_matrix<S: GetNumRows + GetNumColumns>(
     matrix: &S,
     row: impl TryInto<i64> + Display,
@@ -199,7 +199,7 @@ mod test_eval_index {
         assert!(evaluate_index(u16::MAX).is_ok());
         assert!(evaluate_index(u32::MAX).is_ok());
 
-        assert!(evaluate_index(&Z::from(10)).is_ok());
+        assert!(evaluate_index(Z::from(10)).is_ok());
     }
 
     /// Ensure that integers which can not be converted to an [`i64`]

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -30,7 +30,7 @@ use string_builder::Builder;
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-/// if the matrix is not formatted in a suitable way.
+///     if the matrix is not formatted in a suitable way.
 pub(crate) fn parse_matrix_string(string: &str) -> Result<Vec<Vec<String>>, MathError> {
     // check if the matrix format is correct
     let entry_str = r"([^\[\],]+)";

--- a/src/utils/sample/binomial.rs
+++ b/src/utils/sample/binomial.rs
@@ -33,11 +33,11 @@ use rand_distr::{Binomial, Distribution};
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-/// if `n < 1`.
+///     if `n < 1`.
 /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-/// if `p ∉ (0,1)`.
+///     if `p ∉ (0,1)`.
 /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-/// if `n` does not fit into an [`i64`].
+///     if `n` does not fit into an [`i64`].
 pub(crate) fn sample_binomial(n: &Z, p: &Q) -> Result<u64, MathError> {
     if p <= &Q::ZERO || p >= &Q::ONE {
         return Err(MathError::InvalidInterval(format!(

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -12,9 +12,9 @@
 //! The main references are listed in the following
 //! and will be further referenced in submodules by these numbers:
 //! - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-//! Trapdoors for hard lattices and new cryptographic constructions.
-//! In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-//! <https://citeseerx.ist.psu.edu/document?doi=d9f54077d568784c786f7b1d030b00493eb3ae35>
+//!     Trapdoors for hard lattices and new cryptographic constructions.
+//!     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+//!     <https://citeseerx.ist.psu.edu/document?doi=d9f54077d568784c786f7b1d030b00493eb3ae35>
 
 use super::uniform::sample_uniform_rejection;
 use crate::{
@@ -35,7 +35,7 @@ use rand::RngCore;
 /// - `n`: specifies the range from which is sampled
 /// - `center`: specifies the position of the center with peak probability
 /// - `s`: specifies the Gaussian parameter, which is proportional
-/// to the standard deviation `sigma * sqrt(2 * pi) = s`
+///     to the standard deviation `sigma * sqrt(2 * pi) = s`
 ///
 /// Returns a sample chosen according to the specified discrete Gaussian distribution or
 /// a [`MathError`] if the specified parameters were not chosen appropriately,
@@ -54,7 +54,7 @@ use rand::RngCore;
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-/// if the `n <= 1` or `s <= 0`.
+///     if the `n <= 1` or `s <= 0`.
 pub(crate) fn sample_z(n: &Z, center: &Q, s: &Q) -> Result<Z, MathError> {
     if n <= &Z::ONE {
         return Err(MathError::InvalidIntegerInput(format!(
@@ -95,7 +95,7 @@ pub(crate) fn sample_z(n: &Z, center: &Q, s: &Q) -> Result<Z, MathError> {
 /// - `x`: specifies the value/ sample for which the Gaussian function's value is computed
 /// - `c`: specifies the position of the center with peak probability
 /// - `s`: specifies the Gaussian parameter, which is proportional
-/// to the standard deviation `sigma * sqrt(2 * pi) = s`
+///     to the standard deviation `sigma * sqrt(2 * pi) = s`
 ///
 /// Returns the computed value of the Gaussian function for `x`.
 ///
@@ -129,7 +129,7 @@ fn gaussian_function(x: &Z, c: &Q, s: &Q) -> Q {
 /// - `n`: specifies the range from which [`sample_z`] samples
 /// - `center`: specifies the positions of the center with peak probability
 /// - `s`: specifies the Gaussian parameter, which is proportional
-/// to the standard deviation `sigma * sqrt(2 * pi) = s`
+///     to the standard deviation `sigma * sqrt(2 * pi) = s`
 ///
 /// Returns a vector with discrete gaussian error based on a lattice point
 /// as in [\[1\]](<index.html#:~:text=[1]>): SampleD.
@@ -148,11 +148,11 @@ fn gaussian_function(x: &Z, c: &Q, s: &Q) -> Q {
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-/// if the `n <= 1` or `s <= 0`.
+///     if the `n <= 1` or `s <= 0`.
 /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-/// if the number of rows of the `basis` and `center` differ.
+///     if the number of rows of the `basis` and `center` differ.
 /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-/// if `center` is not a column vector.
+///     if `center` is not a column vector.
 pub(crate) fn sample_d(basis: &MatZ, n: &Z, center: &MatQ, s: &Q) -> Result<MatZ, MathError> {
     let basis_gso = MatQ::from(basis).gso();
     sample_d_precomputed_gso(basis, &basis_gso, n, center, s)
@@ -170,7 +170,7 @@ pub(crate) fn sample_d(basis: &MatZ, n: &Z, center: &MatQ, s: &Q) -> Result<MatZ
 /// - `n`: specifies the range from which [`sample_z`] samples
 /// - `center`: specifies the positions of the center with peak probability
 /// - `s`: specifies the Gaussian parameter, which is proportional
-/// to the standard deviation `sigma * sqrt(2 * pi) = s`
+///     to the standard deviation `sigma * sqrt(2 * pi) = s`
 ///
 /// Returns a vector with discrete gaussian error based on a lattice point
 /// as in [\[1\]](<index.html#:~:text=[1]>): SampleD.
@@ -191,11 +191,11 @@ pub(crate) fn sample_d(basis: &MatZ, n: &Z, center: &MatQ, s: &Q) -> Result<MatZ
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-/// if the `n <= 1` or `s <= 0`.
+///     if the `n <= 1` or `s <= 0`.
 /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-/// if the number of rows of the `basis` and `center` differ.
+///     if the number of rows of the `basis` and `center` differ.
 /// - Returns a [`MathError`] of type [`StringConversionError`](MathError::StringConversionError)
-/// if `center` is not a column vector.
+///     if `center` is not a column vector.
 ///
 /// # Panics...
 /// - if the number of rows/columns of `basis_gso` and `basis` mismatch.

--- a/src/utils/sample/uniform.rs
+++ b/src/utils/sample/uniform.rs
@@ -16,7 +16,7 @@ use rand::RngCore;
 ///
 /// Parameters:
 /// - `interval_size`: specifies the size of the interval
-/// over which the samples are drawn
+///     over which the samples are drawn
 ///
 /// Returns a uniform at random chosen [`Z`] instance in `[0, interval_size)`.
 ///
@@ -34,7 +34,7 @@ use rand::RngCore;
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-/// if the interval is chosen smaller than or equal to `1`.
+///     if the interval is chosen smaller than or equal to `1`.
 pub(crate) fn sample_uniform_rejection(interval_size: &Z) -> Result<Z, MathError> {
     if interval_size <= &Z::ONE {
         return Err(MathError::InvalidInterval(format!(


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR corrects newly marked warnings by clippy that were introduced by recent updates of clippy.
- [x] lists in doc comments where not indented correctly when linebreaks occur. The respective check in clippy was introduced in patch 1.80.0 (March 30th 2024) https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation
- [x] fix clippy errors in tests that were not marked before
- [x] Update version of "derive_more"


<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] The documentation does not change a lot as the previous formulation passed the same way, but was simply flagged by clippy. (But now the doc-comments in the code are better to read)
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The doc comments fit our style guide
