### PR TITLE
From for MatPolyRingZq with support for MatZ

### DIFF
--- a/src/integer_mod_q/mat_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/from.rs
@@ -13,15 +13,19 @@
 use super::MatPolynomialRingZq;
 use crate::{integer::MatPolyOverZ, integer_mod_q::ModulusPolynomialRingZq};
 
-impl<Mod: Into<ModulusPolynomialRingZq>> From<(&MatPolyOverZ, Mod)> for MatPolynomialRingZq {
+impl<Matrix: Into<MatPolyOverZ>, Mod: Into<ModulusPolynomialRingZq>> From<(Matrix, Mod)>
+    for MatPolynomialRingZq
+{
     /// Creates a polynomial ring matrix of type [`MatPolynomialRingZq`] from
-    /// a [`MatPolyOverZ`] and a [`ModulusPolynomialRingZq`].
+    /// a value that implements [`Into<MatPolyOverZ>`] and a value that
+    /// implements [`Into<ModulusPolynomialRingZq>`].
     ///
     /// Parameters:
     /// - `matrix`: the polynomial matrix defining each entry.
     /// - `modulus`: the modulus that is applied to each polynomial.
     ///
-    /// Returns a [`ModulusPolynomialRingZq`].
+    /// Returns a new [`MatPolynomialRingZq`] with the entries from `matrix`
+    /// under the modulus `modulus`.
     ///
     /// # Examples
     /// ```
@@ -32,65 +36,47 @@ impl<Mod: Into<ModulusPolynomialRingZq>> From<(&MatPolyOverZ, Mod)> for MatPolyn
     ///
     /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
     /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
-    /// let poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
+    ///
+    /// let poly_ring_mat = MatPolynomialRingZq::from((poly_mat, modulus));
     /// ```
-    fn from((matrix, modulus): (&MatPolyOverZ, Mod)) -> Self {
+    fn from((matrix, modulus): (Matrix, Mod)) -> Self {
         let mut out = Self {
-            matrix: matrix.clone(),
+            matrix: matrix.into(),
             modulus: modulus.into(),
         };
         out.reduce();
         out
-    }
-}
-
-impl<Mod: Into<ModulusPolynomialRingZq>> From<(MatPolyOverZ, Mod)> for MatPolynomialRingZq {
-    /// Creates a polynomial ring matrix of type [`MatPolynomialRingZq`] from
-    /// a [`MatPolyOverZ`] and a [`ModulusPolynomialRingZq`].
-    ///
-    /// Parameters:
-    /// - `matrix`: the polynomial matrix defining each entry.
-    /// - `modulus`: the modulus that is applied to each polynomial.
-    ///
-    /// Returns a [`ModulusPolynomialRingZq`].
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::integer_mod_q::MatPolynomialRingZq;
-    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
-    /// use qfall_math::integer::MatPolyOverZ;
-    /// use std::str::FromStr;
-    ///
-    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
-    /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
-    /// let poly_ring_mat = MatPolynomialRingZq::from((poly_mat, &modulus));
-    /// ```
-    fn from((matrix, modulus): (MatPolyOverZ, Mod)) -> Self {
-        let mut out = MatPolynomialRingZq {
-            matrix,
-            modulus: modulus.into(),
-        };
-        out.reduce();
-        out
-    }
-}
-
-impl From<&MatPolynomialRingZq> for MatPolynomialRingZq {
-    /// Alias for [`MatPolynomialRingZq::clone`].
-    fn from(value: &MatPolynomialRingZq) -> Self {
-        value.clone()
     }
 }
 
 #[cfg(test)]
 mod test_from {
     use crate::{
-        integer::MatPolyOverZ,
-        integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq},
+        integer::{MatPolyOverZ, MatZ},
+        integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq, PolyOverZq},
     };
     use std::str::FromStr;
 
     const LARGE_PRIME: u64 = u64::MAX - 58;
+
+    /// Checks whether `from` is available for all types implementing
+    /// [`Into<MatPolyOverZ>`] and [`Into<ModulusPolynomialRingZq>`]
+    #[test]
+    fn availability() {
+        let modulus_1 = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+        let modulus_2 = PolyOverZq::from_str("4  1 0 0 1 mod 17").unwrap();
+        let poly_mat_1 = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
+        let poly_mat_2 = MatZ::from_str("[[1, 2, 3],[4, 5, 6]]").unwrap();
+
+        let _ = MatPolynomialRingZq::from((&poly_mat_1, &modulus_1));
+        let _ = MatPolynomialRingZq::from((&poly_mat_1, modulus_1.clone()));
+        let _ = MatPolynomialRingZq::from((poly_mat_1.clone(), &modulus_1));
+        let _ = MatPolynomialRingZq::from((&poly_mat_2, &modulus_2));
+        let _ = MatPolynomialRingZq::from((&poly_mat_2, modulus_2.clone()));
+        let _ = MatPolynomialRingZq::from((poly_mat_2.clone(), &modulus_2));
+        let _ = MatPolynomialRingZq::from((&poly_mat_1, &modulus_2));
+        let _ = MatPolynomialRingZq::from((&poly_mat_2, modulus_1));
+    }
 
     /// Ensure that the modulus is applied with a large prime and large coefficients
     #[test]

--- a/src/integer_mod_q/mat_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/from.rs
@@ -49,6 +49,13 @@ impl<Matrix: Into<MatPolyOverZ>, Mod: Into<ModulusPolynomialRingZq>> From<(Matri
     }
 }
 
+impl From<&MatPolynomialRingZq> for MatPolynomialRingZq {
+    /// Alias for [`MatPolynomialRingZq::clone`].
+    fn from(value: &MatPolynomialRingZq) -> Self {
+        value.clone()
+    }
+}
+
 #[cfg(test)]
 mod test_from {
     use crate::{


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

We currently only have From for MatPolyRingZq with input MatPolyRingZq and  Into<ModulusPolynomialRingZq>. 
Since MatZ can be transformed into MatPolyRingZq, I changed our current implementation such that the input can be Into<MatPolyRingZq> and  Into<ModulusPolynomialRingZq>, without losing the efficiency of our current implementation.

This PR implements...
- [x] From for MatPolyRingZq with support for MatZ

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
