### PR TITLE
UTF8-De-/Encoding for MatZ

### DIFF
--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -83,6 +83,8 @@ impl From<&MatZ> for MatZ {
 impl MatZ {
     /// Create a [`MatZ`] from a [`String`], i.e. its UTF8-Encoding.
     /// This function can only construct positive or zero integers, but not negative ones.
+    /// If the number of bytes and number of entries does not line up, we pad the message
+    /// with `'0'`s.
     /// The inverse of this function is [`Z::to_utf8`].
     ///
     /// Parameters:
@@ -100,6 +102,10 @@ impl MatZ {
     ///  
     /// let value = MatZ::from_utf8(&message, 2, 1);
     /// ```
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    ///     For further information see [`MatZ::new`].
     pub fn from_utf8(
         message: &str,
         num_rows: impl TryInto<i64> + Display,
@@ -220,10 +226,9 @@ mod test_from_str {
 /// This module omits tests that were already provided for [`Z::from_bytes`]
 /// and [`crate::utils::parse::matrix_from_utf8_fill_bytes`].
 mod test_from_utf8 {
-    use std::str::FromStr;
-
     use super::{MatZ, Z};
     use crate::traits::GetEntry;
+    use std::str::FromStr;
 
     /// Ensures that a wide range of (special) characters are correctly transformed correctly.
     #[test]

--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -230,7 +230,7 @@ mod test_from_utf8 {
     use crate::traits::GetEntry;
     use std::str::FromStr;
 
-    /// Ensures that a wide range of (special) characters are correctly transformed correctly.
+    /// Ensures that a wide range of (special) characters are transformed correctly.
     #[test]
     fn characters() {
         let message = "flag{text#1234567890! a_zA-Z$€?/:;,.<>+*}";

--- a/src/integer/mat_z/to_string.rs
+++ b/src/integer/mat_z/to_string.rs
@@ -76,8 +76,9 @@ impl MatZ {
     /// Enables conversion to a UTF8-Encoded [`String`] for [`MatZ`] values.
     /// The inverse to this function is [`MatZ::from_utf8`] for valid UTF8-Encodings.
     ///
-    /// **Warning**: Not every byte-sequence forms a valid UTF8-character.
-    /// If this is the case, a [`FromUtf8Error`] will be returned.
+    /// **Warning**: Not every byte-sequence forms a valid UTF8-Encoding.
+    /// In these cases, an error is returned. Please check the format of your message again.
+    /// The matrix entries are evaluated row by row, i.e. in the order of the output of [`MatZ::to_string`].
     ///
     /// Returns the corresponding UTF8-encoded [`String`] or a
     /// [`FromUtf8Error`] if the byte sequence contains an invalid UTF8-character.

--- a/src/integer/mat_z/to_string.rs
+++ b/src/integer/mat_z/to_string.rs
@@ -78,7 +78,7 @@ impl MatZ {
     ///
     /// **Warning**: Not every byte-sequence forms a valid UTF8-Encoding.
     /// In these cases, an error is returned. Please check the format of your message again.
-    /// The matrix entries are evaluated row by row, i.e. in the order of the output of [`MatZ::to_string`].
+    /// The matrix entries are evaluated row by row, i.e. in the order of the output of `mat_z.to_string()`.
     ///
     /// Returns the corresponding UTF8-encoded [`String`] or a
     /// [`FromUtf8Error`] if the byte sequence contains an invalid UTF8-character.

--- a/src/integer/mat_z/to_string.rs
+++ b/src/integer/mat_z/to_string.rs
@@ -12,8 +12,13 @@
 //! This includes the [`Display`](std::fmt::Display) trait.
 
 use super::MatZ;
-use crate::{macros::for_others::implement_for_owned, utils::parse::matrix_to_string};
+use crate::{
+    macros::for_others::implement_for_owned,
+    traits::{GetEntry, GetNumColumns, GetNumRows},
+    utils::parse::matrix_to_string,
+};
 use core::fmt;
+use std::string::FromUtf8Error;
 
 impl From<&MatZ> for String {
     /// Converts a [`MatZ`] into its [`String`] representation.
@@ -64,6 +69,46 @@ impl fmt::Display for MatZ {
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", matrix_to_string(self))
+    }
+}
+
+impl MatZ {
+    /// Enables conversion to a UTF8-Encoded [`String`] for [`MatZ`] values.
+    /// The inverse to this function is [`MatZ::from_utf8`] for valid UTF8-Encodings.
+    ///
+    /// **Warning**: Not every byte-sequence forms a valid UTF8-character.
+    /// If this is the case, a [`FromUtf8Error`] will be returned.
+    ///
+    /// Returns the corresponding UTF8-encoded [`String`] or a
+    /// [`FromUtf8Error`] if the byte sequence contains an invalid UTF8-character.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatZ;
+    /// use std::str::FromStr;
+    /// let matrix = MatZ::from_str("[[104, 101, 108],[108, 111, 33]]").unwrap();
+    ///
+    /// let message = matrix.to_utf8().unwrap();
+    ///
+    /// assert_eq!("hello!", message);
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`FromUtf8Error`] if the integer's byte sequence contains
+    ///     invalid UTF8-characters.
+    pub fn to_utf8(&self) -> Result<String, FromUtf8Error> {
+        let mut byte_vector: Vec<u8> = vec![];
+
+        // Fill byte vector
+        for row in 0..self.get_num_rows() as usize {
+            for col in 0..self.get_num_columns() as usize {
+                let entry_value = self.get_entry(row, col).unwrap();
+                let mut entry_bytes = entry_value.to_bytes();
+                byte_vector.append(&mut entry_bytes);
+            }
+        }
+
+        String::from_utf8(byte_vector)
     }
 }
 
@@ -142,5 +187,48 @@ mod test_to_string {
 
         assert_eq!(cmp, string);
         assert_eq!(cmp, borrowed_string);
+    }
+}
+
+#[cfg(test)]
+mod test_to_utf8 {
+    use crate::integer::MatZ;
+    use std::str::FromStr;
+
+    /// Ensures that [`MatZ::to_utf8`] is inverse to [`MatZ::from_utf8`].
+    #[test]
+    fn inverse_to_from_utf8() {
+        let message = "some_random_string_1-9A-Z!?-_;:#";
+
+        let matrix = MatZ::from_utf8(message, 4, 4);
+
+        let string = matrix.to_utf8().unwrap();
+
+        assert_eq!(message, string);
+    }
+
+    /// Ensures that [`MatZ::to_utf8`] is inverse to [`MatZ::from_utf8`]
+    /// and padding is applied if necessary.
+    #[test]
+    fn inverse_incl_padding() {
+        let message = "some_random_string_1-9A-Z!?-_;";
+        let cmp_text = "some_random_string_1-9A-Z!?-_;00";
+
+        let matrix = MatZ::from_utf8(message, 4, 8);
+
+        let string = matrix.to_utf8().unwrap();
+
+        assert_eq!(cmp_text, string);
+    }
+
+    /// Ensures that [`MatZ::to_utf8`] outputs an error
+    /// if the integer contains an invalid UTF8-Encoding.
+    #[test]
+    fn invalid_encoding() {
+        // 128 is an invalid UTF8-character (at least at the end and on its own)
+        let matrix = MatZ::from_str("[[1,2],[3,128]]").unwrap();
+        let string = matrix.to_utf8();
+
+        assert!(string.is_err());
     }
 }

--- a/src/integer/mat_z/to_string.rs
+++ b/src/integer/mat_z/to_string.rs
@@ -75,7 +75,7 @@ impl fmt::Display for MatZ {
 impl MatZ {
     /// Enables conversion to a UTF8-Encoded [`String`] for [`MatZ`] values.
     /// Every entry is padded with `00`s s.t. all entries contain the same number of bytes.
-    /// Afterwards, they are appended column-by-column and converted.
+    /// Afterwards, they are appended row-by-row and converted.
     /// The inverse to this function is [`MatZ::from_utf8`] for valid UTF8-Encodings.
     ///
     /// **Warning**: Not every byte-sequence forms a valid UTF8-Encoding.

--- a/src/integer/mat_z/to_string.rs
+++ b/src/integer/mat_z/to_string.rs
@@ -74,6 +74,8 @@ impl fmt::Display for MatZ {
 
 impl MatZ {
     /// Enables conversion to a UTF8-Encoded [`String`] for [`MatZ`] values.
+    /// Every entry is padded with `00`s s.t. all entries contain the same number of bytes.
+    /// Afterwards, they are appended column-by-column and converted.
     /// The inverse to this function is [`MatZ::from_utf8`] for valid UTF8-Encodings.
     ///
     /// **Warning**: Not every byte-sequence forms a valid UTF8-Encoding.
@@ -98,18 +100,38 @@ impl MatZ {
     /// - Returns a [`FromUtf8Error`] if the integer's byte sequence contains
     ///     invalid UTF8-characters.
     pub fn to_utf8(&self) -> Result<String, FromUtf8Error> {
-        let mut byte_vector: Vec<u8> = vec![];
+        let mut byte_vectors: Vec<Vec<u8>> = vec![];
+        let mut max_length = 0;
 
         // Fill byte vector
         for row in 0..self.get_num_rows() as usize {
             for col in 0..self.get_num_columns() as usize {
                 let entry_value = self.get_entry(row, col).unwrap();
-                let mut entry_bytes = entry_value.to_bytes();
-                byte_vector.append(&mut entry_bytes);
+                let entry_bytes = entry_value.to_bytes();
+
+                // Find maximum length of bytes in one entry of the matrix
+                if max_length < entry_bytes.len() {
+                    max_length = entry_bytes.len();
+                }
+
+                byte_vectors.push(entry_bytes);
             }
         }
 
-        String::from_utf8(byte_vector)
+        // Pad every entry to the same length with `0`s
+        // to ensure any matrix given a string provides the same matrix
+        // and append them in the same iteration
+        let mut bytes = vec![];
+        for mut byte_vector in byte_vectors {
+            for _ in 0..max_length - byte_vector.len() {
+                // 0 encodes a control character �, which can be followed by anything
+                // Hence, this might change the encoding of any trailing sequences
+                byte_vector.push(0u8);
+            }
+            bytes.append(&mut byte_vector);
+        }
+
+        String::from_utf8(bytes)
     }
 }
 
@@ -198,7 +220,7 @@ mod test_to_utf8 {
 
     /// Ensures that [`MatZ::to_utf8`] is inverse to [`MatZ::from_utf8`].
     #[test]
-    fn inverse_to_from_utf8() {
+    fn inverse_of_from_utf8() {
         let message = "some_random_string_1-9A-Z!?-_;:#";
 
         let matrix = MatZ::from_utf8(message, 4, 4);
@@ -206,6 +228,22 @@ mod test_to_utf8 {
         let string = matrix.to_utf8().unwrap();
 
         assert_eq!(message, string);
+    }
+
+    /// Ensures that [`MatZ::from_utf8`] is inverse to [`MatZ::to_utf8`].
+    #[test]
+    fn inverse_to_from_utf8() {
+        let matrix_cmp_w_padding = MatZ::from_str("[[104, 101, 108],[28524, 48, 48]]").unwrap();
+        let matrix_cmp_wo_padding = MatZ::from_str("[[104, 101],[108, 108],[111, 33]]").unwrap();
+
+        let string_w_padding = matrix_cmp_w_padding.to_utf8().unwrap();
+        let string_wo_padding = matrix_cmp_wo_padding.to_utf8().unwrap();
+
+        let matrix_w_padding = MatZ::from_utf8(&string_w_padding, 2, 3);
+        let matrix_wo_padding = MatZ::from_utf8(&string_wo_padding, 3, 2);
+        
+        assert_eq!(matrix_cmp_w_padding, matrix_w_padding);
+        assert_eq!(matrix_cmp_wo_padding, matrix_wo_padding);
     }
 
     /// Ensures that [`MatZ::to_utf8`] is inverse to [`MatZ::from_utf8`]

--- a/src/integer/mat_z/to_string.rs
+++ b/src/integer/mat_z/to_string.rs
@@ -123,11 +123,10 @@ impl MatZ {
         // and append them in the same iteration
         let mut bytes = vec![];
         for mut byte_vector in byte_vectors {
-            for _ in 0..max_length - byte_vector.len() {
-                // 0 encodes a control character �, which can be followed by anything
-                // Hence, this might change the encoding of any trailing sequences
-                byte_vector.push(0u8);
-            }
+            // 0 encodes a control character �, which can be followed by anything
+            // Hence, this might change the encoding of any trailing sequences
+            byte_vector.resize(max_length, 0u8);
+
             bytes.append(&mut byte_vector);
         }
 
@@ -241,7 +240,7 @@ mod test_to_utf8 {
 
         let matrix_w_padding = MatZ::from_utf8(&string_w_padding, 2, 3);
         let matrix_wo_padding = MatZ::from_utf8(&string_wo_padding, 3, 2);
-        
+
         assert_eq!(matrix_cmp_w_padding, matrix_w_padding);
         assert_eq!(matrix_cmp_wo_padding, matrix_wo_padding);
     }

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -10,6 +10,8 @@
 
 use crate::{
     error::{MathError, StringConversionError},
+    integer::Z,
+    integer_mod_q::Modulus,
     traits::{GetEntry, GetNumColumns, GetNumRows},
 };
 use regex::Regex;
@@ -112,6 +114,61 @@ pub(crate) fn matrix_to_string<S: Display, T: GetEntry<S> + GetNumRows + GetNumC
     builder
         .string()
         .expect("Matrix string contains invalid bytes.")
+}
+
+/// Adds `0`-padding to the UTF8-Encoding of the `message` until every entry of
+/// the matrix has the same number of bytes assigned to it.
+///
+/// Parameters:
+/// - `message`: a [`String`] whose UTF8-Encoding should be encoded in a matrix.
+/// - `nr_entries`: the number of entries in the matrix, i.e. `nr_rows * nr_columns`.
+/// - `modulus`: optional argument if a [`Modulus`] is involved
+///
+/// Returns a padded byte [`Vec<u8>`] with the same number of bytes assigned to
+/// every entry of the matrix and the number of bytes per entry as [`usize`]
+/// or an error if the number of bytes is not guaranteed
+/// to fit into the assigned matrix due to restrictions by a modulus.
+///
+/// # Errors and Failures
+/// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
+///     if the UTF8-Encoding is not guaranteed to provide enough free memory
+///     to fit into the matrix.
+pub(crate) fn matrix_from_utf8_fill_bytes(
+    message: &str,
+    nr_entries: usize,
+    modulus: Option<&Modulus>,
+) -> Result<(Vec<u8>, usize), MathError> {
+    let msg_bytes = message.as_bytes();
+
+    let bytes_per_entry = msg_bytes.len() as f64 / nr_entries as f64;
+    // Rounding is applied for the case if there was a small loss in precision
+    let num_bytes_to_fill =
+        ((bytes_per_entry.ceil() - bytes_per_entry) * nr_entries as f64).round() as usize;
+
+    if modulus.is_some() {
+        let modulus_value: Z = modulus.unwrap().into();
+        let min_nr_bytes_per_entry = modulus_value.to_bytes().len() - 1;
+
+        let total_nr_msg_bytes_incl_padding = msg_bytes.len() + num_bytes_to_fill;
+        let nr_bytes_available_in_matrix = nr_entries * min_nr_bytes_per_entry;
+
+        if nr_bytes_available_in_matrix < total_nr_msg_bytes_incl_padding {
+            Err(MathError::ConversionError(
+                "The matrix does not provide enough memory space to store this message.".to_owned(),
+            ))?;
+        }
+    }
+
+    let mut bytes: Vec<u8> = vec![];
+    for msg_byte in msg_bytes {
+        bytes.push(*msg_byte);
+    }
+    for _i in 0..num_bytes_to_fill {
+        // 48 encodes `0`
+        bytes.push(48u8);
+    }
+
+    Ok((bytes, bytes_per_entry.ceil() as usize))
 }
 
 #[cfg(test)]
@@ -243,5 +300,136 @@ mod test_matrix_to_string {
         let cmp_str_2 = matrix_to_string(&cmp);
 
         assert!(MatZ::from_str(&cmp_str_2).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod test_matrix_from_utf8_fill_bytes {
+    use crate::integer_mod_q::Modulus;
+
+    use super::matrix_from_utf8_fill_bytes;
+
+    /// A static test to ensure the UTF8-Decoding works properly and the correct padding is applied.
+    #[test]
+    fn static_padding_no_modulus() {
+        let message = "five5";
+        let matrix_size = 8;
+
+        let (byte_vector, _) = matrix_from_utf8_fill_bytes(message, matrix_size, None).unwrap();
+
+        assert_eq!(vec![102, 105, 118, 101, 53, 48, 48, 48], byte_vector);
+    }
+
+    /// Ensures that a correct number of bytes is added s.t. every entry
+    /// in the matrix has the same number of bytes allocated.
+    /// Furthermore, it tests whether the `0`-padding was applied.
+    #[test]
+    fn padding_no_modulus() {
+        let messages = ["abc", "12345", "flag{12345}"];
+        let matrix_sizes: [usize; 3] = [6, 12, 15];
+
+        for message in messages {
+            for matrix_size in matrix_sizes {
+                let (byte_vector, nr_bytes_per_entry) =
+                    matrix_from_utf8_fill_bytes(message, matrix_size, None).unwrap();
+
+                assert_eq!(byte_vector.len() / matrix_size, nr_bytes_per_entry);
+                assert_eq!(
+                    0.0f32,
+                    (byte_vector.len() as f32 / matrix_size as f32).fract()
+                );
+                assert_eq!(48u8, byte_vector[byte_vector.len() - 1]);
+            }
+        }
+    }
+
+    /// Ensures that a no bytes are added if it isn't necessary, i.e.
+    /// if every entry is naturally allocated the same number of bytes.
+    #[test]
+    fn no_padding_no_modulus() {
+        let messages = ["abcdef", "123456", "flag{123456}"];
+        let matrix_sizes: [usize; 2] = [3, 6];
+
+        for message in messages {
+            for matrix_size in matrix_sizes {
+                let (byte_vector, nr_bytes_per_entry) =
+                    matrix_from_utf8_fill_bytes(message, matrix_size, None).unwrap();
+
+                assert_eq!(byte_vector.len() / matrix_size, nr_bytes_per_entry);
+                assert_eq!(
+                    0.0f32,
+                    (byte_vector.len() as f32 / matrix_size as f32).fract()
+                );
+                assert_ne!(48u8, byte_vector[byte_vector.len() - 1]);
+            }
+        }
+    }
+
+    /// Ensures that a correct number of bytes is added s.t. every entry
+    /// in the matrix has the same number of bytes allocated and no modulus is applied.
+    /// Furthermore, it tests whether the `0`-padding was applied.
+    #[test]
+    fn padding_with_modulus() {
+        let messages = ["abc", "12345", "flag{12345}"];
+        let matrix_sizes: [usize; 3] = [6, 12, 15];
+        // Modulus needs to be at least 2^32, which gives space for
+        // 2 bytes in each field, i.e. 12 bytes / 6 entries.
+        let modulus = Modulus::from(u64::pow(2, 16));
+
+        for message in messages {
+            for matrix_size in matrix_sizes {
+                let (byte_vector, nr_bytes_per_entry) =
+                    matrix_from_utf8_fill_bytes(message, matrix_size, Some(&modulus)).unwrap();
+
+                assert_eq!(byte_vector.len() / matrix_size, nr_bytes_per_entry);
+                assert_eq!(
+                    0.0f32,
+                    (byte_vector.len() as f32 / matrix_size as f32).fract()
+                );
+                assert_eq!(48u8, byte_vector[byte_vector.len() - 1]);
+            }
+        }
+    }
+
+    /// Ensures that a no bytes are added if it isn't necessary, i.e.
+    /// if every entry is naturally allocated the same number of bytes.
+    #[test]
+    fn no_padding_with_modulus() {
+        let messages = ["abcd", "1234", "flag{12}"];
+        let matrix_sizes: [usize; 2] = [2, 4];
+        // Modulus needs to be at least 2^32, which gives space for
+        // 4 bytes in each field, i.e. 8 bytes / 2 entries.
+        let modulus = Modulus::from(u64::pow(2, 32));
+
+        for message in messages {
+            for matrix_size in matrix_sizes {
+                let (byte_vector, nr_bytes_per_entry) =
+                    matrix_from_utf8_fill_bytes(message, matrix_size, Some(&modulus)).unwrap();
+
+                assert_eq!(byte_vector.len() / matrix_size, nr_bytes_per_entry);
+                assert_eq!(
+                    0.0f32,
+                    (byte_vector.len() as f32 / matrix_size as f32).fract()
+                );
+                assert_ne!(48u8, byte_vector[byte_vector.len() - 1]);
+            }
+        }
+    }
+
+    /// Ensures that matrices that potentially couldn't provide enough memory
+    /// to store all bytes of the message due to limitations from the [`Modulus`],
+    /// return an error.
+    #[test]
+    fn matrix_space_not_large_enough() {
+        let message = "flag{1}";
+        let matrix_size = 2;
+        // Message has 7 bytes + 1 byte padding = 8 bytes
+        // 8 bytes / 2 (matrix_size) = 4 bytes per entry
+        // Modulus is 2^(32) - 1, i.e. by 1 too small to guarantee storing 4 full bytes per entry
+        let modulus = Modulus::from(u32::MAX);
+
+        let byte_vector = matrix_from_utf8_fill_bytes(message, matrix_size, Some(&modulus));
+
+        assert!(byte_vector.is_err());
     }
 }

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -347,7 +347,7 @@ mod test_matrix_from_utf8_fill_bytes {
         }
     }
 
-    /// Ensures that a no bytes are added if it isn't necessary, i.e.
+    /// Ensures that no bytes are added if it isn't necessary, i.e.
     /// if every entry is naturally allocated the same number of bytes.
     #[test]
     fn no_padding_no_modulus() {
@@ -451,7 +451,7 @@ mod test_matrix_from_utf8_fill_bytes {
         assert_eq!(0, nr_bytes_per_entry);
     }
 
-    /// Ensures that matrices with
+    /// Ensures that matrices with matrix_size 0 panic.
     #[test]
     #[should_panic]
     fn matrix_size_zero() {

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -119,6 +119,11 @@ pub(crate) fn matrix_to_string<S: Display, T: GetEntry<S> + GetNumRows + GetNumC
 /// Adds `0`-padding to the UTF8-Encoding of the `message` until every entry of
 /// the matrix has the same number of bytes assigned to it.
 ///
+/// **WARNING:** For use with modulus, this implementation is very restrictive.
+/// It requires the modulus to be larger than or equal to the next byte-order size,
+/// i.e. `(2^8)^i`. Then, the largest entry may be at most `(2^8)^(i-1)` defines the
+/// maximum entry that is allowed.
+///
 /// Parameters:
 /// - `message`: a [`String`] whose UTF8-Encoding should be encoded in a matrix.
 /// - `nr_entries`: the number of entries in the matrix, i.e. `nr_rows * nr_columns`.
@@ -459,5 +464,19 @@ mod test_matrix_from_utf8_fill_bytes {
         let matrix_size = 0;
 
         let _ = matrix_from_utf8_fill_bytes(message, matrix_size, None).unwrap();
+    }
+
+    /// Ensure that the conversion error is triggered if necessary.
+    /// This test is for the current version of this function, which is very restrictive.
+    /// This test could work (and not trigger the error).
+    #[test]
+    fn trigger_conversion_error() {
+        let message = "A";
+        let nr_entries = 4;
+        let modulus = Modulus::from(255);
+
+        let res = matrix_from_utf8_fill_bytes(&message, nr_entries, Some(&modulus));
+
+        assert!(res.is_err());
     }
 }


### PR DESCRIPTION
**Description**

This PR implements...
- [x] padding for UTF8-encoded strings to ensure that no problems happen along the way of decoding (including major progress for MatZq already)
- [x] from_utf8
- [x] to_utf 

for `MatZ`.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide