### PR TITLE
Replace fmpz_set by fmpz_init_set

### DIFF
--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -16,7 +16,7 @@ use crate::{
     utils::index::{evaluate_index, evaluate_indices_for_matrix},
 };
 use flint_sys::{
-    fmpz::{fmpz, fmpz_set},
+    fmpz::{fmpz, fmpz_init_set},
     fmpz_mat::{fmpz_mat_entry, fmpz_mat_init_set, fmpz_mat_window_clear, fmpz_mat_window_init},
 };
 use std::{fmt::Display, mem::MaybeUninit};
@@ -92,11 +92,11 @@ impl GetEntry<Z> for MatZ {
 
         // since `self.matrix` is a correct fmpz matrix and both row and column
         // are previously checked to be inside of the matrix, no errors
-        // appear inside of `unsafe` and `fmpz_set` can successfully clone the
+        // appear inside of `unsafe` and `fmpz_init_set` can successfully clone the
         // entry of the matrix. Therefore no memory leaks can appear.
         let mut copy = fmpz(0);
         let entry = unsafe { fmpz_mat_entry(&self.matrix, row_i64, column_i64) };
-        unsafe { fmpz_set(&mut copy, entry) };
+        unsafe { fmpz_init_set(&mut copy, entry) };
 
         Ok(Z { value: copy })
     }

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -11,7 +11,8 @@
 use super::Z;
 use crate::traits::AsInteger;
 use flint_sys::fmpz::{
-    fmpz, fmpz_abs, fmpz_cmpabs, fmpz_init_set, fmpz_init_set_si, fmpz_init_set_ui, fmpz_sub, fmpz_swap
+    fmpz, fmpz_abs, fmpz_cmpabs, fmpz_init_set, fmpz_init_set_si, fmpz_init_set_ui, fmpz_sub,
+    fmpz_swap,
 };
 
 /// Efficiently finds maximum absolute value and returns

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -11,7 +11,7 @@
 use super::Z;
 use crate::traits::AsInteger;
 use flint_sys::fmpz::{
-    fmpz, fmpz_abs, fmpz_cmpabs, fmpz_init_set_si, fmpz_init_set_ui, fmpz_set, fmpz_sub, fmpz_swap,
+    fmpz, fmpz_abs, fmpz_cmpabs, fmpz_init_set, fmpz_init_set_si, fmpz_init_set_ui, fmpz_sub, fmpz_swap
 };
 
 /// Efficiently finds maximum absolute value and returns
@@ -138,7 +138,7 @@ unsafe impl AsInteger for &Z {
     /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
         let mut value = fmpz(0);
-        fmpz_set(&mut value, &self.value);
+        fmpz_init_set(&mut value, &self.value);
         value
     }
 
@@ -164,7 +164,7 @@ unsafe impl AsInteger for &fmpz {
     /// Documentation at [`AsInteger::into_fmpz`]
     unsafe fn into_fmpz(self) -> fmpz {
         let mut value = fmpz(0);
-        fmpz_set(&mut value, self);
+        fmpz_init_set(&mut value, self);
         value
     }
 

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -17,7 +17,7 @@ use crate::{
     macros::for_others::implement_empty_trait_owned_ref,
     traits::AsInteger,
 };
-use flint_sys::fmpz::{fmpz, fmpz_combit, fmpz_get_si, fmpz_set, fmpz_set_str};
+use flint_sys::fmpz::{fmpz, fmpz_combit, fmpz_get_si, fmpz_init_set, fmpz_set_str};
 use std::{ffi::CString, str::FromStr};
 
 impl Z {
@@ -54,7 +54,7 @@ impl Z {
     pub(crate) fn from_fmpz_ref(value: &fmpz) -> Self {
         let mut out = Z::default();
         unsafe {
-            fmpz_set(&mut out.value, value);
+            fmpz_init_set(&mut out.value, value);
         }
         out
     }

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -17,7 +17,7 @@ use crate::{
     macros::for_others::implement_empty_trait_owned_ref,
     traits::AsInteger,
 };
-use flint_sys::fmpz::{fmpz, fmpz_combit, fmpz_get_si, fmpz_init_set, fmpz_set_str, fmpz_setbit};
+use flint_sys::fmpz::{fmpz, fmpz_get_si, fmpz_get_ui, fmpz_init_set, fmpz_set_str, fmpz_setbit};
 use std::{ffi::CString, str::FromStr};
 
 impl Z {

--- a/src/integer/z/ownership.rs
+++ b/src/integer/z/ownership.rs
@@ -12,7 +12,7 @@
 //! The explicit functions contain the documentation.
 
 use super::Z;
-use flint_sys::fmpz::{fmpz, fmpz_clear, fmpz_set};
+use flint_sys::fmpz::{fmpz, fmpz_clear, fmpz_init_set};
 
 impl Clone for Z {
     /// Clones the given element and returns a deep clone of the [`Z`] element.
@@ -28,7 +28,7 @@ impl Clone for Z {
         // a fresh fmpz value is created, set to the same value as the cloned one,
         // and wrapped in a new [`Z`] value. Hence, a fresh deep clone is created.
         let mut value = fmpz(0);
-        unsafe { fmpz_set(&mut value, &self.value) };
+        unsafe { fmpz_init_set(&mut value, &self.value) };
         Self { value }
     }
 }

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -17,7 +17,7 @@ use crate::{
     utils::index::{evaluate_index, evaluate_indices_for_matrix},
 };
 use flint_sys::{
-    fmpz::{fmpz, fmpz_set},
+    fmpz::{fmpz, fmpz_init_set},
     fmpz_mat::fmpz_mat_set,
     fmpz_mod_mat::{
         fmpz_mod_mat_entry, fmpz_mod_mat_init_set, fmpz_mod_mat_window_clear,
@@ -405,7 +405,7 @@ impl GetEntry<Z> for MatZq {
 
         let mut out = Z::default();
         let entry = unsafe { fmpz_mod_mat_entry(&self.matrix, row_i64, column_i64) };
-        unsafe { fmpz_set(&mut out.value, entry) };
+        unsafe { fmpz_init_set(&mut out.value, entry) };
         Ok(out)
     }
 }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -16,7 +16,7 @@ use crate::{
     utils::index::evaluate_index,
 };
 use flint_sys::{
-    fmpz::fmpz_set,
+    fmpz::fmpz_init_set,
     fmpz_mod::fmpz_mod_ctx_init,
     fmpz_mod_poly::fmpz_mod_poly_get_coeff_fmpz,
     fq::{fq_ctx_degree, fq_ctx_struct},
@@ -143,7 +143,7 @@ impl ModulusPolynomialRingZq {
     pub fn get_q(&self) -> Z {
         let mut out = Z::default();
         unsafe {
-            fmpz_set(&mut out.value, &self.get_fq_ctx_struct().ctxp[0].n[0]);
+            fmpz_init_set(&mut out.value, &self.get_fq_ctx_struct().ctxp[0].n[0]);
         }
         out
     }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -143,7 +143,7 @@ impl ModulusPolynomialRingZq {
     pub fn get_q(&self) -> Z {
         let mut out = Z::default();
         unsafe {
-            fmpz_init_set(&mut out.value, &self.get_fq_ctx_struct().ctxp[0].n[0]);
+            fmpz_init_set(&mut out.value, &self.get_fq_ctx().ctxp[0].n[0]);
         }
         out
     }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/to_string.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/to_string.rs
@@ -64,7 +64,7 @@ impl Display for ModulusPolynomialRingZq {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // get the value of the modulus
         let mut modulus = Z::default();
-        unsafe { fmpz_init_set(&mut modulus.value, &self.get_fq_ctx_struct().ctxp[0].n[0]) };
+        unsafe { fmpz_init_set(&mut modulus.value, &self.get_fq_ctx().ctxp[0].n[0]) };
 
         // get the value of the polynomial
         let mut poly = PolyOverZ::default();

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/to_string.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/to_string.rs
@@ -16,7 +16,7 @@ use crate::{
     integer::{PolyOverZ, Z},
     macros::for_others::implement_for_owned,
 };
-use flint_sys::{fmpz::fmpz_set, fmpz_mod_poly::fmpz_mod_poly_get_fmpz_poly};
+use flint_sys::{fmpz::fmpz_init_set, fmpz_mod_poly::fmpz_mod_poly_get_fmpz_poly};
 use std::fmt::Display;
 
 impl From<&ModulusPolynomialRingZq> for String {
@@ -64,7 +64,7 @@ impl Display for ModulusPolynomialRingZq {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // get the value of the modulus
         let mut modulus = Z::default();
-        unsafe { fmpz_set(&mut modulus.value, &self.get_fq_ctx_struct().ctxp[0].n[0]) };
+        unsafe { fmpz_init_set(&mut modulus.value, &self.get_fq_ctx_struct().ctxp[0].n[0]) };
 
         // get the value of the polynomial
         let mut poly = PolyOverZ::default();

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use flint_sys::{
     fmpq::{fmpq, fmpq_canonicalise, fmpq_clear, fmpq_get_d, fmpq_set_str},
-    fmpz::{fmpz_is_zero, fmpz_set},
+    fmpz::{fmpz_init_set, fmpz_is_zero},
 };
 use std::{ffi::CString, str::FromStr};
 
@@ -130,7 +130,7 @@ impl<Integer: Into<Z>> From<Integer> for Q {
         let value = value.into();
         // this efficient implementation depends on Q::default instantiating 1 as denominator
         let mut out = Q::default();
-        unsafe { fmpz_set(&mut out.value.num, &value.value) }
+        unsafe { fmpz_init_set(&mut out.value.num, &value.value) }
         out
     }
 }

--- a/src/rational/q/get.rs
+++ b/src/rational/q/get.rs
@@ -10,7 +10,7 @@
 
 use super::Q;
 use crate::integer::Z;
-use flint_sys::fmpz::fmpz_set;
+use flint_sys::fmpz::fmpz_init_set;
 
 impl Q {
     /// Returns the denominator
@@ -28,7 +28,7 @@ impl Q {
     /// ```
     pub fn get_denominator(&self) -> Z {
         let mut result = Z::default();
-        unsafe { fmpz_set(&mut result.value, &self.value.den) };
+        unsafe { fmpz_init_set(&mut result.value, &self.value.den) };
         result
     }
 
@@ -47,7 +47,7 @@ impl Q {
     /// ```
     pub fn get_numerator(&self) -> Z {
         let mut result = Z::default();
-        unsafe { fmpz_set(&mut result.value, &self.value.num) };
+        unsafe { fmpz_init_set(&mut result.value, &self.value.num) };
         result
     }
 }


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR replaces fmpz_set by fmpz_init_set where the value that is set is uninitialised (not set with a large number).

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
