### PR TITLE
GetCoefficient of PolyRingZq as Zq

### DIFF
--- a/src/integer_mod_q/polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/get.rs
@@ -66,8 +66,8 @@ impl GetCoefficient<Z> for PolynomialRingZq {
     /// Parameters:
     /// - `index`: the index of the coefficient to get (has to be positive)
     ///
-    /// Returns the coefficient as a [`Z`] or a [`MathError`] if the provided index
-    /// is negative and therefore invalid or it does not fit into an [`i64`].
+    /// Returns the coefficient as a [`Z`], or a [`MathError`] if the provided index
+    /// is negative and therefore invalid, or it does not fit into an [`i64`].
     ///
     /// # Examples
     /// ```


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

In case of PolyOverZq we have implemented GetCoefficient with a return value in Z and Zq. For PolyRingZq we currently only have GetCoefficient with a return value in Z.

This PR implements...
- [x] GetCoefficient for PolyRingZq with a return value in Zq

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
