### PR TITLE
Conversion between UTF8-encoded `Strings` and `Z`

### DIFF
--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -137,6 +137,8 @@ impl Z {
     }
 
     /// Create a [`Z`] integer from an iterable of [`u8`]s, i.e. a vector of bytes.
+    /// This function can only construct positive or zero integers, but not negative ones.
+    /// The inverse function to [`Z::from_bytes`] is [`Z::to_bytes`] for positive numbers including `0`.
     ///
     /// Parameters:
     /// - `bytes`: specifies an iterable of bytes that should be set in the new [`Z`] instance.
@@ -194,6 +196,29 @@ impl Z {
             }
         }
         value
+    }
+
+    /// Create a [`Z`] integer from a [`str`], i.e. its UTF8-Encoding.
+    /// This function can only construct positive or zero integers, but not negative ones.
+    ///
+    /// The inverse of this function is [`Z::to_utf8`].
+    ///
+    /// Parameters:
+    /// - `message`: specifies the message that is transformed via its UTF8-Encoding
+    ///   to a new [`Z`] instance.
+    ///
+    /// Returns a [`Z`] with corresponding value to the message's UTF8-Encoding.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::Z;
+    /// let message = "hello!";
+    ///  
+    /// let value = Z::from_utf8(&message);
+    /// assert_eq!(Z::from(36762444129640u64), value);
+    /// ```
+    pub fn from_utf8(message: &str) -> Z {
+        Z::from_bytes(message.as_bytes())
     }
 }
 
@@ -431,6 +456,37 @@ mod test_from_bytes {
         assert_eq!(Z::from(257), res_0);
         assert_eq!(Z::from(257), res_1);
         assert_eq!(Z::from(257), res_2);
+    }
+}
+
+#[cfg(test)]
+/// Test the implementation of [`Z::from_utf8`] briefly.
+/// This module omits tests that were already provided for [`Z::from_bytes`].
+mod test_from_utf8 {
+    use super::Z;
+
+    /// Ensures that a wide range of (special) characters are correctly transformed.
+    #[test]
+    fn characters() {
+        let message = "flag{text#1234567890! a_zA-Z$€?/:;,.<>+*}";
+
+        let value = Z::from_utf8(message);
+
+        // easy trick s.t. we don't have to initialize huge [`Z`] value
+        // while this test should still fail if the value changes
+        let value_zq = value.modulo(65537);
+
+        assert_eq!(Z::from(58285), value_zq);
+    }
+
+    /// Ensure that the empty string results in a zero value.
+    #[test]
+    fn empty_string() {
+        let message = "";
+
+        let value = Z::from_utf8(message);
+
+        assert_eq!(Z::ZERO, value);
     }
 }
 

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -199,9 +199,8 @@ impl Z {
         value
     }
 
-    /// Create a [`Z`] integer from a [`str`], i.e. its UTF8-Encoding.
+    /// Create a [`Z`] integer from a [`String`], i.e. its UTF8-Encoding.
     /// This function can only construct positive or zero integers, but not negative ones.
-    ///
     /// The inverse of this function is [`Z::to_utf8`].
     ///
     /// Parameters:
@@ -472,7 +471,7 @@ mod test_from_utf8 {
 
         let value = Z::from_utf8(message);
 
-        // easy trick s.t. we don't have to initialize huge [`Z`] value
+        // easy trick s.t. we don't have to initialize a huge [`Z`] value
         // while this test should still fail if the value changes
         let value_zq = value.modulo(65537);
 

--- a/src/integer/z/to_string.rs
+++ b/src/integer/z/to_string.rs
@@ -72,7 +72,7 @@ impl Z {
     /// with a configurable base `b` between `2` and `62`.
     ///
     /// Parameters:
-    /// - `b`: specifies the any base between `2` and `62` which specifies
+    /// - `b`: specifies any base between `2` and `62` which specifies
     ///     the base of the returned [`String`].
     ///
     /// Returns the integer in form of a [`String`] with regards to the base `b`
@@ -126,7 +126,7 @@ impl Z {
     /// Outputs the integer as a [`Vec`] of bytes.
     /// The inverse function to [`Z::to_bytes`] is [`Z::from_bytes`] for positive numbers including `0`.
     ///
-    /// WARNING: The bits are returned as they are stored in the memory. For negative numbers,
+    /// **Warning**: The bits are returned as they are stored in the memory. For negative numbers,
     /// this means that `-1` is output as `[255]`.
     /// For these values, [`Z::from_bytes`] is not inverse to [`Z::to_bytes`],
     /// as this function can only instantiate positive values.
@@ -136,6 +136,7 @@ impl Z {
     /// # Examples
     /// ```
     /// use qfall_math::integer::Z;
+    ///
     /// let integer = Z::from(257);
     ///
     /// let byte_string = integer.to_bytes();
@@ -165,15 +166,11 @@ impl Z {
     /// Enables conversion to a UTF8-Encoded [`String`] for [`Z`] values.
     /// The inverse to this function is [`Z::from_utf8`] for valid UTF8-Encodings.
     ///
-    /// WARNING: Not every byte-sequence forms a valid UTF8-character.
+    /// **Warning**: Not every byte-sequence forms a valid UTF8-character.
     /// If this is the case, a [`FromUtf8Error`] will be returned.
     ///
     /// Returns the corresponding UTF8-encoded [`String`] or a
     /// [`FromUtf8Error`] if the byte sequence contains an invalid UTF8-character.
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`FromUtf8Error`] if the integer's byte sequence contains
-    ///     invalid UTF8-characters.
     ///
     /// # Examples
     /// ```
@@ -182,6 +179,10 @@ impl Z {
     ///
     /// let text: String = integer.to_utf8().unwrap();
     /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`FromUtf8Error`] if the integer's byte sequence contains
+    ///     invalid UTF8-characters.
     pub fn to_utf8(&self) -> Result<String, FromUtf8Error> {
         String::from_utf8(self.to_bytes())
     }
@@ -312,7 +313,7 @@ mod test_to_bytes {
         let bytes = integer.to_bytes();
         let integer = Z::from_bytes(&bytes);
 
-        println!("{}", integer.to_string());
+        println!("{}", integer);
         assert_eq!(cmp_bytes, bytes);
     }
 }
@@ -326,7 +327,7 @@ mod test_to_utf8 {
     fn inverse_to_from_utf8() {
         let cmp_text = "Some valid string formatted in UTF8!";
 
-        let integer = Z::from_utf8(&cmp_text);
+        let integer = Z::from_utf8(cmp_text);
         let text = integer.to_utf8().unwrap();
 
         assert_eq!(cmp_text, text);

--- a/src/integer/z/to_string.rs
+++ b/src/integer/z/to_string.rs
@@ -47,10 +47,14 @@ impl fmt::Display for Z {
 
 impl Z {
     /// Allows to convert an integer of type [`Z`] into a [`String`]
-    /// with a configurable base between 2 and 62.
+    /// with a configurable base `b` between `2` and `62`.
     ///
-    /// Returns the integer in form of a [`String`] and an error
-    /// if the base is out of bounds.
+    /// Parameters:
+    /// - `b`: specifies the any base between `2` and `62` which specifies
+    ///     the base of the returned [`String`].
+    ///
+    /// Returns the integer in form of a [`String`] with regards to the base `b`
+    /// and an error if the base is out of bounds.
     ///
     /// # Examples
     /// ```

--- a/src/utils/sample/binomial.rs
+++ b/src/utils/sample/binomial.rs
@@ -84,10 +84,10 @@ mod test_sample_binomial {
         let n = Z::from(n_u64);
         let p = Q::from((1, 2));
 
-        for _ in 0..64 {
+        for _ in 0..16 {
             let sample = sample_binomial(&n, &p).unwrap();
-            assert!(sample > 0);
-            assert!(sample < n_u64);
+            // sample >= 0 check is not required as sample is a u64
+            assert!(sample <= n_u64);
         }
     }
 


### PR DESCRIPTION
**Description**
Introduces a way to turn text into `Z` integers that should be useful for a more vivid presentation of en-, decryption, etc.
It is a series of functions that I would like to implement to make our CTF challenges more appealing. These functions should also be implemented for `MatZ`, `Zq`, and `MatZq` for the time being.

This PR implements...
- [x] from_utf8
- [x] to_bytes
- [x] to_utf8

for `Z`.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide