### PR TITLE
Revise `sample_z`

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -13,7 +13,15 @@ use criterion::criterion_main;
 pub mod cholesky_decomposition;
 pub mod classic_crypto;
 pub mod integer;
+pub mod sample_z;
 pub mod sampling;
 pub mod solve;
 
-criterion_main! {integer::benches, classic_crypto::benches, sampling::benches, solve::benches, cholesky_decomposition::benches}
+criterion_main! {
+    integer::benches,
+    classic_crypto::benches,
+    sampling::benches,
+    solve::benches,
+    cholesky_decomposition::benches,
+    sample_z::benches
+}

--- a/benches/sample_z.rs
+++ b/benches/sample_z.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright © 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/sample_z.rs
+++ b/benches/sample_z.rs
@@ -6,7 +6,7 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! Create benchmark for integers in this file.
+//! Create benchmarks for `sample_z` and discrete Gaussian sampling in this file.
 
 use criterion::*;
 use qfall_math::{
@@ -14,59 +14,59 @@ use qfall_math::{
     rational::Q,
 };
 
-/// Create a matrix of size 100x100 sampled by a comparatively wide discrete Gaussian distribution.
-pub fn sample_z_wide() {
-    let n = Z::from(1000);
-    let c = Q::from(0);
-    let s = Q::from(100);
-
-    let _ = MatZ::sample_discrete_gauss(100, 100, &n, &c, &s).unwrap();
-}
-
-/// Create a matrix of size 100x100 sampled by a comparatively narrow discrete Gaussian distribution.
-pub fn sample_z_narrow() {
-    let n = Z::from(100);
-    let c = Q::from(0);
-    let s = Q::from(2);
-
-    let _ = MatZ::sample_discrete_gauss(100, 100, &n, &c, &s).unwrap();
-}
-
-/// Create a single integer sampled by a comparatively wide discrete Gaussian distribution.
-pub fn sample_z_wide_single() {
-    let n = Z::from(1000);
-    let c = Q::from(0);
-    let s = Q::from(100);
-
-    let _ = Z::sample_discrete_gauss(&n, &c, &s).unwrap();
-}
-
-/// Create a single integer sampled by a comparatively wide discrete Gaussian distribution.
-pub fn sample_z_narrow_single() {
-    let n = Z::from(100);
-    let c = Q::from(0);
-    let s = Q::from(2);
-
-    let _ = Z::sample_discrete_gauss(&n, &c, &s).unwrap();
-}
-
-/// benchmark [sample_z_wide]
+/// benchmark creating a matrix of size 100x100 sampled by a comparatively wide discrete Gaussian distribution.
 pub fn bench_sample_z_wide(c: &mut Criterion) {
+    /// Create a matrix of size 100x100 sampled by a comparatively wide discrete Gaussian distribution.
+    fn sample_z_wide() {
+        let n = Z::from(1000);
+        let center = Q::from(0);
+        let s = Q::from(100);
+
+        let _ = MatZ::sample_discrete_gauss(100, 100, n, center, s).unwrap();
+    }
+
     c.bench_function("SampleZ wide 10,000", |b| b.iter(sample_z_wide));
 }
 
-/// benchmark [sample_z_narrow]
+/// benchmark creating a matrix of size 100x100 sampled by a comparatively narrow discrete Gaussian distribution.
 pub fn bench_sample_z_narrow(c: &mut Criterion) {
+    /// Create a matrix of size 100x100 sampled by a comparatively narrow discrete Gaussian distribution.
+    fn sample_z_narrow() {
+        let n = Z::from(100);
+        let c = Q::from(0);
+        let s = Q::from(2);
+
+        let _ = MatZ::sample_discrete_gauss(100, 100, &n, &c, &s).unwrap();
+    }
+
     c.bench_function("SampleZ narrow 10,000", |b| b.iter(sample_z_narrow));
 }
 
-/// benchmark [sample_z_wide_single]
+/// benchmark creating a single integer sampled by a comparatively wide discrete Gaussian distribution.
 pub fn bench_sample_z_wide_single(c: &mut Criterion) {
+    /// Create a single integer sampled by a comparatively wide discrete Gaussian distribution.
+    fn sample_z_wide_single() {
+        let n = Z::from(1000);
+        let c = Q::from(0);
+        let s = Q::from(100);
+
+        let _ = Z::sample_discrete_gauss(&n, &c, &s).unwrap();
+    }
+
     c.bench_function("SampleZ wide single", |b| b.iter(sample_z_wide_single));
 }
 
-/// benchmark [sample_z_narrow_single]
+/// benchmark creating a single integer sampled by a comparatively wide discrete Gaussian distribution.
 pub fn bench_sample_z_narrow_single(c: &mut Criterion) {
+    /// Create a single integer sampled by a comparatively wide discrete Gaussian distribution.
+    fn sample_z_narrow_single() {
+        let n = Z::from(100);
+        let c = Q::from(0);
+        let s = Q::from(2);
+
+        let _ = Z::sample_discrete_gauss(&n, &c, &s).unwrap();
+    }
+
     c.bench_function("SampleZ narrow single", |b| b.iter(sample_z_narrow_single));
 }
 

--- a/benches/sample_z.rs
+++ b/benches/sample_z.rs
@@ -1,0 +1,79 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Create benchmark for integers in this file.
+
+use criterion::*;
+use qfall_math::{
+    integer::{MatZ, Z},
+    rational::Q,
+};
+
+/// Create a matrix of size 100x100 sampled by a comparatively wide discrete Gaussian distribution.
+pub fn sample_z_wide() {
+    let n = Z::from(1000);
+    let c = Q::from(0);
+    let s = Q::from(100);
+
+    let _ = MatZ::sample_discrete_gauss(100, 100, &n, &c, &s).unwrap();
+}
+
+/// Create a matrix of size 100x100 sampled by a comparatively narrow discrete Gaussian distribution.
+pub fn sample_z_narrow() {
+    let n = Z::from(100);
+    let c = Q::from(0);
+    let s = Q::from(2);
+
+    let _ = MatZ::sample_discrete_gauss(100, 100, &n, &c, &s).unwrap();
+}
+
+/// Create a single integer sampled by a comparatively wide discrete Gaussian distribution.
+pub fn sample_z_wide_single() {
+    let n = Z::from(1000);
+    let c = Q::from(0);
+    let s = Q::from(100);
+
+    let _ = Z::sample_discrete_gauss(&n, &c, &s).unwrap();
+}
+
+/// Create a single integer sampled by a comparatively wide discrete Gaussian distribution.
+pub fn sample_z_narrow_single() {
+    let n = Z::from(100);
+    let c = Q::from(0);
+    let s = Q::from(2);
+
+    let _ = Z::sample_discrete_gauss(&n, &c, &s).unwrap();
+}
+
+/// benchmark [sample_z_wide]
+pub fn bench_sample_z_wide(c: &mut Criterion) {
+    c.bench_function("SampleZ wide 10,000", |b| b.iter(sample_z_wide));
+}
+
+/// benchmark [sample_z_narrow]
+pub fn bench_sample_z_narrow(c: &mut Criterion) {
+    c.bench_function("SampleZ narrow 10,000", |b| b.iter(sample_z_narrow));
+}
+
+/// benchmark [sample_z_wide_single]
+pub fn bench_sample_z_wide_single(c: &mut Criterion) {
+    c.bench_function("SampleZ wide single", |b| b.iter(sample_z_wide_single));
+}
+
+/// benchmark [sample_z_narrow_single]
+pub fn bench_sample_z_narrow_single(c: &mut Criterion) {
+    c.bench_function("SampleZ narrow single", |b| b.iter(sample_z_narrow_single));
+}
+
+criterion_group!(
+    benches,
+    bench_sample_z_wide,
+    bench_sample_z_narrow,
+    bench_sample_z_wide_single,
+    bench_sample_z_narrow_single
+);

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -13,7 +13,9 @@ use crate::{
     integer::{MatZ, Z},
     rational::{MatQ, Q},
     traits::{GetNumColumns, GetNumRows, SetEntry},
-    utils::sample::discrete_gauss::{sample_d, sample_d_precomputed_gso, sample_z},
+    utils::sample::discrete_gauss::{
+        sample_d, sample_d_precomputed_gso, DiscreteGaussianIntegerSampler,
+    },
 };
 use std::fmt::Display;
 
@@ -31,7 +33,7 @@ impl MatZ {
     ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a matrix with each entry sampled independently from the
-    /// specified discrete Gaussian distribution or an error if `n <= 1` or `s <= 0`.
+    /// specified discrete Gaussian distribution or an error if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
     ///
     /// # Examples
     /// ```
@@ -59,9 +61,11 @@ impl MatZ {
         let center: Q = center.into();
         let s: Q = s.into();
 
+        let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &s)?;
+
         for row in 0..out.get_num_rows() {
             for col in 0..out.get_num_columns() {
-                let sample = sample_z(&n, &center, &s)?;
+                let sample = dgis.sample_z();
                 out.set_entry(row, col, sample)?;
             }
         }

--- a/src/integer/poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/poly_over_z/sample/discrete_gauss.rs
@@ -14,7 +14,7 @@ use crate::{
     integer::{PolyOverZ, Z},
     rational::Q,
     traits::SetCoefficient,
-    utils::{index::evaluate_index, sample::discrete_gauss::sample_z},
+    utils::{index::evaluate_index, sample::discrete_gauss::DiscreteGaussianIntegerSampler},
 };
 use std::fmt::Display;
 
@@ -43,7 +43,7 @@ impl PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///     if `n <= 1` or `s <= 0`.
+    ///     if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
     ///
     /// # Panics ...
     /// - if `max_degree` is negative, or does not fit into an [`i64`].
@@ -60,8 +60,10 @@ impl PolyOverZ {
         let s = s.into();
         let mut poly = PolyOverZ::default();
 
+        let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &s)?;
+
         for index in 0..=max_degree {
-            let sample = sample_z(&n, &center, &s)?;
+            let sample = dgis.sample_z();
             poly.set_coeff(index, &sample)?;
         }
         Ok(poly)

--- a/src/integer/z.rs
+++ b/src/integer/z.rs
@@ -18,6 +18,7 @@ mod distance;
 pub(crate) mod fmpz_helpers;
 mod from;
 mod gcd;
+mod hash;
 mod lcm;
 mod ownership;
 mod properties;

--- a/src/integer/z/hash.rs
+++ b/src/integer/z/hash.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright © 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/hash.rs
+++ b/src/integer/z/hash.rs
@@ -20,6 +20,8 @@ impl Hash for Z {
     /// Calculates the value of `self` mod 2^62 - 57 and then uses
     /// the inbuilt hash function for [`i64`].
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // We use Hash of i64 instead of String or Vec<u8> as it
+        // significantly reduces the runtime of this function.
         let modulo_value = self.modulo(MODULUS).value.0;
         modulo_value.hash(state);
     }

--- a/src/integer/z/hash.rs
+++ b/src/integer/z/hash.rs
@@ -6,16 +6,21 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! `Z` is a type for integers with arbitrary length.
-//! This implementation uses the [FLINT](https://flintlib.org/) library.
+//! Implementation of the [`Hash`] trait for [`Z`].
 
 use super::Z;
 use std::hash::Hash;
 
+// MODULUS is 2^62 - 57, which is the largest prime below 2^62.
+// We choose it prime to reduce the risk of accidentally introducing
+// a hash collision by multiplying values by a prime factor of the given modulus.
+static MODULUS: i64 = 4611686018427387847;
+
 impl Hash for Z {
-    /// This function uses the hash of [`String`] with the decimal representation of `self`.
+    /// Calculates the value of `self` mod 2^62 - 57 and then uses
+    /// the inbuilt hash function for [`i64`].
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let string = self.to_string();
-        string.hash(state);
+        let modulo_value = self.modulo(MODULUS).value.0;
+        modulo_value.hash(state);
     }
 }

--- a/src/integer/z/hash.rs
+++ b/src/integer/z/hash.rs
@@ -1,0 +1,29 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! `Z` is a type for integers with arbitrary length.
+//! This implementation uses the [FLINT](https://flintlib.org/) library.
+
+use super::Z;
+use std::hash::Hash;
+
+// The modulus is chosen as large as possible, i.e. slighly below 2^62.
+// Furthermore, to ensure that multiplicative actions result in changes with
+// high probability, optimizing when it is prime, i.e. behaves like a field.
+static MODULUS: u64 = 4611686018427387847; // 2^62 - 57 is the largest prime below 2^62
+
+impl Hash for Z {
+    /// Ensure that the [`flint_sys::fmpz::fmpz`] value is below the
+    /// threshold of being a pointer to the memory using modulus.
+    /// 
+    /// Otherwise, this function uses the hash of [`i64`].
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let modulo_value = self.modulo(MODULUS).value.0;
+        modulo_value.hash(state);
+    }
+}

--- a/src/integer/z/hash.rs
+++ b/src/integer/z/hash.rs
@@ -20,7 +20,7 @@ static MODULUS: u64 = 4611686018427387847; // 2^62 - 57 is the largest prime bel
 impl Hash for Z {
     /// Ensure that the [`flint_sys::fmpz::fmpz`] value is below the
     /// threshold of being a pointer to the memory using modulus.
-    /// 
+    ///
     /// Otherwise, this function uses the hash of [`i64`].
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let modulo_value = self.modulo(MODULUS).value.0;

--- a/src/integer/z/hash.rs
+++ b/src/integer/z/hash.rs
@@ -12,18 +12,10 @@
 use super::Z;
 use std::hash::Hash;
 
-// The modulus is chosen as large as possible, i.e. slighly below 2^62.
-// Furthermore, to ensure that multiplicative actions result in changes with
-// high probability, optimizing when it is prime, i.e. behaves like a field.
-static MODULUS: u64 = 4611686018427387847; // 2^62 - 57 is the largest prime below 2^62
-
 impl Hash for Z {
-    /// Ensure that the [`flint_sys::fmpz::fmpz`] value is below the
-    /// threshold of being a pointer to the memory using modulus.
-    ///
-    /// Otherwise, this function uses the hash of [`i64`].
+    /// This function uses the hash of [`String`] with the decimal representation of `self`.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let modulo_value = self.modulo(MODULUS).value.0;
-        modulo_value.hash(state);
+        let string = self.to_string();
+        string.hash(state);
     }
 }

--- a/src/integer/z/sample/discrete_gauss.rs
+++ b/src/integer/z/sample/discrete_gauss.rs
@@ -8,7 +8,10 @@
 
 //! This module contains algorithms for sampling according to the discrete Gaussian distribution.
 
-use crate::{error::MathError, integer::Z, rational::Q, utils::sample::discrete_gauss::sample_z};
+use crate::{
+    error::MathError, integer::Z, rational::Q,
+    utils::sample::discrete_gauss::DiscreteGaussianIntegerSampler,
+};
 
 impl Z {
     /// Chooses a [`Z`] instance according to the discrete Gaussian distribution
@@ -36,7 +39,7 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///     if `n <= 1` or `s <= 0`.
+    ///     if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
     ///
     /// This function implements SampleZ according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
@@ -52,7 +55,9 @@ impl Z {
         let center: Q = center.into();
         let s: Q = s.into();
 
-        sample_z(&n, &center, &s)
+        let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &s)?;
+
+        Ok(dgis.sample_z())
     }
 }
 

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -14,7 +14,9 @@ use crate::{
     integer_mod_q::{MatZq, Modulus},
     rational::{MatQ, Q},
     traits::{GetNumColumns, GetNumRows, SetEntry},
-    utils::sample::discrete_gauss::{sample_d, sample_d_precomputed_gso, sample_z},
+    utils::sample::discrete_gauss::{
+        sample_d, sample_d_precomputed_gso, DiscreteGaussianIntegerSampler,
+    },
 };
 use std::fmt::Display;
 
@@ -43,7 +45,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///     if `n <= 1` or `s <= 0`.
+    ///     if `n <= 1` or `s <= 0` or `s * log_2(n) < 1` or `s * log_2(n) < 1`.
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.
@@ -62,9 +64,11 @@ impl MatZq {
         let s: Q = s.into();
         let mut out = Self::new(num_rows, num_cols, modulus);
 
+        let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &s)?;
+
         for row in 0..out.get_num_rows() {
             for col in 0..out.get_num_columns() {
-                let sample = sample_z(&n, &center, &s)?;
+                let sample = dgis.sample_z();
                 out.set_entry(row, col, sample).unwrap();
             }
         }

--- a/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
@@ -15,7 +15,7 @@ use crate::{
     integer_mod_q::{Modulus, PolyOverZq},
     rational::Q,
     traits::SetCoefficient,
-    utils::{index::evaluate_index, sample::discrete_gauss::sample_z},
+    utils::{index::evaluate_index, sample::discrete_gauss::DiscreteGaussianIntegerSampler},
 };
 use std::fmt::Display;
 
@@ -45,7 +45,7 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///     if `n <= 1` or `s <= 0`.
+    ///     if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
     ///
     /// # Panics ...
     /// - if `max_degree` is negative, or does not fit into an [`i64`].
@@ -65,8 +65,10 @@ impl PolyOverZq {
         let s = s.into();
         let mut poly = PolyOverZq::from(&modulus);
 
+        let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &s)?;
+
         for index in 0..=max_degree {
-            let sample = sample_z(&n, &center, &s)?;
+            let sample = dgis.sample_z();
             poly.set_coeff(index, &sample)?;
         }
         Ok(poly)

--- a/src/integer_mod_q/z_q/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/z_q/sample/discrete_gauss.rs
@@ -13,7 +13,7 @@ use crate::{
     integer::Z,
     integer_mod_q::{Modulus, Zq},
     rational::Q,
-    utils::sample::discrete_gauss::sample_z,
+    utils::sample::discrete_gauss::DiscreteGaussianIntegerSampler,
 };
 
 impl Zq {
@@ -43,7 +43,7 @@ impl Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///     if `n <= 1` or `s <= 0`.
+    ///     if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
     ///
     /// # Panics ...
     /// - if `modulus` is smaller than `2`.
@@ -64,7 +64,9 @@ impl Zq {
         let center: Q = center.into();
         let s: Q = s.into();
 
-        let sample = sample_z(&n, &center, &s)?;
+        let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &s)?;
+
+        let sample = dgis.sample_z();
         Ok(Zq::from((&sample, &modulus)))
     }
 }

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -24,22 +24,17 @@ use crate::{
     traits::{GetNumColumns, GetNumRows, Pow},
 };
 use rand::RngCore;
+use std::collections::HashMap;
 
-/// Chooses a sample according to the discrete Gaussian distribution out of
-/// `[center - ⌈s * log_2(n)⌉ , center + ⌊s * log_2(n)⌋ ]`.
+/// Enables for discrete Gaussian sampling out of
+/// `[⌈center - s * log_2(n)⌉ , ⌊center + s * log_2(n)⌋ ]`.
+/// This struct computes the Gauss function lazily and saves it in a [`HashMap`].
 ///
-/// This function implements discrete Gaussian sampling according to the definition of
-/// SampleZ as in [\[1\]](<index.html#:~:text=[1]>).
-///
-/// Parameters:
+/// Attributes:
 /// - `n`: specifies the range from which is sampled
 /// - `center`: specifies the position of the center with peak probability
 /// - `s`: specifies the Gaussian parameter, which is proportional
 ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
-///
-/// Returns a sample chosen according to the specified discrete Gaussian distribution or
-/// a [`MathError`] if the specified parameters were not chosen appropriately,
-/// i.e. `n > 1` and `s > 0`.
 ///
 /// # Examples
 /// ```compile_fail
@@ -49,43 +44,130 @@ use rand::RngCore;
 /// let center = Q::ZERO;
 /// let gaussian_parameter = Q::ONE;
 ///
-/// let sample = sample_z(&n, &center, &gaussian_parameter).unwrap();
-/// ```
+/// let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &gaussian_parameter).unwrap();
 ///
-/// # Errors and Failures
-/// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-///     if `n <= 1` or `s <= 0`.
-pub(crate) fn sample_z(n: &Z, center: &Q, s: &Q) -> Result<Z, MathError> {
-    if n <= &Z::ONE {
-        return Err(MathError::InvalidIntegerInput(format!(
-            "The value {n} was provided for parameter n of the function sample_z.
-            This function expects this input to be larger than 1."
-        )));
+/// let sample = dgis.sample_z();
+/// ```
+pub(crate) struct DiscreteGaussianIntegerSampler {
+    center: Q,
+    s: Q,
+    lower_bound: Z,
+    interval_size: Z,
+    table: HashMap<Z, f64>,
+}
+
+impl DiscreteGaussianIntegerSampler {
+    /// Initializes the [`DiscreteGaussianIntegerSampler`] with
+    /// - `center` as the peak of the Gaussian function,
+    /// - `s` defining the Gaussian parameter, which is proportional
+    ///   to the standard deviation `sigma * sqrt(2 * pi) = s`,
+    /// - `lower_bound` as `⌈center - s * log_2(n)⌉`,
+    /// - `interval_size` as `⌊center + s * log_2(n)⌋ - ⌈center - s * log_2(n)⌉`, and
+    /// - `table` as an empty [`HashMap`] to store evaluations of the Gaussian function in.
+    ///
+    /// Parameters:
+    /// - `n`: specifies the range from which is sampled
+    /// - `center`: specifies the position of the center with peak probability
+    /// - `s`: specifies the Gaussian parameter, which is proportional
+    ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///
+    /// Returns a sample chosen according to the specified discrete Gaussian distribution or
+    /// a [`MathError`] if the specified parameters were not chosen appropriately,
+    /// i.e. `n > 1` or `s > 0` or `s * log_2(n) < 1`.
+    ///
+    /// # Examples
+    /// ```compile_fail
+    /// use qfall_math::{integer::Z, rational::Q};
+    /// use qfall_math::utils::sample::discrete_gauss::sample_z;
+    /// let n = Z::from(1024);
+    /// let center = Q::ZERO;
+    /// let gaussian_parameter = Q::ONE;
+    ///
+    /// let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &gaussian_parameter).unwrap();
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
+    ///     if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
+    pub(crate) fn init(n: &Z, center: &Q, s: &Q) -> Result<Self, MathError> {
+        if n <= &Z::ONE {
+            return Err(MathError::InvalidIntegerInput(format!(
+                "The value {n} was provided for parameter n of the function sample_z.
+                This function expects this input to be larger than 1."
+            )));
+        }
+        if s <= &Q::ZERO {
+            return Err(MathError::InvalidIntegerInput(format!(
+                "The value {s} was provided for parameter s of the function sample_z.
+                This function expects this input to be larger than 0."
+            )));
+        }
+        if s * n.log(2).unwrap() < Q::ONE {
+            return Err(MathError::InvalidIntegerInput(format!(
+                "The size {s} * log_2({n}) is smaller than 1.
+                Hence, the interval to sample from is of size 1.
+                Please provide larger parameters to sample discrete Gaussian."
+            )));
+        }
+
+        let lower_bound = (center - s * n.log(2).unwrap()).ceil();
+        let upper_bound = (center + s * n.log(2).unwrap()).floor();
+        // interval [lower_bound, upper_bound] has upper_bound - lower_bound + 1 elements in it
+        let interval_size = &upper_bound - &lower_bound + Z::ONE;
+
+        Ok(Self {
+            center: center.clone(),
+            s: s.clone(),
+            lower_bound,
+            interval_size,
+            table: HashMap::new(),
+        })
     }
-    if s <= &Q::ZERO {
-        return Err(MathError::InvalidIntegerInput(format!(
-            "The value {s} was provided for parameter s of the function sample_z.
-            This function expects this input to be larger than 0."
-        )));
+
+    /// Chooses a sample according to the discrete Gaussian distribution out of
+    /// `[lower_bound , lower_bound + interval_size ]`.
+    ///
+    /// This function implements discrete Gaussian sampling according to the definition of
+    /// SampleZ as in [\[1\]](<index.html#:~:text=[1]>).
+    ///
+    /// # Examples
+    /// ```compile_fail
+    /// use qfall_math::{integer::Z, rational::Q};
+    /// use qfall_math::utils::sample::discrete_gauss::sample_z;
+    /// let n = Z::from(1024);
+    /// let center = Q::ZERO;
+    /// let gaussian_parameter = Q::ONE;
+    ///
+    /// let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &gaussian_parameter).unwrap();
+    ///
+    /// let sample = dgis.sample_z();
+    /// ```
+    pub(crate) fn sample_z(&mut self) -> Z {
+        let mut rng = rand::rng();
+        loop {
+            // sample x in [c - s * log_2(n), c + s * log_2(n)]
+            let sample = &self.lower_bound + sample_uniform_rejection(&self.interval_size).unwrap();
+
+            // grab value of Gauss function for sample if it exists
+            let evaluated_gauss_function = self.table.get(&sample);
+            if evaluated_gauss_function.is_some() {
+                // if the function was evaluated for this value before, sample between [0,1]
+                // and accept with the value of the Gauss function
+                let evaluated_gauss_function = evaluated_gauss_function.unwrap();
+                if evaluated_gauss_function >= &(rng.next_u64() as f64 / u64::MAX as f64) {
+                    return sample;
+                }
+            } else {
+                // if the function wasn't evaluated for this value before, compute the value and
+                // sample between [0,1] and accept with the value of the Gauss function
+                let evaluated_gauss_function = gaussian_function(&sample, &self.center, &self.s);
+                self.table.insert(sample.clone(), evaluated_gauss_function);
+                if evaluated_gauss_function >= (rng.next_u64() as f64 / u64::MAX as f64) {
+                    return sample;
+                }
+            }
+        }
     }
-
-    let lower_bound = (center - s * n.log(2).unwrap()).ceil();
-    let upper_bound = (center + s * n.log(2).unwrap()).floor();
-    // interval [lower_bound, upper_bound] has upper_bound - lower_bound + 1 elements in it
-    let interval_size = &upper_bound - &lower_bound + Z::ONE;
-
-    // sample x in [c - s * log_2(n), c + s * log_2(n)]
-    let mut sample = &lower_bound + sample_uniform_rejection(&interval_size).unwrap();
-
-    // rejection sample according to GPV08
-    // https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=d9f54077d568784c786f7b1d030b00493eb3ae35
-    // this eprint version explains in more detail how sample_z works
-    let mut rng = rand::rng();
-    while gaussian_function(&sample, center, s) <= Q::from((rng.next_u64(), u64::MAX)) {
-        sample = &lower_bound + sample_uniform_rejection(&interval_size).unwrap();
-    }
-
-    Ok(sample)
 }
 
 /// Computes the value of the Gaussian function for `x`.
@@ -113,10 +195,11 @@ pub(crate) fn sample_z(n: &Z, center: &Q, s: &Q) -> Result<Z, MathError> {
 ///
 /// # Panics ...
 /// - if `s = 0`.
-fn gaussian_function(x: &Z, c: &Q, s: &Q) -> Q {
+/// - if `-π * (x - c)^2 / s^2` is larger than [`f64::MAX`]
+fn gaussian_function(x: &Z, c: &Q, s: &Q) -> f64 {
     let num = Q::MINUS_ONE * Q::PI * (x - c).pow(2).unwrap();
     let den = s.pow(2).unwrap();
-    let res: Q = num / den;
+    let res = f64::from(&(num / den));
     res.exp()
 }
 
@@ -259,7 +342,8 @@ pub(crate) fn sample_d_precomputed_gso(
         let s_2 = s / (basisvector_orth_i.norm_eucl_sqrd().unwrap().sqrt());
 
         // sample z ~ D_{Z, s2, c2}
-        let z = sample_z(n, &c_2, &s_2)?;
+        let mut dgis = DiscreteGaussianIntegerSampler::init(n, &c_2, &s_2)?;
+        let z = dgis.sample_z();
 
         // update the center c = c - z * b[i]
         let basisvector_i = basis.get_column(i).unwrap();
@@ -273,8 +357,9 @@ pub(crate) fn sample_d_precomputed_gso(
 }
 
 #[cfg(test)]
-mod test_sample_z {
-    use super::{sample_z, Q, Z};
+mod test_discrete_gaussian_integer_sampler {
+    use super::DiscreteGaussianIntegerSampler;
+    use crate::{integer::Z, rational::Q};
 
     /// Ensures that the doc tests works correctly.
     #[test]
@@ -283,7 +368,10 @@ mod test_sample_z {
         let center = Q::ZERO;
         let gaussian_parameter = Q::ONE;
 
-        let sample = sample_z(&n, &center, &gaussian_parameter).unwrap();
+        let mut dgis =
+            DiscreteGaussianIntegerSampler::init(&n, &center, &gaussian_parameter).unwrap();
+
+        let sample = dgis.sample_z();
 
         assert!(Z::from(-10) <= sample);
         assert!(sample <= Z::from(10));
@@ -296,8 +384,11 @@ mod test_sample_z {
         let center = Q::from(15);
         let gaussian_parameter = Q::from((1, 2));
 
+        let mut dgis =
+            DiscreteGaussianIntegerSampler::init(&n, &center, &gaussian_parameter).unwrap();
+
         for _ in 0..64 {
-            let sample = sample_z(&n, &center, &gaussian_parameter).unwrap();
+            let sample = dgis.sample_z();
 
             assert!(Z::from(10) <= sample);
             assert!(sample <= Z::from(20));
@@ -311,8 +402,11 @@ mod test_sample_z {
         let center = Q::MINUS_ONE;
         let gaussian_parameter = Q::ONE;
 
+        let mut dgis =
+            DiscreteGaussianIntegerSampler::init(&n, &center, &gaussian_parameter).unwrap();
+
         for _ in 0..256 {
-            let sample = sample_z(&n, &center, &gaussian_parameter).unwrap();
+            let sample = dgis.sample_z();
 
             assert!(Z::from(-64) <= sample);
             assert!(sample <= Z::from(62));
@@ -325,9 +419,9 @@ mod test_sample_z {
         let n = Z::from(4);
         let center = Q::ZERO;
 
-        assert!(sample_z(&n, &center, &Q::ZERO).is_err());
-        assert!(sample_z(&n, &center, &Q::MINUS_ONE).is_err());
-        assert!(sample_z(&n, &center, &Q::from(i64::MIN)).is_err());
+        assert!(DiscreteGaussianIntegerSampler::init(&n, &center, &Q::ZERO).is_err());
+        assert!(DiscreteGaussianIntegerSampler::init(&n, &center, &Q::MINUS_ONE).is_err());
+        assert!(DiscreteGaussianIntegerSampler::init(&n, &center, &Q::from(i64::MIN)).is_err());
     }
 
     /// Checks whether `sample_z` returns an error if `n <= 1`.
@@ -336,10 +430,22 @@ mod test_sample_z {
         let center = Q::MINUS_ONE;
         let gaussian_parameter = Q::ONE;
 
-        assert!(sample_z(&Z::ONE, &center, &gaussian_parameter).is_err());
-        assert!(sample_z(&Z::ZERO, &center, &gaussian_parameter).is_err());
-        assert!(sample_z(&Z::MINUS_ONE, &center, &gaussian_parameter).is_err());
-        assert!(sample_z(&Z::from(i64::MIN), &center, &gaussian_parameter).is_err());
+        assert!(
+            DiscreteGaussianIntegerSampler::init(&Z::ONE, &center, &gaussian_parameter).is_err()
+        );
+        assert!(
+            DiscreteGaussianIntegerSampler::init(&Z::ZERO, &center, &gaussian_parameter).is_err()
+        );
+        assert!(
+            DiscreteGaussianIntegerSampler::init(&Z::MINUS_ONE, &center, &gaussian_parameter)
+                .is_err()
+        );
+        assert!(DiscreteGaussianIntegerSampler::init(
+            &Z::from(i64::MIN),
+            &center,
+            &gaussian_parameter
+        )
+        .is_err());
     }
 }
 
@@ -359,7 +465,7 @@ mod test_gaussian_function {
 
         let value = gaussian_function(&sample, &center, &gaussian_parameter);
 
-        assert!(cmp.distance(&value) < Q::from((1, 1_000_000)));
+        assert!(cmp.distance(&Q::from(value)) < Q::from((1, 1_000_000)));
     }
 
     /// Checks whether the values for small values are computed appropriately
@@ -381,10 +487,10 @@ mod test_gaussian_function {
         let res_2 = gaussian_function(&sample_1, &center, &gaussian_parameter_0);
         let res_3 = gaussian_function(&sample_1, &center, &gaussian_parameter_1);
 
-        assert!(cmp_0.distance(&res_0) < Q::from((3, 1_000_000_000)));
-        assert!(cmp_1.distance(&res_1) < Q::from((1, 1_000_000)));
-        assert_eq!(Q::ONE, res_2);
-        assert_eq!(Q::ONE, res_3);
+        assert!(cmp_0.distance(&Q::from(res_0)) < Q::from((3, 1_000_000_000)));
+        assert!(cmp_1.distance(&Q::from(res_1)) < Q::from((1, 1_000_000)));
+        assert_eq!(1.0, res_2);
+        assert_eq!(1.0, res_3);
     }
 
     /// Checks whether the values for large values are computed appropriately
@@ -399,7 +505,7 @@ mod test_gaussian_function {
 
         let res = gaussian_function(&sample, &center, &gaussian_parameter);
 
-        assert!(cmp.distance(&res) < Q::from((3, 1_000_000_000)));
+        assert!(cmp.distance(&Q::from(res)) < Q::from((3, 1_000_000_000)));
     }
 
     /// Checks whether `s = 0` results in a panic.

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -28,7 +28,8 @@ use std::collections::HashMap;
 
 /// Enables for discrete Gaussian sampling out of
 /// `[⌈center - s * log_2(n)⌉ , ⌊center + s * log_2(n)⌋ ]`.
-/// This struct computes the Gauss function lazily and saves it in a [`HashMap`].
+/// This struct evaluates the Gauss function lazily (i.e. only if required)
+/// and saves it in a [`HashMap`].
 ///
 /// Attributes:
 /// - `n`: specifies the range from which is sampled
@@ -58,16 +59,16 @@ pub(crate) struct DiscreteGaussianIntegerSampler {
 
 impl DiscreteGaussianIntegerSampler {
     /// Initializes the [`DiscreteGaussianIntegerSampler`] with
-    /// - `center` as the peak of the Gaussian function,
+    /// - `center` as the center of the discrete Gaussian to sample from,
     /// - `s` defining the Gaussian parameter, which is proportional
     ///   to the standard deviation `sigma * sqrt(2 * pi) = s`,
     /// - `lower_bound` as `⌈center - s * log_2(n)⌉`,
-    /// - `interval_size` as `⌊center + s * log_2(n)⌋ - ⌈center - s * log_2(n)⌉`, and
+    /// - `interval_size` as `⌊center + s * log_2(n)⌋ - ⌈center - s * log_2(n)⌉ + 1`, and
     /// - `table` as an empty [`HashMap`] to store evaluations of the Gaussian function.
     ///
     /// Parameters:
     /// - `n`: specifies the range from which is sampled
-    /// - `center`: specifies the position of the center with peak probability
+    /// - `center`: as the center of the discrete Gaussian to sample from
     /// - `s`: specifies the Gaussian parameter, which is proportional
     ///     to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
@@ -113,8 +114,7 @@ impl DiscreteGaussianIntegerSampler {
         let lower_bound = (center - s * n.log(2).unwrap()).ceil();
         let upper_bound = (center + s * n.log(2).unwrap()).floor();
         // interval [lower_bound, upper_bound] has upper_bound - lower_bound + 1 elements in it
-        // as uniform sampling samples from [0, interval_size), we require interval_size + 1
-        let interval_size = &upper_bound - &lower_bound + Z::from(2);
+        let interval_size = &upper_bound - &lower_bound + Z::ONE;
 
         Ok(Self {
             center: center.clone(),
@@ -151,21 +151,17 @@ impl DiscreteGaussianIntegerSampler {
 
             // grab value of Gauss function for sample if it exists
             let evaluated_gauss_function = self.table.get(&sample);
-            if evaluated_gauss_function.is_some() {
-                // if the function was evaluated for this value before, sample between [0,1]
-                // and accept with the value of the Gauss function
-                let evaluated_gauss_function = evaluated_gauss_function.unwrap();
-                if evaluated_gauss_function >= &(rng.next_u64() as f64 / u64::MAX as f64) {
-                    return sample;
-                }
-            } else {
-                // if the function wasn't evaluated for this value before, compute the value and
-                // sample between [0,1] and accept with the value of the Gauss function
-                let evaluated_gauss_function = gaussian_function(&sample, &self.center, &self.s);
-                self.table.insert(sample.clone(), evaluated_gauss_function);
-                if evaluated_gauss_function >= (rng.next_u64() as f64 / u64::MAX as f64) {
-                    return sample;
-                }
+            let evaluated_gauss_function = match evaluated_gauss_function {
+                Some(x) => x,
+                None => &{
+                    let evaluated_gauss_function =
+                        gaussian_function(&sample, &self.center, &self.s);
+                    self.table.insert(sample.clone(), evaluated_gauss_function);
+                    evaluated_gauss_function
+                },
+            };
+            if evaluated_gauss_function >= &(rng.next_u64() as f64 / u64::MAX as f64) {
+                return sample;
             }
         }
     }

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -113,7 +113,8 @@ impl DiscreteGaussianIntegerSampler {
         let lower_bound = (center - s * n.log(2).unwrap()).ceil();
         let upper_bound = (center + s * n.log(2).unwrap()).floor();
         // interval [lower_bound, upper_bound] has upper_bound - lower_bound + 1 elements in it
-        let interval_size = &upper_bound - &lower_bound + Z::ONE;
+        // as uniform sampling samples from [0, interval_size), we require interval_size + 1
+        let interval_size = &upper_bound - &lower_bound + Z::from(2);
 
         Ok(Self {
             center: center.clone(),

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -24,6 +24,7 @@ use crate::{
     traits::{GetNumColumns, GetNumRows, Pow},
 };
 use rand::RngCore;
+use serde::Serialize;
 use std::collections::HashMap;
 
 /// Enables for discrete Gaussian sampling out of
@@ -49,6 +50,7 @@ use std::collections::HashMap;
 ///
 /// let sample = dgis.sample_z();
 /// ```
+#[derive(Debug, Serialize, Clone)]
 pub(crate) struct DiscreteGaussianIntegerSampler {
     center: Q,
     s: Q,

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -63,7 +63,7 @@ impl DiscreteGaussianIntegerSampler {
     ///   to the standard deviation `sigma * sqrt(2 * pi) = s`,
     /// - `lower_bound` as `⌈center - s * log_2(n)⌉`,
     /// - `interval_size` as `⌊center + s * log_2(n)⌋ - ⌈center - s * log_2(n)⌉`, and
-    /// - `table` as an empty [`HashMap`] to store evaluations of the Gaussian function in.
+    /// - `table` as an empty [`HashMap`] to store evaluations of the Gaussian function.
     ///
     /// Parameters:
     /// - `n`: specifies the range from which is sampled

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -71,7 +71,8 @@ pub(crate) fn sample_z(n: &Z, center: &Q, s: &Q) -> Result<Z, MathError> {
 
     let lower_bound = (center - s * n.log(2).unwrap()).ceil();
     let upper_bound = (center + s * n.log(2).unwrap()).floor();
-    let interval_size = &upper_bound - &lower_bound;
+    // interval [lower_bound, upper_bound] has upper_bound - lower_bound + 1 elements in it
+    let interval_size = &upper_bound - &lower_bound + Z::ONE;
 
     // sample x in [c - s * log_2(n), c + s * log_2(n)]
     let mut sample = &lower_bound + sample_uniform_rejection(&interval_size).unwrap();


### PR DESCRIPTION
**Description**

This PR implements `DiscreteGaussianIntegerSampler` and sample_z to
- [x] store evaluations of the Gaussian function efficiently (requires implementation of `Hash` for `Z`),
- [x] use f64::exp instead of Q::exp (roughly twice as fast - though there is no specification given for its precision),
- [x] corrects the interval that sample_z samples uniformly from, which was one entry too small,
- [x] benchmarks for sample_z.

Overall, the new implementation reduces discrete Gaussian sampling for a single sample by roughly 10 µs for the evaluated parameters (from 28 µs to 17 µs for a wide distribution and 18 µs to 9 µs for a narrow distribution).
If we sample multiple samples from the same distribution (usually done to sample the G-trapdoor R or preimages for G), then the speedup is just shy of 90% for 10,000 samples (280 ms -> 32 ms for a wide and 180 ms -> 19 ms for a narrow distribution).

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed