### PR TITLE
PartialEq between Modulus and Z, Q

### DIFF
--- a/src/integer/z/cmp.rs
+++ b/src/integer/z/cmp.rs
@@ -10,7 +10,7 @@
 //! This uses the traits from [`std::cmp`].
 
 use super::Z;
-use crate::{macros::for_others::implement_for_others, rational::Q};
+use crate::macros::for_others::implement_for_others;
 use flint_sys::fmpz::{fmpz, fmpz_cmp, fmpz_equal};
 use std::cmp::Ordering;
 
@@ -46,39 +46,6 @@ impl PartialEq for Z {
 // With the [`Eq`] trait, `a == a` is always true.
 // This is not guaranteed by the [`PartialEq`] trait.
 impl Eq for Z {}
-
-impl PartialEq<Q> for Z {
-    /// Checks if an integer and a rational are equal. Used by the `==` and `!=` operators.
-    ///
-    /// Parameters:
-    /// - `other`: the other value that is used to compare the elements
-    ///
-    /// Returns `true` if the elements are equal, otherwise `false`.
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::integer::Z;
-    /// use qfall_math::rational::Q;
-    /// let a: Z = Z::from(42);
-    /// let b: Q = Q::from(42);
-    ///
-    /// // These are all equivalent and return true.
-    /// let compared: bool = (a == b);
-    /// # assert!(compared);
-    /// let compared: bool = (&a == &b);
-    /// # assert!(compared);
-    /// let compared: bool = (a.eq(&b));
-    /// # assert!(compared);
-    /// let compared: bool = (Z::eq(&a, &b));
-    /// # assert!(compared);
-    /// ```
-    fn eq(&self, other: &Q) -> bool {
-        unsafe {
-            (1 == fmpz_equal(&other.value.den, &fmpz(1)))
-                && (1 == fmpz_equal(&other.value.num, &self.value))
-        }
-    }
-}
 
 implement_for_others!(Z, Z, PartialEq for fmpz i8 i16 i32 i64 u8 u16 u32 u64);
 
@@ -267,51 +234,37 @@ mod test_partial_eq_z {
 
 /// Test that the [`PartialEq`] trait is correctly implemented.
 #[cfg(test)]
-mod test_partial_eq_z_q {
+mod test_partial_eq_z_other {
     use super::Z;
-    use crate::rational::Q;
 
     // Ensure that the function can be called with several types
     #[test]
     #[allow(clippy::op_ref)]
     fn availability() {
-        let q = Q::from((1, 1));
-        let z = Z::from(1);
+        let z = Z::from(2);
 
-        assert!(z == q);
         assert!(z == z.value);
-        assert!(z == 1i8);
-        assert!(z == 1u8);
-        assert!(z == 1i16);
-        assert!(z == 1u16);
-        assert!(z == 1i32);
-        assert!(z == 1u32);
-        assert!(z == 1i64);
-        assert!(z == 1u64);
+        assert!(z == 2i8);
+        assert!(z == 2u8);
+        assert!(z == 2i16);
+        assert!(z == 2u16);
+        assert!(z == 2i32);
+        assert!(z == 2u32);
+        assert!(z == 2i64);
+        assert!(z == 2u64);
 
         assert!(z.value == z);
-        assert!(1i8 == z);
-        assert!(1u8 == z);
-        assert!(1i16 == z);
-        assert!(1u16 == z);
-        assert!(1i32 == z);
-        assert!(1u32 == z);
-        assert!(1i64 == z);
-        assert!(1u64 == z);
+        assert!(2i8 == z);
+        assert!(2u8 == z);
+        assert!(2i16 == z);
+        assert!(2u16 == z);
+        assert!(2i32 == z);
+        assert!(2u32 == z);
+        assert!(2i64 == z);
+        assert!(2u64 == z);
 
-        assert!(&z == &q);
-        assert!(&z == &1i8);
-        assert!(&1i8 == &q);
-    }
-
-    // Ensure that large values are compared correctly
-    #[test]
-    fn equal_large() {
-        let q = Q::from((u64::MAX, 1));
-        let z = Z::from(u64::MAX);
-
-        assert!(z == q);
-        assert!(z != q + 1);
+        assert!(&z == &2i8);
+        assert!(&2i8 == &z);
     }
 }
 

--- a/src/integer_mod_q/modulus/cmp.rs
+++ b/src/integer_mod_q/modulus/cmp.rs
@@ -12,7 +12,11 @@
 //! The explicit functions contain the documentation.
 
 use super::Modulus;
-use crate::integer::Z;
+use crate::{
+    integer::Z,
+    macros::for_others::{implement_for_others, implement_trait_reverse},
+};
+use flint_sys::fmpz::{fmpz, fmpz_equal};
 use std::cmp::Ordering;
 
 impl PartialEq for Modulus {
@@ -48,6 +52,49 @@ impl PartialEq for Modulus {
 // With the [`Eq`] trait, `a == a` is always true.
 // This is not guaranteed by the [`PartialEq`] trait.
 impl Eq for Modulus {}
+
+impl PartialEq<Z> for Modulus {
+    /// Checks if an integer and a modulus are equal. Used by the `==` and `!=` operators.
+    /// [`PartialEq`] is also implemented for [`Z`] using [`Modulus`].
+    ///
+    /// Parameters:
+    /// - `other`: the other value that is used to compare the elements
+    ///
+    /// Returns `true` if the elements are equal, otherwise `false`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::Z;
+    /// use qfall_math::integer_mod_q::Modulus;
+    /// let a: Modulus = Modulus::from(42);
+    /// let b: Z = Z::from(42);
+    ///
+    /// // These are all equivalent and return true.
+    /// let compared: bool = (a == b);
+    /// # assert!(compared);
+    /// let compared: bool = (b == a);
+    /// # assert!(compared);
+    /// let compared: bool = (&a == &b);
+    /// # assert!(compared);
+    /// let compared: bool = (&b == &a);
+    /// # assert!(compared);
+    /// let compared: bool = (a.eq(&b));
+    /// # assert!(compared);
+    /// let compared: bool = (b.eq(&a));
+    /// # assert!(compared);
+    /// let compared: bool = (Z::eq(&b, &a));
+    /// # assert!(compared);
+    /// let compared: bool = (Modulus::eq(&a, &b));
+    /// # assert!(compared);
+    /// ```
+    fn eq(&self, other: &Z) -> bool {
+        unsafe { 1 == fmpz_equal(&other.value, &self.modulus.n[0]) }
+    }
+}
+
+implement_trait_reverse!(PartialEq, eq, Z, Modulus, bool);
+
+implement_for_others!(Z, Modulus, PartialEq for fmpz i8 i16 i32 i64 u8 u16 u32 u64);
 
 impl PartialOrd for Modulus {
     /// Compares two [`Modulus`] values. Used by the `<`, `<=`, `>`, and `>=` operators.
@@ -156,6 +203,58 @@ mod test_eq {
         assert_ne!(one, two);
         assert_ne!(one, large);
         assert_ne!(two, large);
+    }
+}
+
+/// Test that the [`PartialEq`] trait is correctly implemented.
+#[cfg(test)]
+mod test_partial_eq_modulus_other {
+    use super::Z;
+    use crate::integer_mod_q::Modulus;
+
+    // Ensure that the function can be called with several types
+    #[test]
+    #[allow(clippy::op_ref)]
+    fn availability() {
+        let modulus = Modulus::from(2);
+        let z = Z::from(2);
+
+        assert!(modulus == z);
+        assert!(modulus == z.value);
+        assert!(modulus == 2i8);
+        assert!(modulus == 2u8);
+        assert!(modulus == 2i16);
+        assert!(modulus == 2u16);
+        assert!(modulus == 2i32);
+        assert!(modulus == 2u32);
+        assert!(modulus == 2i64);
+        assert!(modulus == 2u64);
+
+        assert!(z == modulus);
+        assert!(z.value == modulus);
+        assert!(2i8 == modulus);
+        assert!(2u8 == modulus);
+        assert!(2i16 == modulus);
+        assert!(2u16 == modulus);
+        assert!(2i32 == modulus);
+        assert!(2u32 == modulus);
+        assert!(2i64 == modulus);
+        assert!(2u64 == modulus);
+
+        assert!(&modulus == &z);
+        assert!(&z == &modulus);
+        assert!(&modulus == &2i8);
+        assert!(&2i8 == &modulus);
+    }
+
+    // Ensure that large values are compared correctly
+    #[test]
+    fn equal_large() {
+        let modulus = Modulus::from(u64::MAX);
+        let z = Z::from(u64::MAX);
+
+        assert!(modulus == z);
+        assert!(modulus != z + 1);
     }
 }
 

--- a/src/integer_mod_q/modulus/serialize.rs
+++ b/src/integer_mod_q/modulus/serialize.rs
@@ -58,7 +58,7 @@ mod test_deserialize {
     #[test]
     fn deserialize_positive() {
         let z_string = "{\"modulus\":\"17\"}";
-        assert_eq!(Modulus::from(17), serde_json::from_str(z_string).unwrap());
+        assert_eq!(Modulus::from(17), serde_json::from_str::<Modulus>(z_string).unwrap());
     }
 
     /// Tests whether the deserialization of a negative [`Modulus`] fails.
@@ -78,7 +78,7 @@ mod test_deserialize {
 
         assert_eq!(
             Modulus::from_str(&val_str).unwrap(),
-            serde_json::from_str(&z_string).unwrap()
+            serde_json::from_str::<Modulus>(&z_string).unwrap()
         )
     }
 

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -157,8 +157,7 @@ macro_rules! arithmetic_between_types {
 
 pub(crate) use arithmetic_between_types;
 
-/// Implements the `*trait*` for `*type*` using the `*trait*` for
-/// `&*type*`.
+/// Implements the `*trait*` for `*type*` using an implementation for `*other_type*`.
 ///
 /// **Warning**: Only works for commutative operations.
 ///

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -201,3 +201,37 @@ macro_rules! implement_empty_trait_owned_ref {
     };
 }
 pub(crate) use implement_empty_trait_owned_ref;
+
+/// Implements the `*trait*` for `*type*` using an implementation for `*other_type*`.
+///
+/// **Warning**: Only works for commutative operations.
+///
+/// Parameters:
+/// - `trait`: the trait that is implemented
+///     (e.g. [`Add`](std::ops::Add),[`Sub`](std::ops::Sub), ...).
+/// - `trait_function`: the function the trait implements
+///     (e.g. add for [`Add`](std::ops::Add), ...).
+/// - `type`: the type the trait is implemented for
+///     (e.g. [`Z`](crate::integer::Z),[`Q`](crate::rational::Q))
+/// - `other_type`: the type the second part of the computation.
+/// - `output_type`: the type of the result.
+///
+/// Returns the owned Implementation code for the `*trait*`
+/// trait with the signature:
+///
+/// ```impl *trait<*other_type*>* for *type*```
+macro_rules! implement_trait_reverse {
+    ($trait:ident, $trait_function:ident, $type:ident, $other_type:ident, $output_type:ident) => {
+        #[doc(hidden)]
+        impl $trait<$other_type> for $type {
+            paste::paste! {
+                #[doc = "Documentation at [`" $output_type "::" $trait_function "`]."]
+                fn $trait_function(&self, other: &$other_type) -> $output_type {
+                    other.$trait_function(self)
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use implement_trait_reverse;

--- a/src/rational/q/cmp.rs
+++ b/src/rational/q/cmp.rs
@@ -10,7 +10,11 @@
 //! This uses the traits from [`std::cmp`].
 
 use super::Q;
-use crate::{integer::Z, macros::for_others::implement_for_others};
+use crate::{
+    integer::Z,
+    integer_mod_q::Modulus,
+    macros::for_others::{implement_for_others, implement_trait_reverse},
+};
 use flint_sys::{
     fmpq::{fmpq_cmp, fmpq_equal},
     fmpz::{fmpz, fmpz_equal},
@@ -54,6 +58,7 @@ impl Eq for Q {}
 
 impl PartialEq<Z> for Q {
     /// Checks if an integer and a rational are equal. Used by the `==` and `!=` operators.
+    /// [`PartialEq`] is also implemented for [`Z`] using [`Q`].
     ///
     /// Parameters:
     /// - `other`: the other value that is used to compare the elements
@@ -65,16 +70,24 @@ impl PartialEq<Z> for Q {
     /// use qfall_math::integer::Z;
     /// use qfall_math::rational::Q;
     /// let a: Q = Q::from(42);
-    /// let b = 42;
+    /// let b: Z = Z::from(42);
     ///
     /// // These are all equivalent and return true.
     /// let compared: bool = (a == b);
     /// # assert!(compared);
+    /// let compared: bool = (b == a);
+    /// # assert!(compared);
     /// let compared: bool = (&a == &b);
+    /// # assert!(compared);
+    /// let compared: bool = (&b == &a);
     /// # assert!(compared);
     /// let compared: bool = (a.eq(&b));
     /// # assert!(compared);
+    /// let compared: bool = (b.eq(&a));
+    /// # assert!(compared);
     /// let compared: bool = (Q::eq(&a, &b));
+    /// # assert!(compared);
+    /// let compared: bool = (Z::eq(&b, &a));
     /// # assert!(compared);
     /// ```
     fn eq(&self, other: &Z) -> bool {
@@ -84,6 +97,52 @@ impl PartialEq<Z> for Q {
         }
     }
 }
+
+implement_trait_reverse!(PartialEq, eq, Z, Q, bool);
+
+impl PartialEq<Modulus> for Q {
+    /// Checks if an integer and a rational are equal. Used by the `==` and `!=` operators.
+    /// [`PartialEq`] is also implemented for [`Modulus`] using [`Q`].
+    ///
+    /// Parameters:
+    /// - `other`: the other value that is used to compare the elements
+    ///
+    /// Returns `true` if the elements are equal, otherwise `false`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::Modulus;
+    /// use qfall_math::rational::Q;
+    /// let a: Q = Q::from(42);
+    /// let b: Modulus = Modulus::from(42);
+    ///
+    /// // These are all equivalent and return true.
+    /// let compared: bool = (a == b);
+    /// # assert!(compared);
+    /// let compared: bool = (b == a);
+    /// # assert!(compared);
+    /// let compared: bool = (&a == &b);
+    /// # assert!(compared);
+    /// let compared: bool = (&b == &a);
+    /// # assert!(compared);
+    /// let compared: bool = (a.eq(&b));
+    /// # assert!(compared);
+    /// let compared: bool = (b.eq(&a));
+    /// # assert!(compared);
+    /// let compared: bool = (Q::eq(&a, &b));
+    /// # assert!(compared);
+    /// let compared: bool = (Modulus::eq(&b, &a));
+    /// # assert!(compared);
+    /// ```
+    fn eq(&self, other: &Modulus) -> bool {
+        unsafe {
+            (1 == fmpz_equal(&self.value.den, &fmpz(1)))
+                && (1 == fmpz_equal(&self.value.num, &other.modulus.n[0]))
+        }
+    }
+}
+
+implement_trait_reverse!(PartialEq, eq, Modulus, Q, bool);
 
 implement_for_others!(Z, Q, PartialEq for fmpz i8 i16 i32 i64 u8 u16 u32 u64);
 
@@ -344,41 +403,48 @@ mod test_partial_eq_q {
 
 /// Test that the [`PartialEq`] trait is correctly implemented.
 #[cfg(test)]
-mod test_partial_eq_q_z {
+mod test_partial_eq_q_other {
     use super::Q;
-    use crate::integer::Z;
+    use crate::{integer::Z, integer_mod_q::Modulus};
 
     // Ensure that the function can be called with several types
     #[test]
     #[allow(clippy::op_ref)]
     fn availability() {
-        let q = Q::from((1, 1));
-        let z = Z::from(1);
+        let q = Q::from((2, 1));
+        let z = Z::from(2);
+        let modulus = Modulus::from(2);
 
         assert!(q == z);
+        assert!(q == modulus);
         assert!(q == z.value);
-        assert!(q == 1i8);
-        assert!(q == 1u8);
-        assert!(q == 1i16);
-        assert!(q == 1u16);
-        assert!(q == 1i32);
-        assert!(q == 1u32);
-        assert!(q == 1i64);
-        assert!(q == 1u64);
+        assert!(q == 2i8);
+        assert!(q == 2u8);
+        assert!(q == 2i16);
+        assert!(q == 2u16);
+        assert!(q == 2i32);
+        assert!(q == 2u32);
+        assert!(q == 2i64);
+        assert!(q == 2u64);
 
+        assert!(z == q);
+        assert!(modulus == q);
         assert!(z.value == q);
-        assert!(1i8 == q);
-        assert!(1u8 == q);
-        assert!(1i16 == q);
-        assert!(1u16 == q);
-        assert!(1i32 == q);
-        assert!(1u32 == q);
-        assert!(1i64 == q);
-        assert!(1u64 == q);
+        assert!(2i8 == q);
+        assert!(2u8 == q);
+        assert!(2i16 == q);
+        assert!(2u16 == q);
+        assert!(2i32 == q);
+        assert!(2u32 == q);
+        assert!(2i64 == q);
+        assert!(2u64 == q);
 
         assert!(&q == &z);
-        assert!(&q == &1i8);
-        assert!(&1i8 == &q);
+        assert!(&z == &q);
+        assert!(&q == &modulus);
+        assert!(&modulus == &q);
+        assert!(&q == &2i8);
+        assert!(&2i8 == &q);
     }
 
     // Ensure that large values are compared correctly
@@ -386,9 +452,13 @@ mod test_partial_eq_q_z {
     fn equal_large() {
         let q = Q::from((u64::MAX, 1));
         let z = Z::from(u64::MAX);
+        let modulus1 = Modulus::from(u64::MAX);
+        let modulus2 = Modulus::from(u64::MAX-1);
 
         assert!(q == z);
+        assert!(q == modulus1);
         assert!(q != z + 1);
+        assert!(q != modulus2);
     }
 }
 


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements PartialEq between Modulus and Z, and between Modulus and Q. 
It also introduces a macro for automatic implementations of second directions of commutative operations, such that we no longer have to implement both directions of commutative operations. 

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [ ] I added basic working examples (possibly in doc-comment)
- [ ] I added tests for large (pointer representation) values
- [ ] I triggered all possible errors in my test in every possible way
- [ ] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [ ] I have performed a self-review of my own code
  - [ ] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [ ] The chosen implementation is not more complex than it has to be
  - [ ] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [ ] The doc comments fit our style guide
  - [ ] I have credited related sources if needed
