### PR TITLE
Matrix multiplication bug fix

### DIFF
--- a/src/integer/mat_z/arithmetic/mul.rs
+++ b/src/integer/mat_z/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer, Phil Milewski
+// Copyright © 2023 Niklas Siemer, Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //
@@ -10,11 +10,15 @@
 
 use super::super::MatZ;
 use crate::error::MathError;
+use crate::integer_mod_q::MatZq;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
 };
+use crate::rational::MatQ;
 use crate::traits::{GetNumColumns, GetNumRows};
+use flint_sys::fmpq_mat::fmpq_mat_mul_r_fmpz_mat;
 use flint_sys::fmpz_mat::fmpz_mat_mul;
+use flint_sys::fmpz_mod_mat::_fmpz_mod_mat_reduce;
 use std::ops::Mul;
 
 impl Mul for &MatZ {
@@ -48,6 +52,105 @@ impl Mul for &MatZ {
         self.mul_safe(other).unwrap()
     }
 }
+
+arithmetic_trait_borrowed_to_owned!(Mul, mul, MatZ, MatZ, MatZ);
+arithmetic_trait_mixed_borrowed_owned!(Mul, mul, MatZ, MatZ, MatZ);
+
+impl Mul<&MatZq> for &MatZ {
+    type Output = MatZq;
+
+    /// Implements the [`Mul`] trait for [`MatZ`] and [`MatZq`].
+    /// [`Mul`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to multiply with `self`
+    ///
+    /// Returns the product of `self` and `other` as a [`MatZq`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::MatZq;
+    /// use qfall_math::integer::MatZ;
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatZ::identity(2, 2);
+    /// let b = MatZq::from_str("[[2, 1],[1, 2]] mod 3").unwrap();
+    ///
+    /// let c = &a * &b;
+    /// let d = a * b;
+    /// let e = &MatZ::identity(2, 2) * d;
+    /// let f = MatZ::identity(2, 2) * &e;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
+    fn mul(self, other: &MatZq) -> Self::Output {
+        assert_eq!(
+            self.get_num_columns(),
+            other.get_num_rows(),
+            "Tried to multiply matrices with mismatching matrix dimensions."
+        );
+
+        let mut new = MatZq::new(
+            self.get_num_rows(),
+            other.get_num_columns(),
+            other.get_mod(),
+        );
+        unsafe {
+            fmpz_mat_mul(&mut new.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
+            _fmpz_mod_mat_reduce(&mut new.matrix)
+        }
+        new
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Mul, mul, MatZ, MatZq, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Mul, mul, MatZ, MatZq, MatZq);
+
+impl Mul<&MatQ> for &MatZ {
+    type Output = MatQ;
+
+    /// Implements the [`Mul`] trait for [`MatZ`] and [`MatQ`].
+    /// [`Mul`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to multiply with `self`
+    ///
+    /// Returns the product of `self` and `other` as a [`MatQ`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatZ;
+    /// use qfall_math::rational::MatQ;
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatZ::identity(2, 2);
+    /// let b = MatQ::from_str("[[2/3, 1/2],[8/4, 7]]").unwrap();
+    ///
+    ///
+    /// let c = &a * &b;
+    /// let d = a * b;
+    /// let e = &MatZ::identity(2, 2) * c;
+    /// let f = MatZ::identity(2, 2) * &e;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
+    fn mul(self, other: &MatQ) -> Self::Output {
+        assert_eq!(
+            self.get_num_columns(),
+            other.get_num_rows(),
+            "Tried to multiply matrices with mismatching matrix dimensions."
+        );
+
+        let mut new = MatQ::new(self.get_num_rows(), other.get_num_columns());
+        unsafe { fmpq_mat_mul_r_fmpz_mat(&mut new.matrix, &self.matrix, &other.matrix) };
+        new
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Mul, mul, MatZ, MatQ, MatQ);
+arithmetic_trait_mixed_borrowed_owned!(Mul, mul, MatZ, MatQ, MatQ);
 
 impl MatZ {
     /// Implements multiplication for two [`MatZ`] values.
@@ -89,9 +192,6 @@ impl MatZ {
         Ok(new)
     }
 }
-
-arithmetic_trait_borrowed_to_owned!(Mul, mul, MatZ, MatZ, MatZ);
-arithmetic_trait_mixed_borrowed_owned!(Mul, mul, MatZ, MatZ, MatZ);
 
 #[cfg(test)]
 mod test_mul {
@@ -141,5 +241,111 @@ mod test_mul {
         let mat_2 = MatZ::from_str("[[1, 0],[0, 1],[0, 0]]").unwrap();
 
         assert!((mat_1.mul_safe(&mat_2)).is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_mul_matzq {
+    use super::MatZq;
+    use crate::integer::MatZ;
+    use crate::{integer::Z, traits::SetEntry};
+    use std::str::FromStr;
+
+    /// Checks if matrix multiplication works fine for squared matrices
+    #[test]
+    fn square_correctness() {
+        let mat_1 = MatZ::from_str("[[2, 1],[1, 2]]").unwrap();
+        let mat_2 = MatZq::identity(2, 2, 3);
+        let mat_3 = MatZq::from_str("[[1, 2],[2, 1]] mod 3").unwrap();
+        let cmp = MatZq::from_str("[[4, 5],[2, 4]] mod 3").unwrap();
+
+        assert_eq!(MatZq::from((&mat_1, 3)), &mat_1 * &mat_2);
+        assert_eq!(cmp, &mat_1 * &mat_3);
+    }
+
+    /// Checks if matrix multiplication works fine for matrices of different dimensions
+    #[test]
+    fn different_dimensions_correctness() {
+        let mat = MatZq::from_str("[[2, 1],[1, 2]] mod 3").unwrap();
+        let vec = MatZ::from_str("[[2, 0]]").unwrap();
+        let cmp = MatZq::from_str("[[4, 2]] mod 3").unwrap();
+
+        assert_eq!(cmp, &vec * &mat);
+    }
+
+    /// Checks if matrix multiplication works fine for large entries
+    #[test]
+    fn large_entries() {
+        let mat =
+            MatZq::from_str(&format!("[[{}, 0],[1, 2]] mod {}", u64::MAX, u64::MAX - 58)).unwrap();
+        let vec = MatZ::from_str(&format!("[[{}, 0]]", u64::MAX)).unwrap();
+        let mut cmp = MatZq::new(1, 2, u64::MAX - 58);
+        let max: Z = u64::MAX.into();
+        cmp.set_entry(0, 0, &(&max * &max)).unwrap();
+
+        assert_eq!(cmp, vec * mat);
+    }
+
+    /// Checks if matrix multiplication with incompatible matrix dimensions
+    /// throws an error as expected
+    #[test]
+    #[should_panic]
+    fn errors() {
+        let mat_1 = MatZ::from_str("[[2, 1],[1, 2]]").unwrap();
+        let mat_2 = MatZq::from_str("[[1, 0],[0, 1],[0, 0]] mod 4").unwrap();
+        let _ = &mat_1 * &mat_2;
+    }
+}
+
+#[cfg(test)]
+mod test_mul_matq {
+    use super::MatQ;
+    use crate::integer::MatZ;
+    use crate::rational::Q;
+    use crate::traits::SetEntry;
+    use std::str::FromStr;
+
+    /// Checks if matrix multiplication works fine for squared matrices
+    #[test]
+    fn square_correctness() {
+        let mat_1 = MatQ::from_str("[[2/3, 1],[1/2, 2]]").unwrap();
+        let mat_2 = MatZ::identity(2, 2);
+        let mat_3 = MatZ::from_str("[[1, 2],[2, 1]]").unwrap();
+        let cmp = MatQ::from_str("[[5/3, 5],[11/6, 4]]").unwrap();
+
+        assert_eq!(mat_1, &mat_2 * &mat_1);
+        assert_eq!(cmp, &mat_3 * &mat_1);
+    }
+
+    /// Checks if matrix multiplication works fine for matrices of different dimensions
+    #[test]
+    fn different_dimensions_correctness() {
+        let mat = MatQ::from_str("[[2/3, 1],[1/2, 2]]").unwrap();
+        let vec = MatZ::from_str("[[2, 0]]").unwrap();
+        let cmp = MatQ::from_str("[[4/3, 2]]").unwrap();
+
+        assert_eq!(cmp, &vec * &mat);
+    }
+
+    /// Checks if matrix multiplication works fine for large entries
+    #[test]
+    fn large_entries() {
+        let mat = MatQ::from_str(&format!("[[{}, 0],[1, 2/{}]]", u64::MAX, u64::MAX)).unwrap();
+        let vec = MatZ::from_str(&format!("[[{}, 0]]", u64::MAX)).unwrap();
+        let mut cmp = MatQ::new(1, 2);
+        let max: Q = u64::MAX.into();
+        cmp.set_entry(0, 0, &(&max * &max)).unwrap();
+
+        assert_eq!(cmp, vec * mat);
+    }
+
+    /// Checks if matrix multiplication with incompatible matrix dimensions
+    /// throws an error as expected
+    #[test]
+    #[should_panic]
+    fn errors() {
+        let mat_1 = MatZ::from_str("[[2, 1],[1, 2]]").unwrap();
+        let mat_2 = MatQ::from_str("[[2/3, 0],[0, 1/2],[0, 0]]").unwrap();
+        let _ = &mat_1 * &mat_2;
     }
 }

--- a/src/integer_mod_q/mat_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/mul.rs
@@ -13,7 +13,6 @@ use crate::error::MathError;
 use crate::integer::MatZ;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
-    arithmetic_trait_reverse,
 };
 use crate::traits::{GetNumColumns, GetNumRows};
 use flint_sys::fmpz_mat::fmpz_mat_mul;
@@ -78,8 +77,8 @@ impl Mul<&MatZ> for &MatZq {
     ///
     /// let c = &a * &b;
     /// let d = a * b;
-    /// let e = &MatZ::identity(2, 2) * d;
-    /// let f = MatZ::identity(2, 2) * &e;
+    /// let e = d * &MatZ::identity(2, 2);
+    /// let f = &e * MatZ::identity(2, 2);
     /// ```
     ///
     /// # Panics ...
@@ -100,12 +99,8 @@ impl Mul<&MatZ> for &MatZq {
     }
 }
 
-arithmetic_trait_reverse!(Mul, mul, MatZ, MatZq, MatZq);
-
 arithmetic_trait_borrowed_to_owned!(Mul, mul, MatZq, MatZ, MatZq);
-arithmetic_trait_borrowed_to_owned!(Mul, mul, MatZ, MatZq, MatZq);
 arithmetic_trait_mixed_borrowed_owned!(Mul, mul, MatZq, MatZ, MatZq);
-arithmetic_trait_mixed_borrowed_owned!(Mul, mul, MatZ, MatZq, MatZq);
 
 impl MatZq {
     /// Implements multiplication for two [`MatZq`] values.
@@ -237,7 +232,6 @@ mod test_mul_matz {
         let cmp = MatZq::from_str("[[1],[2]] mod 3").unwrap();
 
         assert_eq!(cmp, &mat * &vec);
-        assert_eq!(cmp, &vec * &mat);
     }
 
     /// Checks if matrix multiplication works fine for large entries
@@ -251,7 +245,6 @@ mod test_mul_matz {
         cmp.set_entry(0, 0, &(&max * &max)).unwrap();
 
         assert_eq!(cmp, &mat * &vec);
-        assert_eq!(cmp, vec * mat);
     }
 
     /// Checks if matrix multiplication with incompatible matrix dimensions

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -160,6 +160,8 @@ pub(crate) use arithmetic_between_types;
 /// Implements the `*trait*` for `*type*` using the `*trait*` for
 /// `&*type*`.
 ///
+/// **Warning**: Only works for commutative operations.
+///
 /// Parameters:
 /// - `trait`: the trait that is implemented
 ///     (e.g. [`Add`](std::ops::Add),[`Sub`](std::ops::Sub), ...).

--- a/src/rational/mat_q/arithmetic/mul.rs
+++ b/src/rational/mat_q/arithmetic/mul.rs
@@ -13,7 +13,6 @@ use crate::error::MathError;
 use crate::integer::MatZ;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
-    arithmetic_trait_reverse,
 };
 use crate::traits::{GetNumColumns, GetNumRows};
 use flint_sys::fmpq_mat::{fmpq_mat_mul, fmpq_mat_mul_fmpz_mat};
@@ -76,8 +75,8 @@ impl Mul<&MatZ> for &MatQ {
     ///
     /// let c = &a * &b;
     /// let d = a * b;
-    /// let e = &MatZ::identity(2, 2) * c;
-    /// let f = MatZ::identity(2, 2) * &e;
+    /// let e = c * &MatZ::identity(2, 2);
+    /// let f = &e * MatZ::identity(2, 2);
     /// ```
     ///
     /// # Panics ...
@@ -95,12 +94,8 @@ impl Mul<&MatZ> for &MatQ {
     }
 }
 
-arithmetic_trait_reverse!(Mul, mul, MatZ, MatQ, MatQ);
-
 arithmetic_trait_borrowed_to_owned!(Mul, mul, MatQ, MatZ, MatQ);
-arithmetic_trait_borrowed_to_owned!(Mul, mul, MatZ, MatQ, MatQ);
 arithmetic_trait_mixed_borrowed_owned!(Mul, mul, MatQ, MatZ, MatQ);
-arithmetic_trait_mixed_borrowed_owned!(Mul, mul, MatZ, MatQ, MatQ);
 
 impl MatQ {
     /// Implements multiplication for two [`MatQ`] values.
@@ -223,7 +218,6 @@ mod test_mul_matz {
         let cmp = MatQ::from_str("[[4/3],[1]]").unwrap();
 
         assert_eq!(cmp, &mat * &vec);
-        assert_eq!(cmp, &vec * &mat);
     }
 
     /// Checks if matrix multiplication works fine for large entries
@@ -236,7 +230,6 @@ mod test_mul_matz {
         cmp.set_entry(0, 0, &(&max * &max)).unwrap();
 
         assert_eq!(cmp, &mat * &vec);
-        assert_eq!(cmp, vec * mat);
     }
 
     /// Checks if matrix multiplication with incompatible matrix dimensions


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR fixes the multiplication between MatZ and MatZq, and between MatZ and MatQ. The multiplication A * B was treated the same way as B * A, this is now fixed by separate implementations and the macro that was used before is marked with a warning, that it should only be used for commutative operations.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
