### PR TITLE
MatPolyRingZq MismatchingModulus error for concatenation

### DIFF
--- a/src/integer_mod_q/mat_polynomial_ring_zq/concat.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/concat.rs
@@ -45,7 +45,10 @@ impl Concatenate for &MatPolynomialRingZq {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
     ///     [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    ///     if the matrices can not be concatenated due to mismatching dimensions
+    ///     if the matrices can not be concatenated due to mismatching dimensions.
+    /// - Returns a [`MathError`] of type
+    ///     [`MismatchingModulus`](MathError::MismatchingModulus)
+    ///     if the matrices can not be concatenated due to mismatching moduli.
     fn concat_vertical(self, other: Self) -> Result<Self::Output, crate::error::MathError> {
         if self.get_num_columns() != other.get_num_columns() {
             return Err(MathError::MismatchingMatrixDimension(format!(
@@ -56,6 +59,15 @@ impl Concatenate for &MatPolynomialRingZq {
                 other.get_num_columns()
             )));
         }
+
+        if self.modulus != other.modulus {
+            return Err(MathError::MismatchingModulus(format!(
+                "Tried to concatenate matrices with different moduli {} and {}.",
+                self.get_mod(),
+                other.get_mod(),
+            )));
+        }
+
         let mut matrix = MatPolyOverZ::new(
             self.get_num_rows() + other.get_num_rows(),
             self.get_num_columns(),
@@ -99,7 +111,10 @@ impl Concatenate for &MatPolynomialRingZq {
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type
     ///     [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-    ///     if the matrices can not be concatenated due to mismatching dimensions
+    ///     if the matrices can not be concatenated due to mismatching dimensions.
+    /// - Returns a [`MathError`] of type
+    ///     [`MismatchingModulus`](MathError::MismatchingModulus)
+    ///     if the matrices can not be concatenated due to mismatching moduli.
     fn concat_horizontal(self, other: Self) -> Result<Self::Output, crate::error::MathError> {
         if self.get_num_rows() != other.get_num_rows() {
             return Err(MathError::MismatchingMatrixDimension(format!(
@@ -110,6 +125,15 @@ impl Concatenate for &MatPolynomialRingZq {
                 other.get_num_columns()
             )));
         }
+
+        if self.modulus != other.modulus {
+            return Err(MathError::MismatchingModulus(format!(
+                "Tried to concatenate matrices with different moduli {} and {}.",
+                self.get_mod(),
+                other.get_mod(),
+            )));
+        }
+
         let mut matrix = MatPolyOverZ::new(
             self.get_num_rows(),
             self.get_num_columns() + other.get_num_columns(),
@@ -173,6 +197,20 @@ mod test_concatenate {
 
         assert_eq!(11, mat_vert.get_num_columns());
         assert_eq!(17, mat_vert.get_num_rows());
+    }
+
+    /// Ensure that concatenation of matrices with mismatching moduli results in
+    /// in an error.
+    #[test]
+    fn mismatching_moduli() {
+        let mat_1 = MatPolynomialRingZq::from_str("[[0, 0],[0, 0]] / 2  1 1 mod 6").unwrap();
+        let mat_2 = MatPolynomialRingZq::from_str("[[0, 0],[0, 0]] / 2  1 1 mod 7").unwrap();
+
+        let mat_hor = mat_1.concat_horizontal(&mat_2);
+        let mat_vert = mat_1.concat_vertical(&mat_2);
+
+        assert!(mat_hor.is_err());
+        assert!(mat_vert.is_err());
     }
 
     /// Ensure that vertical concatenation works correctly.


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements the MismatchingModulus error for concatenation of MatPolyRingZq elements.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
