### PR TITLE
PolyOverZq, ModulusPoly get_representative

### DIFF
--- a/benches/classic_crypto.rs
+++ b/benches/classic_crypto.rs
@@ -50,9 +50,20 @@ pub fn gen_prime_order_group_plus_generator(security_lvl: u32) -> (Modulus, Zq) 
 
     // choose generator s.t. `g^2 != 1 mod p` and `g^q != 1 mod p`
     let mut generator = Zq::sample_uniform(&modulus).unwrap();
-    while generator.pow(&two).unwrap().get_representative_0_modulus() == Z::ONE
-        || generator.pow(&q).unwrap().get_representative_0_modulus() == Z::ONE
-        || generator.clone().get_representative_0_modulus() == Z::ZERO
+    while generator
+        .pow(&two)
+        .unwrap()
+        .get_representative_least_nonnegative_residue()
+        == Z::ONE
+        || generator
+            .pow(&q)
+            .unwrap()
+            .get_representative_least_nonnegative_residue()
+            == Z::ONE
+        || generator
+            .clone()
+            .get_representative_least_nonnegative_residue()
+            == Z::ZERO
     {
         generator = Zq::sample_uniform(&modulus).unwrap();
     }
@@ -108,7 +119,7 @@ mod rsa_textbook {
         let sk = Zq::from((&pk, &phi_mod))
             .inverse()
             .expect("There must an inverse of this element as pk is prime.")
-            .get_representative_0_modulus();
+            .get_representative_least_nonnegative_residue();
 
         (modulus, pk, sk)
     }
@@ -133,7 +144,10 @@ mod rsa_textbook {
     ///
     /// `rsa_textbook.dec(N, sk, cipher) = cipher^sk mod N`
     pub fn dec(sk: &Z, cipher: &Zq) -> Z {
-        cipher.pow(sk).unwrap().get_representative_0_modulus()
+        cipher
+            .pow(sk)
+            .unwrap()
+            .get_representative_least_nonnegative_residue()
     }
 
     /// Run textbook RSA encryption with 1024 bit security.

--- a/src/integer/mat_poly_over_z/arithmetic/mul.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/mul.rs
@@ -35,7 +35,6 @@ impl Mul for &MatPolyOverZ {
     ///
     /// let a: MatPolyOverZ = MatPolyOverZ::from_str("[[0, 1  42, 2  42 24],[3  17 24 42, 1  17, 1  42]]").unwrap();
     /// let b: MatPolyOverZ = MatPolyOverZ::from_str("[[1  -42, 2  24 42],[1  -1, 1  17],[0, 2  1 42]]").unwrap();
-
     ///
     /// let c = &a * &b;
     /// let d = a * b;

--- a/src/integer/mat_poly_over_z/arithmetic/sub.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/sub.rs
@@ -67,7 +67,6 @@ impl MatPolyOverZ {
     /// let b: MatPolyOverZ = MatPolyOverZ::from_str("[[1  -42, 0, 2  24 42],[3  1 12 4, 1  -1, 1  17]]").unwrap();
     ///
     /// let c: MatPolyOverZ = a.sub_safe(&b).unwrap();
-
     /// ```
     /// # Errors
     /// - Returns a [`MathError`] of type

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -11,14 +11,11 @@
 //! The explicit functions contain the documentation.
 
 use super::PolyOverZ;
-use crate::integer_mod_q::PolyOverZq;
-use crate::macros::for_others::implement_for_owned;
 use crate::{
     error::{MathError, StringConversionError},
     integer::Z,
     traits::AsInteger,
 };
-use flint_sys::fmpz_mod_poly::fmpz_mod_poly_get_fmpz_poly;
 use flint_sys::fmpz_poly::{fmpz_poly_set_fmpz, fmpz_poly_set_str};
 use std::{ffi::CString, str::FromStr};
 
@@ -132,43 +129,6 @@ impl From<&PolyOverZ> for PolyOverZ {
     }
 }
 
-impl From<&PolyOverZq> for PolyOverZ {
-    /// Creates a [`PolyOverZ`] from a [`PolyOverZq`].
-    ///
-    /// Parameters:
-    /// - `poly`: the polynomial from which the coefficients are copied.
-    ///
-    /// Returns the representative polynomial (all reduced coefficients)
-    /// of the [`PolyOverZq`] as a [`PolyOverZ`].
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::integer::PolyOverZ;
-    /// use qfall_math::integer_mod_q::PolyOverZq;
-    /// use std::str::FromStr;
-    ///
-    /// let poly = PolyOverZq::from_str("4  0 1 5 3 mod 4").unwrap();
-    ///
-    /// let poly_z = PolyOverZ::from(&poly);
-    ///
-    /// # let cmp_poly = PolyOverZ::from_str("4  0 1 1 3").unwrap();
-    /// # assert_eq!(cmp_poly, poly_z);
-    /// ```
-    fn from(poly: &PolyOverZq) -> Self {
-        let mut out = Self::default();
-        unsafe {
-            fmpz_mod_poly_get_fmpz_poly(
-                &mut out.poly,
-                &poly.poly,
-                poly.modulus.get_fmpz_mod_ctx_struct(),
-            )
-        };
-        out
-    }
-}
-
-implement_for_owned!(PolyOverZq, PolyOverZ, From);
-
 #[cfg(test)]
 mod test_from_str {
     use super::PolyOverZ;
@@ -232,33 +192,6 @@ mod test_from_str {
         let poly = PolyOverZ::from_str("                   4  1 2 3 -4                  ");
         assert!(poly.is_ok());
         assert_eq!(PolyOverZ::from_str("4  1 2 3 -4").unwrap(), poly.unwrap());
-    }
-}
-
-#[cfg(test)]
-mod test_from_poly_over_zq {
-    use crate::{integer::PolyOverZ, integer_mod_q::PolyOverZq};
-    use std::str::FromStr;
-
-    /// Ensure that the conversion works with positive large entries
-    #[test]
-    fn large_positive() {
-        let poly = PolyOverZq::from_str(&format!("4  0 1 102 {} mod {}", u64::MAX - 58, u64::MAX))
-            .unwrap();
-
-        let poly_z = PolyOverZ::from(&poly);
-
-        let cmp_poly = PolyOverZ::from_str(&format!("4  0 1 102 {}", u64::MAX - 58)).unwrap();
-        assert_eq!(cmp_poly, poly_z);
-    }
-
-    /// Ensure that the conversion works for owned values
-    #[test]
-    fn availability() {
-        let poly = PolyOverZq::from_str(&format!("4  0 1 102 {} mod {}", u64::MAX - 58, u64::MAX))
-            .unwrap();
-
-        let _ = PolyOverZ::from(poly);
     }
 }
 

--- a/src/integer/poly_over_z/norm.rs
+++ b/src/integer/poly_over_z/norm.rs
@@ -39,6 +39,7 @@ impl PolyOverZ {
         }
         res
     }
+
     /// Returns the infinity norm or the maximal absolute value of a
     /// coefficient of the given polynomial.
     ///

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
@@ -315,7 +315,7 @@ impl MatPolynomialRingZq {
             )));
         }
 
-        Ok(self * scalar)
+        Ok(self * scalar.get_representative_0_modulus())
     }
 
     /// Implements multiplication for a [`MatPolynomialRingZq`] matrix with a [`PolynomialRingZq`].

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
@@ -315,7 +315,7 @@ impl MatPolynomialRingZq {
             )));
         }
 
-        Ok(self * PolyOverZ::from(scalar))
+        Ok(self * scalar)
     }
 
     /// Implements multiplication for a [`MatPolynomialRingZq`] matrix with a [`PolynomialRingZq`].

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
@@ -315,7 +315,7 @@ impl MatPolynomialRingZq {
             )));
         }
 
-        Ok(self * scalar.get_representative_0_modulus())
+        Ok(self * scalar.get_representative_least_nonnegative_residue())
     }
 
     /// Implements multiplication for a [`MatPolynomialRingZq`] matrix with a [`PolynomialRingZq`].

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -56,12 +56,12 @@ impl MatPolynomialRingZq {
     /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
     /// let poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
     ///
-    /// let matrix = poly_ring_mat.get_representative_0_modulus();
+    /// let matrix = poly_ring_mat.get_representative_least_nonnegative_residue();
     ///
     /// let cmp_poly_mat = MatPolyOverZ::from_str("[[3  15 0 1, 1  8],[0, 2  1 2]]").unwrap();
     /// assert_eq!(cmp_poly_mat, matrix);
     /// ```
-    pub fn get_representative_0_modulus(&self) -> MatPolyOverZ {
+    pub fn get_representative_least_nonnegative_residue(&self) -> MatPolyOverZ {
         self.matrix.clone()
     }
 }
@@ -538,7 +538,7 @@ mod test_mod {
 }
 
 #[cfg(test)]
-mod test_get_representative_0_modulus {
+mod test_get_representative_least_nonnegative_residue {
     use crate::{
         integer::MatPolyOverZ,
         integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq},
@@ -549,7 +549,7 @@ mod test_get_representative_0_modulus {
 
     /// Ensure that the getter for a large modulus and large entries works.
     #[test]
-    fn get_representative_0_modulus_large_entry_and_modulus() {
+    fn get_representative_least_nonnegative_residue_large_entry_and_modulus() {
         let modulus =
             ModulusPolynomialRingZq::from_str(&format!("5  42 0 0 0 1 mod {LARGE_PRIME}")).unwrap();
         let poly_mat = MatPolyOverZ::from_str("[[4  1 0 0 1, 1  42],[0, 1  -1]]").unwrap();
@@ -561,7 +561,7 @@ mod test_get_representative_0_modulus {
                 LARGE_PRIME - 1
             ))
             .unwrap(),
-            matrix.get_representative_0_modulus()
+            matrix.get_representative_least_nonnegative_residue()
         )
     }
 }

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -31,7 +31,7 @@ impl MatZq {
     /// equivalence class of each entry from a [`MatZq`].
     ///
     /// The values in the output matrix are in the range of `[0, modulus)`.
-    /// Use [`MatZq::get_representative_around_0`] if they should be
+    /// Use [`MatZq::get_representative_least_absolute_residue`] if they should be
     /// in the range `[-modulus/2, modulus/2]`.
     ///
     /// Returns the matrix as a [`MatZ`].
@@ -44,11 +44,11 @@ impl MatZq {
     ///
     /// let mat_zq = MatZq::from_str("[[1, 2],[3, -1]] mod 5").unwrap();
     ///
-    /// let mat_z = mat_zq.get_representative_0_modulus();
+    /// let mat_z = mat_zq.get_representative_least_nonnegative_residue();
     ///
     /// assert_eq!(mat_z.to_string(), "[[1, 2],[3, 4]]");
     /// ```
-    pub fn get_representative_0_modulus(&self) -> MatZ {
+    pub fn get_representative_least_nonnegative_residue(&self) -> MatZ {
         let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns());
         unsafe { fmpz_mat_set(&mut out.matrix, &self.matrix.mat[0]) };
         out
@@ -60,7 +60,7 @@ impl MatZq {
     ///
     /// The values in the output matrix are in the range of `[-modulus/2, modulus/2]`.
     /// For even moduli, the positive representative is chosen for the element `modulus / 2`.
-    /// Use [`MatZq::get_representative_0_modulus`] if they should be
+    /// Use [`MatZq::get_representative_least_nonnegative_residue`] if they should be
     /// in the range `[0, modulus)`.
     ///
     /// Returns an [`MatZ`] representation of the given matrix with
@@ -74,13 +74,13 @@ impl MatZq {
     /// let mat_zq_1 = MatZq::from_str("[[1,2],[3,4]] mod 5").unwrap();
     /// let mat_zq_2 = MatZq::from_str("[[1,2],[3,4]] mod 4").unwrap();
     ///
-    /// let mat_z_1 = mat_zq_1.get_representative_around_0();
-    /// let mat_z_2 = mat_zq_2.get_representative_around_0();
+    /// let mat_z_1 = mat_zq_1.get_representative_least_absolute_residue();
+    /// let mat_z_2 = mat_zq_2.get_representative_least_absolute_residue();
     ///
     /// assert_eq!(mat_z_1.to_string(), "[[1, 2],[-2, -1]]");
     /// assert_eq!(mat_z_2.to_string(), "[[1, 2],[-1, 0]]");
     /// ```
-    pub fn get_representative_around_0(&self) -> MatZ {
+    pub fn get_representative_least_absolute_residue(&self) -> MatZ {
         let modulus: Z = Z::from(&self.modulus);
         let modulus_half = modulus.div_floor(2);
 
@@ -648,7 +648,7 @@ mod test_get_num {
 }
 
 #[cfg(test)]
-mod test_get_representative_0_modulus {
+mod test_get_representative_least_nonnegative_residue {
     use crate::{
         integer::Z,
         integer_mod_q::MatZq,
@@ -660,7 +660,7 @@ mod test_get_representative_0_modulus {
     fn dimensions() {
         let matzq = MatZq::new(15, 17, 13);
 
-        let matz_1 = matzq.get_representative_0_modulus();
+        let matz_1 = matzq.get_representative_least_nonnegative_residue();
 
         assert_eq!(15, matz_1.get_num_rows());
         assert_eq!(17, matz_1.get_num_columns());
@@ -673,7 +673,7 @@ mod test_get_representative_0_modulus {
         matzq.set_entry(0, 0, u64::MAX - 58).unwrap();
         matzq.set_entry(0, 1, -1).unwrap();
 
-        let matz_1 = matzq.get_representative_0_modulus();
+        let matz_1 = matzq.get_representative_least_nonnegative_residue();
 
         assert_eq!(Z::from(u64::MAX - 1), matz_1.get_entry(0, 1).unwrap());
         assert_eq!(Z::from(u64::MAX - 58), matz_1.get_entry(0, 0).unwrap());
@@ -989,7 +989,7 @@ mod test_collect_lengths {
 }
 
 #[cfg(test)]
-mod test_get_representative_around_0 {
+mod test_get_representative_least_absolute_residue {
     use super::*;
     use std::str::FromStr;
 
@@ -998,7 +998,7 @@ mod test_get_representative_around_0 {
     fn large_modulus() {
         let mat_zq = MatZq::from_str(&format!("[[1,2],[-1,-2]] mod {}", u64::MAX)).unwrap();
 
-        let mat_z = mat_zq.get_representative_around_0();
+        let mat_z = mat_zq.get_representative_least_absolute_residue();
 
         let mat_cmp = MatZ::from_str("[[1,2],[-1,-2]]").unwrap();
         assert_eq!(mat_z.to_string(), mat_cmp.to_string());
@@ -1009,7 +1009,7 @@ mod test_get_representative_around_0 {
     fn even_modulus() {
         let mat_zq = MatZq::from_str("[[0,1,2,3,4,5,6,7,8,9,10]] mod 10").unwrap();
 
-        let mat_z = mat_zq.get_representative_around_0();
+        let mat_z = mat_zq.get_representative_least_absolute_residue();
 
         let mat_cmp = MatZ::from_str("[[0,1,2,3,4,5,-4,-3,-2,-1,0]]").unwrap();
         assert_eq!(mat_z.to_string(), mat_cmp.to_string());
@@ -1020,7 +1020,7 @@ mod test_get_representative_around_0 {
     fn uneven_modulus() {
         let mat_zq = MatZq::from_str("[[0,1,2,3,4,5,6,7,8,9,10,11]] mod 11").unwrap();
 
-        let mat_z = mat_zq.get_representative_around_0();
+        let mat_z = mat_zq.get_representative_least_absolute_residue();
 
         let mat_cmp = MatZ::from_str("[[0,1,2,3,4,5,-5,-4,-3,-2,-1,0]]").unwrap();
         assert_eq!(mat_z.to_string(), mat_cmp.to_string());

--- a/src/integer_mod_q/mat_zq/inverse.rs
+++ b/src/integer_mod_q/mat_zq/inverse.rs
@@ -34,7 +34,7 @@ impl MatZq {
     /// ```
     pub fn inverse(&self) -> Option<MatZq> {
         // Check if the matrix is square and compute the determinant.
-        if let Ok(det) = self.get_representative_0_modulus().det() {
+        if let Ok(det) = self.get_representative_least_nonnegative_residue().det() {
             // Check whether the square matrix is invertible or not.
             if det.gcd(self.get_mod()) != Z::ONE {
                 None
@@ -93,7 +93,7 @@ impl MatZq {
         );
 
         // Check if the matrix is square and compute the determinant.
-        if let Ok(det) = self.get_representative_0_modulus().det() {
+        if let Ok(det) = self.get_representative_least_nonnegative_residue().det() {
             if det == Z::ZERO {
                 None
             } else {

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -119,7 +119,12 @@ impl MatZq {
         let n: Z = n.into();
         let s: Q = s.into();
 
-        let sample = sample_d(&basis.get_representative_0_modulus(), &n, center, &s)?;
+        let sample = sample_d(
+            &basis.get_representative_least_nonnegative_residue(),
+            &n,
+            center,
+            &s,
+        )?;
 
         Ok(MatZq::from((&sample, basis.get_mod())))
     }
@@ -177,7 +182,7 @@ impl MatZq {
     /// use qfall_math::{integer::MatZ, integer_mod_q::MatZq, rational::MatQ};
     /// let basis = MatZq::identity(5, 5, 17);
     /// let center = MatQ::new(5, 1);
-    /// let basis_gso = MatQ::from(&basis.get_representative_0_modulus()).gso();
+    /// let basis_gso = MatQ::from(&basis.get_representative_least_nonnegative_residue()).gso();
     ///
     /// let sample = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 1024, &center, 1.25f32).unwrap();
     /// ```
@@ -209,7 +214,7 @@ impl MatZq {
         let s: Q = s.into();
 
         let sample = sample_d_precomputed_gso(
-            &basis.get_representative_0_modulus(),
+            &basis.get_representative_least_nonnegative_residue(),
             basis_gso,
             &n,
             center,
@@ -302,7 +307,7 @@ mod test_sample_d {
         let n = Z::from(1024);
         let center = MatQ::new(5, 1);
         let s = Q::ONE;
-        let basis_gso = MatQ::from(&basis.get_representative_0_modulus());
+        let basis_gso = MatQ::from(&basis.get_representative_least_nonnegative_residue());
 
         let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 16u16, &center, 1u16);
         let _ = MatZq::sample_d_precomputed_gso(&basis, &basis_gso, 2u32, &center, 1u8);

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -350,7 +350,7 @@ impl MatZq {
             b_i = MatZq::from((
                 &(unsafe {
                     (b_i - &invertible_matrix * x_i)
-                        .get_representative_0_modulus()
+                        .get_representative_least_nonnegative_residue()
                         .div_exact(base)
                 }),
                 &self.get_mod(),
@@ -652,11 +652,17 @@ mod test_find_invertible_entry_column {
 
         let (i, entry) = find_invertible_entry_column(&mat, 0, &Vec::new()).unwrap();
         assert_eq!(0, i);
-        assert_eq!(Z::from(7), entry.get_representative_0_modulus());
+        assert_eq!(
+            Z::from(7),
+            entry.get_representative_least_nonnegative_residue()
+        );
 
         let (i, entry) = find_invertible_entry_column(&mat, 0, [0].as_ref()).unwrap();
         assert_eq!(1, i);
-        assert_eq!(Z::from(5), entry.get_representative_0_modulus());
+        assert_eq!(
+            Z::from(5),
+            entry.get_representative_least_nonnegative_residue()
+        );
 
         let invert = find_invertible_entry_column(&mat, 0, [0, 1].as_ref());
         assert!(invert.is_none())

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -10,8 +10,8 @@
 
 use crate::{
     error::MathError,
-    integer::Z,
-    integer_mod_q::{Modulus, ModulusPolynomialRingZq, Zq},
+    integer::{PolyOverZ, Z},
+    integer_mod_q::{Modulus, ModulusPolynomialRingZq, PolyOverZq, Zq},
     traits::GetCoefficient,
     utils::index::evaluate_index,
 };
@@ -163,6 +163,28 @@ impl ModulusPolynomialRingZq {
     pub fn get_degree(&self) -> i64 {
         unsafe { fq_ctx_degree(self.get_fq_ctx_struct()) }
     }
+
+    /// Returns a representative polynomial of the [`ModulusPolynomialRingZq`] element.
+    ///
+    /// The representation of the coefficients is in the range `[0, modulus)`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::PolyOverZ;
+    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  -3 0 31 1 mod 17").unwrap();
+    ///
+    /// let poly_z = modulus.get_representative_0_modulus();
+    ///
+    /// let cmp_poly = PolyOverZ::from_str("4  14 0 14 1").unwrap();
+    /// assert_eq!(cmp_poly, poly_z);
+    /// ```
+    pub fn get_representative_0_modulus(&self) -> PolyOverZ {
+        let poly_zq = PolyOverZq::from(self);
+        poly_zq.get_representative_0_modulus()
+    }
 }
 
 #[cfg(test)]
@@ -299,5 +321,29 @@ mod test_get_q {
 
         let cmp_modulus = Z::from(large_prime);
         assert_eq!(cmp_modulus, modulus);
+    }
+}
+
+#[cfg(test)]
+mod test_get_representative_0_modulus {
+    use crate::{
+        integer::PolyOverZ,
+        integer_mod_q::{ModulusPolynomialRingZq, PolynomialRingZq},
+    };
+    use std::str::FromStr;
+
+    /// Ensure that the getter works for large entries.
+    #[test]
+    fn large_positive() {
+        let large_prime = u64::MAX - 58;
+        let modulus =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {large_prime}")).unwrap();
+        let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
+        let poly_ring = PolynomialRingZq::from((&poly, &modulus));
+
+        let poly_z = poly_ring.get_representative_0_modulus();
+
+        let cmp_poly = PolyOverZ::from_str(&format!("3  {} 0 1", u64::MAX - 60)).unwrap();
+        assert_eq!(cmp_poly, poly_z);
     }
 }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -176,14 +176,14 @@ impl ModulusPolynomialRingZq {
     ///
     /// let modulus = ModulusPolynomialRingZq::from_str("4  -3 0 31 1 mod 17").unwrap();
     ///
-    /// let poly_z = modulus.get_representative_0_modulus();
+    /// let poly_z = modulus.get_representative_least_nonnegative_residue();
     ///
     /// let cmp_poly = PolyOverZ::from_str("4  14 0 14 1").unwrap();
     /// assert_eq!(cmp_poly, poly_z);
     /// ```
-    pub fn get_representative_0_modulus(&self) -> PolyOverZ {
+    pub fn get_representative_least_nonnegative_residue(&self) -> PolyOverZ {
         let poly_zq = PolyOverZq::from(self);
-        poly_zq.get_representative_0_modulus()
+        poly_zq.get_representative_least_nonnegative_residue()
     }
 }
 
@@ -325,7 +325,7 @@ mod test_get_q {
 }
 
 #[cfg(test)]
-mod test_get_representative_0_modulus {
+mod test_get_representative_least_nonnegative_residue {
     use crate::{
         integer::PolyOverZ,
         integer_mod_q::{ModulusPolynomialRingZq, PolynomialRingZq},
@@ -341,7 +341,7 @@ mod test_get_representative_0_modulus {
         let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
         let poly_ring = PolynomialRingZq::from((&poly, &modulus));
 
-        let poly_z = poly_ring.get_representative_0_modulus();
+        let poly_z = poly_ring.get_representative_least_nonnegative_residue();
 
         let cmp_poly = PolyOverZ::from_str(&format!("3  {} 0 1", u64::MAX - 60)).unwrap();
         assert_eq!(cmp_poly, poly_z);

--- a/src/integer_mod_q/poly_over_zq/get.rs
+++ b/src/integer_mod_q/poly_over_zq/get.rs
@@ -11,12 +11,14 @@
 use super::PolyOverZq;
 use crate::{
     error::MathError,
-    integer::Z,
+    integer::{PolyOverZ, Z},
     integer_mod_q::{Modulus, Zq},
     traits::GetCoefficient,
     utils::index::evaluate_index,
 };
-use flint_sys::fmpz_mod_poly::{fmpz_mod_poly_degree, fmpz_mod_poly_get_coeff_fmpz};
+use flint_sys::fmpz_mod_poly::{
+    fmpz_mod_poly_degree, fmpz_mod_poly_get_coeff_fmpz, fmpz_mod_poly_get_fmpz_poly,
+};
 use std::fmt::Display;
 
 impl GetCoefficient<Zq> for PolyOverZq {
@@ -133,6 +135,35 @@ impl PolyOverZq {
     /// ```
     pub fn get_mod(&self) -> Modulus {
         self.modulus.clone()
+    }
+
+    /// Returns a representative polynomial of the [`PolyOverZq`] element.
+    ///
+    /// The representation of the coefficients is in the range `[0, modulus)`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::PolyOverZ;
+    /// use qfall_math::integer_mod_q::PolyOverZq;
+    /// use std::str::FromStr;
+    ///
+    /// let poly_zq = PolyOverZq::from_str("4  -3 0 31 1 mod 17").unwrap();
+    ///
+    /// let poly_z = poly_zq.get_representative_0_modulus();
+    ///
+    /// let cmp_poly = PolyOverZ::from_str("4  14 0 14 1").unwrap();
+    /// assert_eq!(cmp_poly, poly_z);
+    /// ```
+    pub fn get_representative_0_modulus(&self) -> PolyOverZ {
+        let mut out = PolyOverZ::default();
+        unsafe {
+            fmpz_mod_poly_get_fmpz_poly(
+                &mut out.poly,
+                &self.poly,
+                self.modulus.get_fmpz_mod_ctx_struct(),
+            )
+        };
+        out
     }
 }
 
@@ -303,5 +334,23 @@ mod test_mod {
         let poly = PolyOverZq::from_str(&format!("2  1 2 mod {}", u64::MAX)).unwrap();
 
         assert_eq!(poly.get_mod(), Modulus::from(u64::MAX));
+    }
+}
+
+#[cfg(test)]
+mod test_get_representative_0_modulus {
+    use crate::{integer::PolyOverZ, integer_mod_q::PolyOverZq};
+    use std::str::FromStr;
+
+    /// Ensure that the getter works for large entries.
+    #[test]
+    fn large_positive() {
+        let large_prime = u64::MAX - 58;
+        let poly_zq = PolyOverZq::from_str(&format!("4  -1 0 0 1 mod {large_prime}")).unwrap();
+
+        let poly_z = poly_zq.get_representative_0_modulus();
+
+        let cmp_poly = PolyOverZ::from_str(&format!("4  {} 0 0 1", u64::MAX - 59)).unwrap();
+        assert_eq!(cmp_poly, poly_z);
     }
 }

--- a/src/integer_mod_q/poly_over_zq/get.rs
+++ b/src/integer_mod_q/poly_over_zq/get.rs
@@ -149,12 +149,12 @@ impl PolyOverZq {
     ///
     /// let poly_zq = PolyOverZq::from_str("4  -3 0 31 1 mod 17").unwrap();
     ///
-    /// let poly_z = poly_zq.get_representative_0_modulus();
+    /// let poly_z = poly_zq.get_representative_least_nonnegative_residue();
     ///
     /// let cmp_poly = PolyOverZ::from_str("4  14 0 14 1").unwrap();
     /// assert_eq!(cmp_poly, poly_z);
     /// ```
-    pub fn get_representative_0_modulus(&self) -> PolyOverZ {
+    pub fn get_representative_least_nonnegative_residue(&self) -> PolyOverZ {
         let mut out = PolyOverZ::default();
         unsafe {
             fmpz_mod_poly_get_fmpz_poly(
@@ -338,7 +338,7 @@ mod test_mod {
 }
 
 #[cfg(test)]
-mod test_get_representative_0_modulus {
+mod test_get_representative_least_nonnegative_residue {
     use crate::{integer::PolyOverZ, integer_mod_q::PolyOverZq};
     use std::str::FromStr;
 
@@ -348,7 +348,7 @@ mod test_get_representative_0_modulus {
         let large_prime = u64::MAX - 58;
         let poly_zq = PolyOverZq::from_str(&format!("4  -1 0 0 1 mod {large_prime}")).unwrap();
 
-        let poly_z = poly_zq.get_representative_0_modulus();
+        let poly_z = poly_zq.get_representative_least_nonnegative_residue();
 
         let cmp_poly = PolyOverZ::from_str(&format!("4  {} 0 0 1", u64::MAX - 59)).unwrap();
         assert_eq!(cmp_poly, poly_z);

--- a/src/integer_mod_q/polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/get.rs
@@ -271,7 +271,7 @@ mod test_get_representative_0_modulus {
     };
     use std::str::FromStr;
 
-    /// Ensure that the getter returns for large entries.
+    /// Ensure that the getter works for large entries.
     #[test]
     fn large_positive() {
         let large_prime = u64::MAX - 58;

--- a/src/integer_mod_q/polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/get.rs
@@ -136,12 +136,12 @@ impl PolynomialRingZq {
     /// let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
     /// let poly_ring = PolynomialRingZq::from((&poly, &modulus));
     ///
-    /// let poly_z = poly_ring.get_representative_0_modulus();
+    /// let poly_z = poly_ring.get_representative_least_nonnegative_residue();
     ///
     /// let cmp_poly = PolyOverZ::from_str("3  15 0 1").unwrap();
     /// assert_eq!(cmp_poly, poly_z);
     /// ```
-    pub fn get_representative_0_modulus(&self) -> PolyOverZ {
+    pub fn get_representative_least_nonnegative_residue(&self) -> PolyOverZ {
         self.poly.clone()
     }
 
@@ -264,7 +264,7 @@ mod test_get_mod {
 }
 
 #[cfg(test)]
-mod test_get_representative_0_modulus {
+mod test_get_representative_least_nonnegative_residue {
     use crate::{
         integer::PolyOverZ,
         integer_mod_q::{ModulusPolynomialRingZq, PolynomialRingZq},
@@ -280,7 +280,7 @@ mod test_get_representative_0_modulus {
         let poly = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
         let poly_ring = PolynomialRingZq::from((&poly, &modulus));
 
-        let poly_z = poly_ring.get_representative_0_modulus();
+        let poly_z = poly_ring.get_representative_least_nonnegative_residue();
 
         let cmp_poly = PolyOverZ::from_str(&format!("3  {} 0 1", u64::MAX - 60)).unwrap();
         assert_eq!(cmp_poly, poly_z);

--- a/src/integer_mod_q/z_q/get.rs
+++ b/src/integer_mod_q/z_q/get.rs
@@ -17,7 +17,7 @@ impl Zq {
     /// Returns the [`Z`] value of the [`Zq`] element.
     ///
     /// The representation in the range `[0, modulus)` is returned.
-    /// Use [`Zq::get_representative_around_0`] if they should be
+    /// Use [`Zq::get_representative_least_absolute_residue`] if they should be
     /// in the range `[-modulus/2, modulus/2]`.
     ///
     /// # Examples
@@ -26,11 +26,11 @@ impl Zq {
     /// use qfall_math::integer::Z;
     /// let zq_value = Zq::from((4, 7));
     ///
-    /// let z_value = zq_value.get_representative_0_modulus();
+    /// let z_value = zq_value.get_representative_least_nonnegative_residue();
     ///
     /// assert_eq!(Z::from(4), z_value);
     /// ```
-    pub fn get_representative_0_modulus(&self) -> Z {
+    pub fn get_representative_least_nonnegative_residue(&self) -> Z {
         self.value.clone()
     }
 
@@ -38,7 +38,7 @@ impl Zq {
     ///
     /// The output value is in the range of `[-modulus/2, modulus/2]`.
     /// For even moduli, the positive representative is chosen for the element `modulus / 2`.
-    /// Use [`Zq::get_representative_0_modulus`] if they should be
+    /// Use [`Zq::get_representative_least_nonnegative_residue`] if they should be
     /// in the range `[0, modulus)`.
     ///
     /// # Examples
@@ -47,11 +47,11 @@ impl Zq {
     /// use qfall_math::integer::Z;
     /// let zq_value = Zq::from((5, 7));
     ///
-    /// let z_value = zq_value.get_representative_around_0();
+    /// let z_value = zq_value.get_representative_least_absolute_residue();
     ///
     /// assert_eq!(Z::from(2), z_value);
     /// ```
-    pub fn get_representative_around_0(&self) -> Z {
+    pub fn get_representative_least_absolute_residue(&self) -> Z {
         let mod_z = Z::from(&self.modulus);
         if self.value < mod_z.div_ceil(2) {
             self.value.clone()
@@ -79,30 +79,30 @@ impl Zq {
 }
 
 #[cfg(test)]
-mod test_get_representative_0_modulus {
+mod test_get_representative_least_nonnegative_residue {
     use super::{Zq, Z};
 
-    /// Check whether `get_representative_0_modulus` outputs the correct value for small values
+    /// Check whether `get_representative_least_nonnegative_residue` outputs the correct value for small values
     #[test]
     fn get_small() {
         let value_0 = Zq::from((2, 20));
         let value_1 = Zq::from((-2, 20));
 
-        let res_0 = value_0.get_representative_0_modulus();
-        let res_1 = value_1.get_representative_0_modulus();
+        let res_0 = value_0.get_representative_least_nonnegative_residue();
+        let res_1 = value_1.get_representative_least_nonnegative_residue();
 
         assert_eq!(res_0, Z::from(2));
         assert_eq!(res_1, Z::from(18));
     }
 
-    /// Check whether `get_representative_0_modulus` outputs the correct value for large values
+    /// Check whether `get_representative_least_nonnegative_residue` outputs the correct value for large values
     #[test]
     fn get_large() {
         let value_0 = Zq::from((i64::MAX, u64::MAX));
         let value_1 = Zq::from((i64::MIN, u64::MAX));
 
-        let res_0 = value_0.get_representative_0_modulus();
-        let res_1 = value_1.get_representative_0_modulus();
+        let res_0 = value_0.get_representative_least_nonnegative_residue();
+        let res_1 = value_1.get_representative_least_nonnegative_residue();
 
         assert_eq!(res_0, Z::from(i64::MAX));
         assert_eq!(res_1, Z::from(i64::MAX));
@@ -110,43 +110,43 @@ mod test_get_representative_0_modulus {
 }
 
 #[cfg(test)]
-mod test_get_representative_around_0 {
+mod test_get_representative_least_absolute_residue {
     use super::{Zq, Z};
 
-    /// Check whether `get_representative_around_0` outputs the correct value for small values
+    /// Check whether `get_representative_least_absolute_residue` outputs the correct value for small values
     #[test]
     fn get_small() {
         let value_0 = Zq::from((2, 20));
         let value_1 = Zq::from((-2, 20));
 
-        let res_0 = value_0.get_representative_around_0();
-        let res_1 = value_1.get_representative_around_0();
+        let res_0 = value_0.get_representative_least_absolute_residue();
+        let res_1 = value_1.get_representative_least_absolute_residue();
 
         assert_eq!(res_0, Z::from(2));
         assert_eq!(res_1, Z::from(2));
     }
 
-    /// Check whether `get_representative_around_0` outputs the correct value for large values
+    /// Check whether `get_representative_least_absolute_residue` outputs the correct value for large values
     #[test]
     fn get_large() {
         let value_0 = Zq::from((i64::MAX, u64::MAX));
         let value_1 = Zq::from((u64::MAX - 1, u64::MAX));
 
-        let res_0 = value_0.get_representative_around_0();
-        let res_1 = value_1.get_representative_around_0();
+        let res_0 = value_0.get_representative_least_absolute_residue();
+        let res_1 = value_1.get_representative_least_absolute_residue();
 
         assert_eq!(res_0, Z::from(i64::MAX));
         assert_eq!(res_1, Z::from(1));
     }
 
-    /// Check whether `get_representative_around_0` outputs the correct value for special cases
+    /// Check whether `get_representative_least_absolute_residue` outputs the correct value for special cases
     #[test]
     fn get_special() {
         let value_0 = Zq::from((10, 20));
         let value_1 = Zq::from((0, 20));
 
-        let res_0 = value_0.get_representative_around_0();
-        let res_1 = value_1.get_representative_around_0();
+        let res_0 = value_0.get_representative_least_absolute_residue();
+        let res_1 = value_1.get_representative_least_absolute_residue();
 
         assert_eq!(res_0, Z::from(10));
         assert_eq!(res_1, Z::from(0));

--- a/src/integer_mod_q/z_q/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/z_q/sample/discrete_gauss.rs
@@ -117,8 +117,8 @@ mod test_sample_discrete_gauss {
         // count sampled instances
         for _ in 0..200 {
             let sample = Zq::sample_discrete_gauss(20, 1024, 0, 2).unwrap();
-            let sample_int =
-                i64::try_from(&sample.get_representative_0_modulus()).unwrap() as usize;
+            let sample_int = i64::try_from(&sample.get_representative_least_nonnegative_residue())
+                .unwrap() as usize;
             counts[sample_int] += 1;
         }
 

--- a/src/integer_mod_q/z_q/to_string.rs
+++ b/src/integer_mod_q/z_q/to_string.rs
@@ -90,7 +90,10 @@ impl Zq {
     /// - Returns a [`FromUtf8Error`] if the integer's byte sequence contains
     ///     invalid UTF8-characters.
     pub fn to_utf8(&self) -> Result<String, FromUtf8Error> {
-        String::from_utf8(self.get_representative_0_modulus().to_bytes())
+        String::from_utf8(
+            self.get_representative_least_nonnegative_residue()
+                .to_bytes(),
+        )
     }
 }
 


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements get_representative for PolyOverZq and ModulusPolynomialRingZq. Furthermore, it deletes from<PolyOverZq> for PolyOverZ and renames the get_representative functions to a more meaningful name.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
