### PR TITLE
Cholesky Decomposition with less Precision

### DIFF
--- a/src/rational/mat_q/cholesky_decomp.rs
+++ b/src/rational/mat_q/cholesky_decomp.rs
@@ -78,7 +78,7 @@ impl MatQ {
         l
     }
 
-    /// This function implements the cholesky decomposition according to FLINTs
+    /// This function implements the Cholesky decomposition according to FLINTs
     /// implementation. As FLINTs algorithm is not (yet) accessible through flint-sys,
     /// this implementation follows the implementation of the algorithm from FLINT.
     /// This, however, also means that we will work with less precision as we will work

--- a/src/rational/mat_q/cholesky_decomp.rs
+++ b/src/rational/mat_q/cholesky_decomp.rs
@@ -112,9 +112,10 @@ impl MatQ {
 
         let mut out = MatQ::new(self.get_num_rows(), self.get_num_columns());
 
-        // This code snippet originates from [`fmpz_mat_chol_d`] (FLINT)
+        // This code snippet originates from [flint](https://github.com/flintlib/flint/blob/main/src/fmpz_mat/chol_d.c)
+        // it is not part of [flint-sys] as it requires a specific data-type `d_mat_t`
         for i in 0..self.get_num_rows() {
-            for j in 0..(i + 1) {
+            for j in 0..=i {
                 let mut s: f64 = 0.0;
                 for k in 0..j {
                     let r_ik = f64::from(&out.get_entry(i, k).unwrap());
@@ -123,6 +124,8 @@ impl MatQ {
                 }
                 if i == j {
                     let a_ii = f64::from(&self.get_entry(i, i).unwrap());
+                    // Find this requirement in https://en.wikipedia.org/wiki/Cholesky_decomposition#The_Cholesky_algorithm
+                    // a_ii > 0 as `self` needs to be positive definite
                     assert!(a_ii > s, "The provided matrix is not positive definite.");
 
                     out.set_entry(i, j, (a_ii - s).sqrt()).unwrap();


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Problem: The current implementation of the cholesky decomposition is far to slow as
- We use a self-implementation
- We are working with [`Q`]s which have a high precision at the cost of runtime

Therefore I looked at ways to overcome these issues
- Using FLINTs function -> sadly not supported in FFI
- Use simplify to get to a certain precision -> too slow...
- [x] Use [`f64`] (double-precision) between conversions
The latest of these options proved to be the best. As we can not access FLINTs function, I basically reformulated their implementation into Rust and used the same format.

for/ of `Component`.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
-  Due to the precision - it does not work for large integers
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
