### PR TITLE
From for ModulusPolyRingZq

### DIFF
--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -69,7 +69,7 @@ impl FromStr for MatPolyOverZ {
     ///     - if the number of rows or columns is too large (must fit into i64),
     ///     - if the number of entries in rows is unequal, or
     ///     - if an entry is not formatted correctly.
-    ///         For further information see [`PolyOverZ::from_str`].
+    ///     - For further information see [`PolyOverZ::from_str`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.

--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -48,7 +48,7 @@ impl FromStr for MatZ {
     ///     - if the number of rows or columns is too large (must fit into i64),
     ///     - if the number of entries in rows is unequal, or
     ///     - if an entry is not formatted correctly.
-    ///         For further information see [`Z::from_str`].
+    ///     - For further information see [`Z::from_str`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -64,7 +64,7 @@ impl FromStr for MatZq {
     ///     - if the number of rows or columns is too large (must fit into i64),
     ///     - if the number of entries in rows is unequal, or
     ///     - if the modulus or an entry is not formatted correctly.
-    ///         For further information see [`Z::from_str`].
+    ///     - For further information see [`Z::from_str`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
@@ -113,7 +113,7 @@ mod test_partial_eq {
     fn equal_small() {
         let small_1 = ModulusPolynomialRingZq::from_str("1  10 mod 17").unwrap();
         let small_2 = ModulusPolynomialRingZq::from_str("1  10 mod 17").unwrap();
-        let negative = ModulusPolynomialRingZq::from_str("1  -1 mod 17").unwrap();
+        let negative = ModulusPolynomialRingZq::from_str("1  -2 mod 17").unwrap();
 
         assert!(small_1 == small_2);
         assert!(small_2 == small_1);
@@ -184,8 +184,8 @@ mod test_partial_eq {
         let max = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let min = ModulusPolynomialRingZq::from_str(&min_str).unwrap();
 
-        let small_positive = ModulusPolynomialRingZq::from_str("1  1 mod 17").unwrap();
-        let small_negative = ModulusPolynomialRingZq::from_str("1  -1 mod 17").unwrap();
+        let small_positive = ModulusPolynomialRingZq::from_str("1  2 mod 17").unwrap();
+        let small_negative = ModulusPolynomialRingZq::from_str("1  -2 mod 17").unwrap();
 
         assert!(!(max == small_negative));
         assert!(!(small_negative == max));
@@ -208,8 +208,8 @@ mod test_partial_eq {
         let max = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let min = ModulusPolynomialRingZq::from_str(&min_str).unwrap();
 
-        let small_positive = ModulusPolynomialRingZq::from_str("1  1 mod 17").unwrap();
-        let small_negative = ModulusPolynomialRingZq::from_str("1  -1 mod 17").unwrap();
+        let small_positive = ModulusPolynomialRingZq::from_str("1  2 mod 17").unwrap();
+        let small_negative = ModulusPolynomialRingZq::from_str("1  -2 mod 17").unwrap();
 
         assert!(max != small_negative);
         assert!(small_negative != max);
@@ -225,8 +225,8 @@ mod test_partial_eq {
     /// Test not equal for the same polynomial but with a different modulus
     #[test]
     fn different_modulus() {
-        let first_str = "1  1 mod 17";
-        let second_str = "1  1 mod 19";
+        let first_str = "1  2 mod 17";
+        let second_str = "1  2 mod 19";
 
         let first = ModulusPolynomialRingZq::from_str(first_str).unwrap();
         let second = ModulusPolynomialRingZq::from_str(second_str).unwrap();

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
@@ -331,12 +331,13 @@ mod test_try_from_poly_z {
     use crate::{integer::PolyOverZ, integer_mod_q::ModulusPolynomialRingZq};
     use std::str::FromStr;
 
-    /// Ensure that non-primes work
+    /// Ensure that primes and non-primes work as modulus
     #[test]
-    fn poly_z_non_prime() {
+    fn poly_z_primes() {
         let poly_z = PolyOverZ::from_str("2  2 2").unwrap();
 
-        let _ = ModulusPolynomialRingZq::from((poly_z, 10));
+        let _ = ModulusPolynomialRingZq::from((&poly_z, 10));
+        let _ = ModulusPolynomialRingZq::from((poly_z, 11));
     }
 
     /// Ensure that the function panics if the modulus polynomial is 0
@@ -364,10 +365,11 @@ mod test_try_from_poly_z {
 mod test_try_from_integer_mod {
     use crate::integer_mod_q::ModulusPolynomialRingZq;
 
-    /// Ensure that non-primes work
+    /// Ensure that primes and non-primes work as modulus
     #[test]
-    fn mod_non_prime() {
+    fn mod_primes() {
         let _ = ModulusPolynomialRingZq::from((5, 10));
+        let _ = ModulusPolynomialRingZq::from((5, 11));
     }
 
     /// Ensure that the function panics if the modulus polynomial is 0
@@ -411,12 +413,14 @@ mod test_try_from_poly_zq {
         assert_eq!(cmp_str, poly_zq.to_string());
     }
 
-    /// Ensure that non-primes work
+    /// Ensure that primes and non-primes work as modulus
     #[test]
-    fn poly_zq_non_prime() {
-        let poly_zq = PolyOverZq::from_str("2  1 1 mod 10").unwrap();
+    fn poly_zq_primes() {
+        let poly_zq_1 = PolyOverZq::from_str("2  1 1 mod 10").unwrap();
+        let poly_zq_2 = PolyOverZq::from_str("2  1 1 mod 11").unwrap();
 
-        let _ = ModulusPolynomialRingZq::from(poly_zq);
+        let _ = ModulusPolynomialRingZq::from(poly_zq_1);
+        let _ = ModulusPolynomialRingZq::from(poly_zq_2);
     }
 
     /// Ensure that the function panics if the modulus polynomial is 0
@@ -466,14 +470,10 @@ mod test_from_str {
         .is_ok());
     }
 
-    /// Ensure that non-primes work
+    /// Ensure that primes and non-primes work as modulus
     #[test]
-    fn poly_zq_non_prime() {
-        assert!(ModulusPolynomialRingZq::from_str(&format!(
-            "4  0 1 3 {} mod {}",
-            u64::MAX,
-            2_i32.pow(16)
-        ))
-        .is_ok())
+    fn poly_zq_primes() {
+        assert!(ModulusPolynomialRingZq::from_str("4  0 1 3 2 mod 10").is_ok());
+        assert!(ModulusPolynomialRingZq::from_str("4  0 1 3 2 mod 11").is_ok());
     }
 }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //
@@ -11,16 +11,155 @@
 //! The explicit functions contain the documentation.
 
 use super::ModulusPolynomialRingZq;
-use crate::{error::MathError, integer_mod_q::PolyOverZq, macros::for_others::implement_for_owned};
+use crate::{
+    error::MathError,
+    integer::{PolyOverZ, Z},
+    integer_mod_q::{Modulus, PolyOverZq, Zq},
+    macros::for_others::implement_for_owned,
+};
 use flint_sys::fq::fq_ctx_init_modulus;
 use std::{ffi::CString, mem::MaybeUninit, rc::Rc, str::FromStr};
+
+impl From<&Zq> for ModulusPolynomialRingZq {
+    /// Creates a constant [`ModulusPolynomialRingZq`], i.e. the polynomial `x mod q`,
+    /// where `x` is the value of the given [`Zq`] value and `q` its modulus.
+    ///
+    /// Parameters:
+    /// - `value`: the constant value the polynomial will have.
+    ///   
+    /// Returns a new constant [`ModulusPolynomialRingZq`] with the specified
+    /// `value` and `modulus` of the [`Zq`] value.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer_mod_q::*, traits::*};
+    ///
+    /// let mod_poly = ModulusPolynomialRingZq::from(&Zq::from((2, 10)));
+    ///
+    /// let poly_cmp = ModulusPolynomialRingZq::from((2, 10));
+    /// assert_eq!(mod_poly, poly_cmp);
+    /// assert_eq!(mod_poly.get_degree(), 0);
+    /// ```
+    fn from(value: &Zq) -> Self {
+        let poly_zq = PolyOverZq::from(value);
+
+        Self::from(poly_zq)
+    }
+}
+
+implement_for_owned!(Zq, ModulusPolynomialRingZq, From);
+
+impl<Mod: Into<Modulus>> From<(&PolyOverZ, Mod)> for ModulusPolynomialRingZq {
+    /// Creates a [`ModulusPolynomialRingZq`] from a [`PolyOverZ`] and a value that implements [`Into<Modulus>`].
+    ///
+    /// Parameters:
+    /// - `poly`: the coefficients of the polynomial.
+    /// - `modulus`: the modulus by which each entry is reduced.
+    ///
+    /// Returns a new [`ModulusPolynomialRingZq`] with the coefficients from the
+    /// [`PolyOverZ`] instance under the specified [`Modulus`] value.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{ModulusPolynomialRingZq, Modulus};
+    /// use qfall_math::integer::PolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let poly = PolyOverZ::from_str("4  0 1 102 3").unwrap();
+    ///
+    /// let mod_poly = ModulusPolynomialRingZq::from((&poly, 100));
+    ///
+    /// let poly_cmp = ModulusPolynomialRingZq::from_str("4  0 1 2 3 mod 100").unwrap();
+    /// assert_eq!(poly_cmp, mod_poly);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`, or
+    /// - if the modulus polynomial is `0` or `1`.
+    fn from((poly, modulus): (&PolyOverZ, Mod)) -> Self {
+        let poly_zq = PolyOverZq::from((poly, modulus));
+
+        check_poly_mod(&poly_zq).unwrap();
+
+        Self::from(poly_zq)
+    }
+}
+
+impl<Mod: Into<Modulus>> From<(PolyOverZ, Mod)> for ModulusPolynomialRingZq {
+    /// Creates a [`ModulusPolynomialRingZq`] from a [`PolyOverZ`] and a value that implements [`Into<Modulus>`].
+    ///
+    /// Parameters:
+    /// - `poly`: the coefficients of the polynomial.
+    /// - `modulus`: the modulus by which each entry is reduced.
+    ///
+    /// Returns a new [`ModulusPolynomialRingZq`] with the coefficients from the
+    /// [`PolyOverZ`] instance under the specified [`Modulus`] value.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
+    /// use qfall_math::integer::PolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let poly = PolyOverZ::from_str("4  0 1 102 3").unwrap();
+    ///
+    /// let mod_poly = ModulusPolynomialRingZq::from((poly, 100));
+    ///
+    /// let poly_cmp = ModulusPolynomialRingZq::from_str("4  0 1 2 3 mod 100").unwrap();
+    /// assert_eq!(poly_cmp, mod_poly);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`, or
+    /// - if the modulus polynomial is `0` or `1`.
+    fn from((poly, modulus): (PolyOverZ, Mod)) -> Self {
+        let poly_zq = PolyOverZq::from((poly, modulus));
+
+        check_poly_mod(&poly_zq).unwrap();
+
+        Self::from(poly_zq)
+    }
+}
+
+impl<Integer: Into<Z>, Mod: Into<Modulus>> From<(Integer, Mod)> for ModulusPolynomialRingZq {
+    /// Creates a [`ModulusPolynomialRingZq`] from any values that implement [`Into<Z>`] and [`Into<Modulus>`],
+    /// where the second value must be larger than `1`.
+    ///
+    /// Parameters:
+    /// - `z`: the single, constant coefficient of the polynomial.
+    /// - `modulus`: the modulus by which each entry is reduced.
+    ///
+    /// Returns a new constant [`ModulusPolynomialRingZq`] with the specified `z` and `modulus` value.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::PolyOverZq;
+    /// use std::str::FromStr;
+    ///
+    /// let mod_poly = PolyOverZq::from((5, 42));
+    ///
+    /// let poly_cmp = PolyOverZq::from_str("1  5 mod 42").unwrap();
+    /// assert_eq!(poly_cmp, mod_poly);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`, or
+    /// - if the modulus polynomial is `0` or `1`.
+    fn from((z, modulus): (Integer, Mod)) -> Self {
+        let poly_zq = PolyOverZq::from((z, modulus));
+
+        check_poly_mod(&poly_zq).unwrap();
+
+        Self::from(poly_zq)
+    }
+}
 
 impl From<&PolyOverZq> for ModulusPolynomialRingZq {
     /// Creates a Modulus object of type [`ModulusPolynomialRingZq`]
     /// for [`PolynomialRingZq`](crate::integer_mod_q::PolynomialRingZq)
     ///
     /// Parameters:
-    /// - `modulus_poly`: the polynomial which is used as the modulus.
+    /// - `poly`: the polynomial which is used as the modulus.
     ///
     /// Returns a new [`ModulusPolynomialRingZq`] object with the coefficients
     /// and modulus from the [`PolyOverZq`] instance.
@@ -31,17 +170,23 @@ impl From<&PolyOverZq> for ModulusPolynomialRingZq {
     /// use qfall_math::integer_mod_q::PolyOverZq;
     /// use std::str::FromStr;
     ///
-    /// let poly_mod = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
-    /// let modulus = ModulusPolynomialRingZq::try_from(&poly_mod).unwrap();
+    /// let poly = PolyOverZq::from_str("3  1 0 1 mod 17").unwrap();
+    /// let mod_poly = ModulusPolynomialRingZq::try_from(&poly).unwrap();
     /// ```
-    fn from(modulus_poly: &PolyOverZq) -> Self {
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`, or
+    /// - if the modulus polynomial is `0` or `1`.
+    fn from(poly: &PolyOverZq) -> Self {
+        check_poly_mod(poly).unwrap();
+
         let mut modulus = MaybeUninit::uninit();
         let c_string = CString::new("X").unwrap();
         unsafe {
             fq_ctx_init_modulus(
                 modulus.as_mut_ptr(),
-                &modulus_poly.poly,
-                modulus_poly.modulus.get_fmpz_mod_ctx_struct(),
+                &poly.poly,
+                poly.modulus.get_fmpz_mod_ctx_struct(),
                 c_string.as_ptr(),
             );
             Self {
@@ -89,15 +234,156 @@ impl FromStr for ModulusPolynomialRingZq {
     /// let poly_mod = ModulusPolynomialRingZq::from_str("3  1 0 1 mod 17").unwrap();
     /// ```
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::StringConversionError`]
-    ///     - if the string was not formatted correctly, e.g. not a correctly
-    ///         formatted [`PolyOverZq`].
-    ///         For further information see [`PolyOverZq::from_str`].
+    /// - Returns a [`MathError`] of type
+    ///     [`StringConversionError`](MathError::StringConversionError)
+    ///     - if the provided first half of the string was not formatted correctly to
+    ///         create a [`PolyOverZ`],
+    ///     - if the provided second half of the
+    ///         string was not formatted correctly to create a [`Modulus`],
+    ///     - if the number of coefficients was smaller than the number provided
+    ///         at the start of the provided string, or
+    ///     - if the provided value did not contain two whitespaces.
+    ///     - For further information see [`PolyOverZq::from_str`].
     /// - Returns a [`MathError`] of type
     ///     [`InvalidModulus`](MathError::InvalidModulus)
-    ///     if `modulus` is smaller than `2`.
+    ///     - if `modulus` is smaller than `2`, or
+    ///     - if the modulus polynomial is `0` or `1`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::from(&PolyOverZq::from_str(s)?))
+        let poly_zq = PolyOverZq::from_str(s)?;
+
+        check_poly_mod(&poly_zq)?;
+
+        Ok(Self::from(poly_zq))
+    }
+}
+
+/// Checks weather a given [`PolyOverZq`] can be used as a [`ModulusPolynomialRingZq`].
+///
+/// Parameters:
+/// - `poly_zq`: the [`PolyOverZq`] value that should be checked.
+///
+/// Returns an empty `Ok`, or an [`MathError`] if the polynomial is no valid modulus polynomial.
+///
+/// # Examples
+/// ```compile_fail
+/// use qfall_math::integer_mod_q::PolyOverZq;
+/// use std::str::FromStr;
+///
+/// let poly_zq = PolyOverZq::from_str("2  1 2 mod 17").unwrap();
+///
+/// check_poly_mod(&poly_zq)?
+/// ```
+///
+/// # Errors and Failures
+/// - Returns a [`MathError`] of type
+///     [`InvalidModulus`](MathError::InvalidModulus)
+///     if the modulus polynomial is `0` or `1`.
+pub(crate) fn check_poly_mod(poly_zq: &PolyOverZq) -> Result<(), MathError> {
+    if poly_zq == &PolyOverZq::from((1, &poly_zq.modulus))
+        || poly_zq == &PolyOverZq::from((0, &poly_zq.modulus))
+    {
+        return Err(MathError::InvalidModulus(poly_zq.to_string()));
+    }
+
+    Ok(())
+}
+
+/// Most tests with specific values are covered in [`PolyOverZq`](crate::integer_mod_q::PolyOverZq)
+/// since the format is reused, we omit some tests
+#[cfg(test)]
+mod test_availability {
+    use super::*;
+    use crate::{integer::Z, integer_mod_q::Zq};
+    use crate::{integer_mod_q::ModulusPolynomialRingZq, integer_mod_q::PolyOverZq};
+    use std::str::FromStr;
+
+    /// Ensure that the from function can be called with several types.
+    #[test]
+    fn availability() {
+        let z = Z::from(4);
+        let modulus = Modulus::from(3);
+        let zq = Zq::from((2, 3));
+        let poly = PolyOverZ::from_str("2  1 1").unwrap();
+        let poly_zq = PolyOverZq::from_str("4  1 0 0 1 mod 17").unwrap();
+
+        let _ = ModulusPolynomialRingZq::from(&zq);
+        let _ = ModulusPolynomialRingZq::from(zq.clone());
+
+        let _ = ModulusPolynomialRingZq::from((2, 5));
+        let _ = ModulusPolynomialRingZq::from((&z, 5));
+        let _ = ModulusPolynomialRingZq::from((z.clone(), 5));
+        let _ = ModulusPolynomialRingZq::from((&modulus, 5));
+        let _ = ModulusPolynomialRingZq::from((modulus.clone(), 5));
+        let _ = ModulusPolynomialRingZq::from((&poly, 5));
+        let _ = ModulusPolynomialRingZq::from((poly.clone(), 5));
+        let _ = ModulusPolynomialRingZq::from((3, &z));
+        let _ = ModulusPolynomialRingZq::from((3, z.clone()));
+        let _ = ModulusPolynomialRingZq::from((2, &modulus));
+        let _ = ModulusPolynomialRingZq::from((2, modulus));
+
+        let _ = ModulusPolynomialRingZq::from(&poly_zq);
+        let _ = ModulusPolynomialRingZq::from(poly_zq);
+    }
+}
+
+/// Most tests with specific values are covered in [`PolyOverZq`](crate::integer_mod_q::PolyOverZq)
+/// since the format is reused, we omit some tests
+#[cfg(test)]
+mod test_try_from_poly_z {
+    use crate::{integer::PolyOverZ, integer_mod_q::ModulusPolynomialRingZq};
+    use std::str::FromStr;
+
+    /// Ensure that non-primes work
+    #[test]
+    fn poly_z_non_prime() {
+        let poly_z = PolyOverZ::from_str("2  2 2").unwrap();
+
+        let _ = ModulusPolynomialRingZq::from((poly_z, 10));
+    }
+
+    /// Ensure that the function panics if the modulus polynomial is 0
+    #[test]
+    #[should_panic]
+    fn panic_0() {
+        let poly = PolyOverZ::from(0);
+
+        let _ = ModulusPolynomialRingZq::from((poly, 17));
+    }
+
+    /// Ensure that the function panics if the modulus polynomial is 1
+    #[test]
+    #[should_panic]
+    fn panic_1() {
+        let poly = PolyOverZ::from(1);
+
+        let _ = ModulusPolynomialRingZq::from((poly, 17));
+    }
+}
+
+/// Most tests with specific values are covered in [`PolyOverZq`](crate::integer_mod_q::PolyOverZq)
+/// since the format is reused, we omit some tests
+#[cfg(test)]
+mod test_try_from_integer_mod {
+    use crate::integer_mod_q::ModulusPolynomialRingZq;
+
+    /// Ensure that non-primes work
+    #[test]
+    fn mod_non_prime() {
+        let _ = ModulusPolynomialRingZq::from((5, 10));
+    }
+
+    /// Ensure that the function panics if the modulus polynomial is 0
+    #[test]
+    #[should_panic]
+    fn panic_0() {
+        let _ = ModulusPolynomialRingZq::from((0, 17));
+    }
+
+    /// Ensure that the function panics if the modulus polynomial is 1
+    #[test]
+    #[should_panic]
+    fn panic_1() {
+        let _ = ModulusPolynomialRingZq::from((1, 17));
     }
 }
 
@@ -130,15 +416,25 @@ mod test_try_from_poly_zq {
     /// Ensure that non-primes work
     #[test]
     fn poly_zq_non_prime() {
-        let in_str = format!("4  0 1 3 {} mod {}", u64::MAX, 2_i32.pow(16));
-        PolyOverZq::from_str(&in_str).unwrap();
+        let poly_zq = PolyOverZq::from_str("2  1 1 mod 10").unwrap();
+
+        let _ = ModulusPolynomialRingZq::from(poly_zq);
     }
 
-    /// Ensure that the conversion works for owned values
+    /// Ensure that the function panics if the modulus polynomial is 0
     #[test]
-    fn availability() {
-        let poly = PolyOverZq::from_str(&format!("4  0 1 102 {} mod {}", u64::MAX - 58, u64::MAX))
-            .unwrap();
+    #[should_panic]
+    fn panic_0() {
+        let poly = PolyOverZq::from((0, 17));
+
+        let _ = ModulusPolynomialRingZq::from(poly);
+    }
+
+    /// Ensure that the function panics if the modulus polynomial is 1
+    #[test]
+    #[should_panic]
+    fn panic_1() {
+        let poly = PolyOverZq::from((1, 17));
 
         let _ = ModulusPolynomialRingZq::from(poly);
     }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
@@ -34,11 +34,9 @@ impl From<&Zq> for ModulusPolynomialRingZq {
     /// ```
     /// use qfall_math::{integer_mod_q::*, traits::*};
     ///
-    /// let mod_poly = ModulusPolynomialRingZq::from(&Zq::from((2, 10)));
+    /// let zq = Zq::from((2, 10));
     ///
-    /// let poly_cmp = ModulusPolynomialRingZq::from((2, 10));
-    /// assert_eq!(mod_poly, poly_cmp);
-    /// assert_eq!(mod_poly.get_degree(), 0);
+    /// let mod_poly = ModulusPolynomialRingZq::from(&zq);
     /// ```
     fn from(value: &Zq) -> Self {
         let poly_zq = PolyOverZq::from(value);

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
@@ -73,7 +73,7 @@ impl<Mod: Into<Modulus>> From<(&PolyOverZ, Mod)> for ModulusPolynomialRingZq {
     ///
     /// # Panics ...
     /// - if `modulus` is smaller than `2`, or
-    /// - if the modulus polynomial is `0` or `1`.
+    /// - if the modulus polynomial is `0`.
     fn from((poly, modulus): (&PolyOverZ, Mod)) -> Self {
         let poly_zq = PolyOverZq::from((poly, modulus));
 
@@ -109,7 +109,7 @@ impl<Mod: Into<Modulus>> From<(PolyOverZ, Mod)> for ModulusPolynomialRingZq {
     ///
     /// # Panics ...
     /// - if `modulus` is smaller than `2`, or
-    /// - if the modulus polynomial is `0` or `1`.
+    /// - if the modulus polynomial is `0`.
     fn from((poly, modulus): (PolyOverZ, Mod)) -> Self {
         let poly_zq = PolyOverZq::from((poly, modulus));
 
@@ -142,7 +142,7 @@ impl<Integer: Into<Z>, Mod: Into<Modulus>> From<(Integer, Mod)> for ModulusPolyn
     ///
     /// # Panics ...
     /// - if `modulus` is smaller than `2`, or
-    /// - if the modulus polynomial is `0` or `1`.
+    /// - if the modulus polynomial is `0`.
     fn from((z, modulus): (Integer, Mod)) -> Self {
         let poly_zq = PolyOverZq::from((z, modulus));
 
@@ -174,7 +174,7 @@ impl From<&PolyOverZq> for ModulusPolynomialRingZq {
     ///
     /// # Panics ...
     /// - if `modulus` is smaller than `2`, or
-    /// - if the modulus polynomial is `0` or `1`.
+    /// - if the modulus polynomial is `0`.
     fn from(poly: &PolyOverZq) -> Self {
         check_poly_mod(poly).unwrap();
 
@@ -245,7 +245,7 @@ impl FromStr for ModulusPolynomialRingZq {
     /// - Returns a [`MathError`] of type
     ///     [`InvalidModulus`](MathError::InvalidModulus)
     ///     - if `modulus` is smaller than `2`, or
-    ///     - if the modulus polynomial is `0` or `1`.
+    ///     - if the modulus polynomial is `0`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let poly_zq = PolyOverZq::from_str(s)?;
 
@@ -275,11 +275,9 @@ impl FromStr for ModulusPolynomialRingZq {
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type
 ///     [`InvalidModulus`](MathError::InvalidModulus)
-///     if the modulus polynomial is `0` or `1`.
+///     if the modulus polynomial is `0`.
 pub(crate) fn check_poly_mod(poly_zq: &PolyOverZq) -> Result<(), MathError> {
-    if poly_zq == &PolyOverZq::from((1, &poly_zq.modulus))
-        || poly_zq == &PolyOverZq::from((0, &poly_zq.modulus))
-    {
+    if poly_zq == &PolyOverZq::from((0, &poly_zq.modulus)) {
         return Err(MathError::InvalidModulus(poly_zq.to_string()));
     }
 
@@ -348,15 +346,6 @@ mod test_try_from_poly_z {
 
         let _ = ModulusPolynomialRingZq::from((poly, 17));
     }
-
-    /// Ensure that the function panics if the modulus polynomial is 1
-    #[test]
-    #[should_panic]
-    fn panic_1() {
-        let poly = PolyOverZ::from(1);
-
-        let _ = ModulusPolynomialRingZq::from((poly, 17));
-    }
 }
 
 /// Most tests with specific values are covered in [`PolyOverZq`](crate::integer_mod_q::PolyOverZq)
@@ -377,13 +366,6 @@ mod test_try_from_integer_mod {
     #[should_panic]
     fn panic_0() {
         let _ = ModulusPolynomialRingZq::from((0, 17));
-    }
-
-    /// Ensure that the function panics if the modulus polynomial is 1
-    #[test]
-    #[should_panic]
-    fn panic_1() {
-        let _ = ModulusPolynomialRingZq::from((1, 17));
     }
 }
 
@@ -428,15 +410,6 @@ mod test_try_from_poly_zq {
     #[should_panic]
     fn panic_0() {
         let poly = PolyOverZq::from((0, 17));
-
-        let _ = ModulusPolynomialRingZq::from(poly);
-    }
-
-    /// Ensure that the function panics if the modulus polynomial is 1
-    #[test]
-    #[should_panic]
-    fn panic_1() {
-        let poly = PolyOverZq::from((1, 17));
 
         let _ = ModulusPolynomialRingZq::from(poly);
     }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -242,7 +242,7 @@ mod test_get_degree {
         let degrees = [0, 1, 3, 7, 15, 32, 120];
         for degree in degrees {
             let modulus_ring = ModulusPolynomialRingZq::from_str(&format!(
-                "{}  {}1 mod 17",
+                "{}  {}2 mod 17",
                 degree + 1,
                 "0 ".repeat(degree)
             ))
@@ -255,7 +255,7 @@ mod test_get_degree {
     /// Ensure that degree is working for polynomials with leading 0 coefficients.
     #[test]
     fn degree_leading_zeros() {
-        let poly = ModulusPolynomialRingZq::from_str("4  1 0 0 0 mod 199").unwrap();
+        let poly = ModulusPolynomialRingZq::from_str("4  2 0 0 0 mod 199").unwrap();
 
         let deg = poly.get_degree();
 

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -60,7 +60,6 @@ impl From<&Zq> for PolyOverZq {
     ///
     /// Parameters:
     /// - `value`: the constant value the polynomial will have.
-    ///   It has to be a [`Zq`], or a value that can be converted into [`Zq`].
     ///   
     /// Returns a new constant [`PolyOverZq`] with the specified `value` and `modulus` of the [`Zq`] value.
     ///
@@ -111,8 +110,8 @@ impl<Mod: Into<Modulus>> From<(&PolyOverZ, Mod)> for PolyOverZq {
     ///
     /// let mod_poly = PolyOverZq::from((&poly, &modulus));
     ///
-    /// # let cmp_poly = PolyOverZq::from_str("4  0 1 2 3 mod 100").unwrap();
-    /// # assert_eq!(cmp_poly, mod_poly);
+    /// # let poly_cmp = PolyOverZq::from_str("4  0 1 2 3 mod 100").unwrap();
+    /// # assert_eq!(poly_cmp, mod_poly);
     /// ```
     ///
     /// # Panics ...
@@ -150,8 +149,8 @@ impl<Mod: Into<Modulus>> From<(PolyOverZ, Mod)> for PolyOverZq {
     ///
     /// let mod_poly = PolyOverZq::from((poly, 100));
     ///
-    /// # let cmp_poly = PolyOverZq::from_str("4  0 1 2 3 mod 100").unwrap();
-    /// # assert_eq!(cmp_poly, mod_poly);
+    /// # let poly_cmp = PolyOverZq::from_str("4  0 1 2 3 mod 100").unwrap();
+    /// # assert_eq!(poly_cmp, mod_poly);
     /// ```
     ///
     /// # Panics ...
@@ -186,8 +185,8 @@ impl<Integer: Into<Z>, Mod: Into<Modulus>> From<(Integer, Mod)> for PolyOverZq {
     ///
     /// let mod_poly = PolyOverZq::from((5, 42));
     ///
-    /// # let cmp_poly = PolyOverZq::from_str("1  5 mod 42").unwrap();
-    /// # assert_eq!(cmp_poly, mod_poly);
+    /// # let poly_cmp = PolyOverZq::from_str("1  5 mod 42").unwrap();
+    /// # assert_eq!(poly_cmp, mod_poly);
     /// ```
     ///
     /// # Panics ...
@@ -225,8 +224,8 @@ impl From<&ModulusPolynomialRingZq> for PolyOverZq {
     ///
     /// let poly_zq = PolyOverZq::from(&modulus);
     ///
-    /// let cmp_poly = PolyOverZq::from_str("4  1 0 0 1 mod 17").unwrap();
-    /// assert_eq!(cmp_poly, poly_zq);
+    /// let poly_cmp = PolyOverZq::from_str("4  1 0 0 1 mod 17").unwrap();
+    /// assert_eq!(poly_cmp, poly_zq);
     /// ```
     fn from(modulus: &ModulusPolynomialRingZq) -> Self {
         let modulus_q = Modulus::from(&modulus.get_q());
@@ -314,7 +313,7 @@ mod test_availability {
     use super::*;
     use crate::{integer::Z, integer_mod_q::Zq};
 
-    /// Ensure that the submatrix function can be called with several types.
+    /// Ensure that the from function can be called with several types.
     #[test]
     fn availability() {
         let z = Z::from(3);

--- a/src/rational/mat_q/from.rs
+++ b/src/rational/mat_q/from.rs
@@ -66,7 +66,7 @@ impl FromStr for MatQ {
     ///     - if the number of rows or columns is too large (must fit into i64),
     ///     - if the number of entries in rows is unequal, or
     ///     - if an entry is not formatted correctly.
-    ///         For further information see [`Q::from_str`].
+    ///     - For further information see [`Q::from_str`].
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR corrects the current implementation of ModulusPolyRingZq, since it did not check the polynomial modulus to be unequal to 0 and 1. 
It also implements...
- [x] From (&)Zq
- [x] From (&)PolyOverZ, Mod
- [x] From Integer, Mod

for ModulusPolyRingZq.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [ ] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
