### PR TITLE
MatPolyRingZq swaps and reverses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ string-builder = "0.2.0"
 thiserror = "2.0"
 lazy_static = "1.4"
 probability = "0.20.3"
-derive_more = { version = "1", features = ["display"] }
+derive_more = { version = "2.0.1", features = ["display"] }
 
 [profile.bench]
 debug = true

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -224,6 +224,125 @@ impl MatPolynomialRingZq {
 
         self.matrix.set_row(row_0, &other.matrix, row_1)
     }
+
+    /// Swaps two entries of the specified matrix.
+    ///
+    /// Parameters:
+    /// - `row_0`: specifies the row, in which the first entry is located
+    /// - `col_0`: specifies the column, in which the first entry is located
+    /// - `row_1`: specifies the row, in which the second entry is located
+    /// - `col_1`: specifies the column, in which the second entry is located
+    ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
+    /// Returns an empty `Ok` if the action could be performed successfully.
+    /// Otherwise, a [`MathError`] is returned if one of the specified entries is not part of the matrix.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    ///
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// matrix.swap_entries(0, 0, 2, 1);
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
+    ///     if row or column are greater than the matrix size.
+    pub fn swap_entries(
+        &mut self,
+        row_0: impl TryInto<i64> + Display,
+        col_0: impl TryInto<i64> + Display,
+        row_1: impl TryInto<i64> + Display,
+        col_1: impl TryInto<i64> + Display,
+    ) -> Result<(), MathError> {
+        self.matrix.swap_entries(row_0, col_0, row_1, col_1)
+    }
+
+    /// Swaps two columns of the specified matrix.
+    ///
+    /// Parameters:
+    /// - `col_0`: specifies the first column which is swapped with the second one
+    /// - `col_1`: specifies the second column which is swapped with the first one
+    ///
+    /// Returns an empty `Ok` if the action could be performed successfully.
+    /// Otherwise, a [`MathError`] is returned if one of the specified columns is not part of the matrix.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    ///
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// matrix.swap_columns(0, 2);
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
+    ///     if one of the given columns is greater than the matrix or negative.
+    pub fn swap_columns(
+        &mut self,
+        col_0: impl TryInto<i64> + Display,
+        col_1: impl TryInto<i64> + Display,
+    ) -> Result<(), MathError> {
+        self.matrix.swap_columns(col_0, col_1)
+    }
+
+    /// Swaps two rows of the specified matrix.
+    ///
+    /// Parameters:
+    /// - `row_0`: specifies the first row which is swapped with the second one
+    /// - `row_1`: specifies the second row which is swapped with the first one
+    ///
+    /// Returns an empty `Ok` if the action could be performed successfully.
+    /// Otherwise, a [`MathError`] is returned if one of the specified rows is not part of the matrix.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    ///
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// matrix.swap_rows(0, 2);
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
+    ///     if one of the given rows is greater than the matrix or negative.
+    pub fn swap_rows(
+        &mut self,
+        row_0: impl TryInto<i64> + Display,
+        row_1: impl TryInto<i64> + Display,
+    ) -> Result<(), MathError> {
+        self.matrix.swap_rows(row_0, row_1)
+    }
+
+    /// Swaps the `i`-th column with the `n-i`-th column for all `i <= n/2`
+    /// of the specified matrix with `n` columns.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    ///
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// matrix.reverse_columns();
+    /// ```
+    pub fn reverse_columns(&mut self) {
+        self.matrix.reverse_columns()
+    }
+
+    /// Swaps the `i`-th row with the `n-i`-th row for all `i <= n/2`
+    /// of the specified matrix with `n` rows.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    ///
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// matrix.reverse_rows();
+    /// ```
+    pub fn reverse_rows(&mut self) {
+        self.matrix.reverse_rows()
+    }
 }
 
 #[cfg(test)]
@@ -594,5 +713,154 @@ mod test_setter {
 
         assert!(mat_1.set_row(0, &mat_2, 0).is_err());
         assert!(mat_1.set_row(1, &mat_2, 1).is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_swaps {
+    use super::MatPolynomialRingZq;
+    use crate::integer_mod_q::ModulusPolynomialRingZq;
+    use std::str::FromStr;
+
+    /// Since swapping functions only call the existing tested functions for [`MatPolyOverZ`](crate::integer::MatPolyOverZ),
+    /// we omit some tests that are already covered.
+
+    /// Ensures that swapping entries works
+    #[test]
+    fn entries_swapping() {
+        let mut matrix = MatPolynomialRingZq::from_str(
+            "[[1  1, 1  2, 1  3],[1  4, 2  5 6, 0]] / 3  1 2 3 mod 17",
+        )
+        .unwrap();
+        let cmp = MatPolynomialRingZq::from_str(
+            "[[1  1, 2  5 6, 1  3],[1  4, 1  2, 0]] / 3  1 2 3 mod 17",
+        )
+        .unwrap();
+
+        let _ = matrix.swap_entries(1, 1, 0, 1);
+
+        assert_eq!(cmp, matrix);
+    }
+
+    /// Ensures that `swap_entries` returns an error if one of the specified entries is out of bounds
+    #[test]
+    fn entries_out_of_bounds() {
+        let mut matrix = MatPolynomialRingZq::new(5, 2, ModulusPolynomialRingZq::from((3, 17)));
+
+        assert!(matrix.swap_entries(-6, 0, 0, 0).is_err());
+        assert!(matrix.swap_entries(0, -3, 0, 0).is_err());
+        assert!(matrix.swap_entries(0, 0, 5, 0).is_err());
+        assert!(matrix.swap_entries(0, 5, 0, 0).is_err());
+    }
+
+    /// Ensure that `swap_entries` can properly handle negative indexing.
+    #[test]
+    fn entries_negative_indexing() {
+        let modulus = ModulusPolynomialRingZq::from_str("3  1 0 1 mod 17").unwrap();
+        let mut matrix = MatPolynomialRingZq::identity(2, 2, modulus);
+
+        matrix.swap_entries(-2, -2, -2, -1).unwrap();
+        assert_eq!(
+            "[[0, 1  1],[0, 1  1]] / 3  1 0 1 mod 17",
+            matrix.to_string()
+        );
+    }
+
+    /// Ensures that swapping columns works fine for small entries
+    #[test]
+    fn columns_swapping() {
+        let mut matrix = MatPolynomialRingZq::from_str(
+            "[[1  1, 1  2, 1  3],[1  4, 1  5, 1  6]] / 3  1 2 3 mod 17",
+        )
+        .unwrap();
+        let cmp_vec_0 = MatPolynomialRingZq::from_str("[[1  1],[1  4]] / 3  1 2 3 mod 17").unwrap();
+        let cmp_vec_1 = MatPolynomialRingZq::from_str("[[1  3],[1  6]] / 3  1 2 3 mod 17").unwrap();
+        let cmp_vec_2 = MatPolynomialRingZq::from_str("[[1  2],[1  5]] / 3  1 2 3 mod 17").unwrap();
+
+        let _ = matrix.swap_columns(1, 2);
+
+        assert_eq!(cmp_vec_0, matrix.get_column(0).unwrap());
+        assert_eq!(cmp_vec_1, matrix.get_column(1).unwrap());
+        assert_eq!(cmp_vec_2, matrix.get_column(2).unwrap());
+    }
+
+    /// Ensures that `swap_columns` returns an error if one of the specified columns is out of bounds
+    #[test]
+    fn column_out_of_bounds() {
+        let mut matrix = MatPolynomialRingZq::new(5, 2, ModulusPolynomialRingZq::from((3, 17)));
+
+        assert!(matrix.swap_columns(-1, 0).is_err());
+        assert!(matrix.swap_columns(0, -1).is_err());
+        assert!(matrix.swap_columns(5, 0).is_err());
+        assert!(matrix.swap_columns(0, 5).is_err());
+    }
+
+    /// Ensures that swapping rows works
+    #[test]
+    fn rows_swapping() {
+        let mut matrix =
+            MatPolynomialRingZq::from_str("[[1  1, 1  2],[1  3, 2  4 5]] / 3  1 2 3 mod 17")
+                .unwrap();
+        let cmp_vec_0 =
+            MatPolynomialRingZq::from_str("[[1  3, 2  4 5]] / 3  1 2 3 mod 17").unwrap();
+        let cmp_vec_1 = MatPolynomialRingZq::from_str("[[1  1, 1  2]] / 3  1 2 3 mod 17").unwrap();
+
+        let _ = matrix.swap_rows(1, 0);
+
+        assert_eq!(cmp_vec_0, matrix.get_row(0).unwrap());
+        assert_eq!(cmp_vec_1, matrix.get_row(1).unwrap());
+    }
+
+    /// Ensures that `swap_rows` returns an error if one of the specified rows is out of bounds
+    #[test]
+    fn row_out_of_bounds() {
+        let mut matrix = MatPolynomialRingZq::new(2, 4, ModulusPolynomialRingZq::from((3, 17)));
+
+        assert!(matrix.swap_rows(-1, 0).is_err());
+        assert!(matrix.swap_rows(0, -1).is_err());
+        assert!(matrix.swap_rows(4, 0).is_err());
+        assert!(matrix.swap_rows(0, 4).is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_reverses {
+    use super::MatPolynomialRingZq;
+    use std::str::FromStr;
+
+    /// Since reversing functions only call the existing tested functions for [`MatPolyOverZ`](crate::integer::MatPolyOverZ),
+    /// we omit some tests that are already covered.
+
+    /// Ensures that reversing columns works fine for small entries
+    #[test]
+    fn columns_reversing() {
+        let mut matrix = MatPolynomialRingZq::from_str(
+            "[[1  1, 1  2, 2  3 4],[0, 1  5, 1  6]] / 3  1 2 3 mod 17",
+        )
+        .unwrap();
+        let cmp_vec_0 = MatPolynomialRingZq::from_str("[[1  1],[0]] / 3  1 2 3 mod 17").unwrap();
+        let cmp_vec_1 = MatPolynomialRingZq::from_str("[[1  2],[1  5]] / 3  1 2 3 mod 17").unwrap();
+        let cmp_vec_2 =
+            MatPolynomialRingZq::from_str("[[2  3 4],[1  6]] / 3  1 2 3 mod 17").unwrap();
+
+        matrix.reverse_columns();
+
+        assert_eq!(cmp_vec_2, matrix.get_column(0).unwrap());
+        assert_eq!(cmp_vec_1, matrix.get_column(1).unwrap());
+        assert_eq!(cmp_vec_0, matrix.get_column(2).unwrap());
+    }
+
+    /// Ensures that reversing rows works fine for small entries
+    #[test]
+    fn rows_reversing() {
+        let mut matrix =
+            MatPolynomialRingZq::from_str("[[1  1, 1  2],[2  3 4, 0]] / 3  1 2 3 mod 17").unwrap();
+        let cmp_vec_0 = MatPolynomialRingZq::from_str("[[1  1, 1  2]] / 3  1 2 3 mod 17").unwrap();
+        let cmp_vec_1 = MatPolynomialRingZq::from_str("[[2  3 4, 0]] / 3  1 2 3 mod 17").unwrap();
+
+        matrix.reverse_rows();
+
+        assert_eq!(cmp_vec_1, matrix.get_row(0).unwrap());
+        assert_eq!(cmp_vec_0, matrix.get_row(1).unwrap());
     }
 }


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements all swap functions and reverse functions for MatPolyRingZq, based on their implementation for MatPolyOverZ.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
