### PR TITLE
Make `Q::simplify` more viable

### DIFF
--- a/src/rational/q/default.rs
+++ b/src/rational/q/default.rs
@@ -111,6 +111,51 @@ impl Q {
             den: fmpz(842468587426513207),
         },
     };
+
+    /// Returns an instantiation of [`Q`] with value `2^62 - 1`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///  
+    /// let a: Q = Q::MAX62;
+    /// ```
+    pub const MAX62: Q = Q {
+        value: fmpq {
+            num: fmpz(i64::pow(2, 62) - 1),
+            den: fmpz(1),
+        },
+    };
+
+    /// Returns an instantiation of [`Q`] with value `1 / (2^62 - 1)`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///  
+    /// let a: Q = Q::INV_MAX62;
+    /// ```
+    pub const INV_MAX62: Q = Q {
+        value: fmpq {
+            num: fmpz(1),
+            den: fmpz(i64::pow(2, 62) - 1),
+        },
+    };
+
+    /// Returns an instantiation of [`Q`] with value `1 / (2^32 - 1)`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///  
+    /// let a: Q = Q::INV_MAX32;
+    /// ```
+    pub const INV_MAX32: Q = Q {
+        value: fmpq {
+            num: fmpz(1),
+            den: fmpz(i64::pow(2, 32) - 1),
+        },
+    };
 }
 
 #[cfg(test)]
@@ -139,5 +184,23 @@ mod tests_init {
     #[test]
     fn init_minus_one() {
         assert_eq!(Q::from(-1), Q::MINUS_ONE);
+    }
+
+    /// Ensure that `MAX62` initializes [`Q`] with `2^62 - 1`.
+    #[test]
+    fn init_max62() {
+        assert_eq!(Q::from(i64::pow(2, 62) - 1), Q::MAX62);
+    }
+
+    /// Ensure that `INV_MAX62` initializes [`Q`] with `1 / (2^62 - 1)`.
+    #[test]
+    fn init_inv_max62() {
+        assert_eq!(Q::from((1, i64::pow(2, 62) - 1)), Q::INV_MAX62);
+    }
+
+    /// Ensure that `INV_MAX32` initializes [`Q`] with `1 / (2^32 - 1)`.
+    #[test]
+    fn init_inv_max32() {
+        assert_eq!(Q::from((1, i64::pow(2, 32) - 1)), Q::INV_MAX32);
     }
 }

--- a/src/rational/q/default.rs
+++ b/src/rational/q/default.rs
@@ -156,6 +156,36 @@ impl Q {
             den: fmpz(i64::pow(2, 32) - 1),
         },
     };
+
+    /// Returns an instantiation of [`Q`] with value `1 / (2^16 - 1)`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///  
+    /// let a: Q = Q::INV_MAX16;
+    /// ```
+    pub const INV_MAX16: Q = Q {
+        value: fmpq {
+            num: fmpz(1),
+            den: fmpz(i64::pow(2, 16) - 1),
+        },
+    };
+
+    /// Returns an instantiation of [`Q`] with value `1 / (2^8 - 1)`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///  
+    /// let a: Q = Q::INV_MAX8;
+    /// ```
+    pub const INV_MAX8: Q = Q {
+        value: fmpq {
+            num: fmpz(1),
+            den: fmpz(i64::pow(2, 8) - 1),
+        },
+    };
 }
 
 #[cfg(test)]
@@ -202,5 +232,17 @@ mod tests_init {
     #[test]
     fn init_inv_max32() {
         assert_eq!(Q::from((1, i64::pow(2, 32) - 1)), Q::INV_MAX32);
+    }
+
+    /// Ensure that `INV_MAX16` initializes [`Q`] with `1 / (2^16 - 1)`.
+    #[test]
+    fn init_inv_max16() {
+        assert_eq!(Q::from((1, i64::pow(2, 16) - 1)), Q::INV_MAX16);
+    }
+
+    /// Ensure that `INV_MAX8` initializes [`Q`] with `1 / (2^8 - 1)`.
+    #[test]
+    fn init_inv_max8() {
+        assert_eq!(Q::from((1, i64::pow(2, 8) - 1)), Q::INV_MAX8);
     }
 }

--- a/src/rational/q/default.rs
+++ b/src/rational/q/default.rs
@@ -142,6 +142,21 @@ impl Q {
         },
     };
 
+    /// Returns an instantiation of [`Q`] with value `2^32 - 1`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///  
+    /// let a: Q = Q::MAX32;
+    /// ```
+    pub const MAX32: Q = Q {
+        value: fmpq {
+            num: fmpz(i64::pow(2, 32) - 1),
+            den: fmpz(1),
+        },
+    };
+
     /// Returns an instantiation of [`Q`] with value `1 / (2^32 - 1)`.
     ///
     /// # Examples
@@ -157,6 +172,21 @@ impl Q {
         },
     };
 
+    /// Returns an instantiation of [`Q`] with value `2^16 - 1`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///  
+    /// let a: Q = Q::MAX16;
+    /// ```
+    pub const MAX16: Q = Q {
+        value: fmpq {
+            num: fmpz(i64::pow(2, 16) - 1),
+            den: fmpz(1),
+        },
+    };
+
     /// Returns an instantiation of [`Q`] with value `1 / (2^16 - 1)`.
     ///
     /// # Examples
@@ -169,6 +199,21 @@ impl Q {
         value: fmpq {
             num: fmpz(1),
             den: fmpz(i64::pow(2, 16) - 1),
+        },
+    };
+
+    /// Returns an instantiation of [`Q`] with value `2^8 - 1`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    ///  
+    /// let a: Q = Q::MAX8;
+    /// ```
+    pub const MAX8: Q = Q {
+        value: fmpq {
+            num: fmpz(i64::pow(2, 8) - 1),
+            den: fmpz(1),
         },
     };
 
@@ -228,16 +273,34 @@ mod tests_init {
         assert_eq!(Q::from((1, i64::pow(2, 62) - 1)), Q::INV_MAX62);
     }
 
+    /// Ensure that `MAX32` initializes [`Q`] with `2^32 - 1`.
+    #[test]
+    fn init_max32() {
+        assert_eq!(Q::from(i64::pow(2, 32) - 1), Q::MAX32);
+    }
+
     /// Ensure that `INV_MAX32` initializes [`Q`] with `1 / (2^32 - 1)`.
     #[test]
     fn init_inv_max32() {
         assert_eq!(Q::from((1, i64::pow(2, 32) - 1)), Q::INV_MAX32);
     }
 
+    /// Ensure that `MAX16` initializes [`Q`] with `2^16 - 1`.
+    #[test]
+    fn init_max16() {
+        assert_eq!(Q::from(i64::pow(2, 16) - 1), Q::MAX16);
+    }
+
     /// Ensure that `INV_MAX16` initializes [`Q`] with `1 / (2^16 - 1)`.
     #[test]
     fn init_inv_max16() {
         assert_eq!(Q::from((1, i64::pow(2, 16) - 1)), Q::INV_MAX16);
+    }
+
+    /// Ensure that `MAX8` initializes [`Q`] with `2^8 - 1`.
+    #[test]
+    fn init_max8() {
+        assert_eq!(Q::from(i64::pow(2, 8) - 1), Q::MAX8);
     }
 
     /// Ensure that `INV_MAX8` initializes [`Q`] with `1 / (2^8 - 1)`.

--- a/src/rational/q/rounding.rs
+++ b/src/rational/q/rounding.rs
@@ -256,7 +256,7 @@ mod test_round {
 
 #[cfg(test)]
 mod test_simplify {
-    use crate::rational::Q;
+    use crate::{integer::Z, rational::Q, traits::Distance};
 
     /// Ensure that negative precision works as expected
     #[test]
@@ -289,6 +289,23 @@ mod test_simplify {
         let simplified = value.simplify(&precision);
         assert!(&value - &precision <= simplified && simplified <= &value + &precision);
         assert!(Q::from((i64::MAX - 2, i64::MAX)) <= simplified && simplified <= 1.into());
+    }
+
+    /// Ensure max_bits of denominator are not bigger than 1/2 * precision
+    #[test]
+    fn max_bits_denominator() {
+        let value = Q::PI;
+        let precisions = [Q::INV_MAX8, Q::INV_MAX16, Q::INV_MAX32];
+
+        for precision in precisions {
+            let inv_precision = precision.inverse().unwrap().get_numerator();
+            let inv_precision = inv_precision.div_ceil(2);
+
+            let simplified = value.simplify(&precision);
+            let denominator = simplified.get_denominator();
+
+            assert!(denominator.distance(Z::ZERO) < inv_precision);
+        }
     }
 
     /// Ensure that a value which can not be simplified is not changed

--- a/src/rational/q/rounding.rs
+++ b/src/rational/q/rounding.rs
@@ -298,7 +298,7 @@ mod test_simplify {
         let precisions = [Q::INV_MAX8, Q::INV_MAX16, Q::INV_MAX32];
 
         for precision in precisions {
-            let inv_precision = precision.inverse().unwrap().get_numerator();
+            let inv_precision = precision.get_denominator();
             let inv_precision = inv_precision.div_ceil(2);
 
             let simplified = value.simplify(&precision);


### PR DESCRIPTION
**Description**

The function `simplify` is capable of more than we thought. This PR makes sure that any developer is aware of the possibility to use it as a trade-off between precision and memory usage.

This PR implements...
- [x] new constants for `Q` : `Q::MAX62` (as this is the maximum number that we can instantiate as a constant and fmpz), `INV_MAX62`, `INV_MAX32` as constants to use for a fair trade-off reg precision and memory-usage.
- [x] explanations and an example of how to use `simplify` with these constants
- [x] ensurance that the sign does not change using `simplify`

for `Q`.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide