### PR TITLE
`MatQ` Multiplication with f64 precision

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -13,6 +13,7 @@ use criterion::criterion_main;
 pub mod cholesky_decomposition;
 pub mod classic_crypto;
 pub mod integer;
+pub mod matrix_arith;
 pub mod sample_z;
 pub mod sampling;
 pub mod solve;
@@ -23,5 +24,6 @@ criterion_main! {
     sampling::benches,
     solve::benches,
     cholesky_decomposition::benches,
-    sample_z::benches
+    sample_z::benches,
+    matrix_arith::benches,
 }

--- a/benches/matrix_arith.rs
+++ b/benches/matrix_arith.rs
@@ -1,0 +1,30 @@
+// Copyright © 2025 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Create benchmark for matrix arithmetic in this file.
+
+use criterion::{criterion_group, Criterion};
+use qfall_math::rational::MatQ;
+
+/// Benchmark [`MatQ::mul_f64_unchecked`].
+///
+/// We uniformly sampled a matrix `A = ZZ^{100 x 100}` with
+/// values between -256 and 256 and inversed this matrix.
+/// This benchmark loads `A^{-1}` and multiplies `A^{-1}` with
+/// itself allowing for some loss of precision.
+pub fn bench_mat_q_mul_f64_unchecked(c: &mut Criterion) {
+    let string =
+        std::fs::read_to_string("benches/mat_q_100x100.txt").expect("Unable to read file.");
+    let matrix: MatQ = serde_json::from_str(&string).expect("Couldn't deserialize matrix.");
+
+    c.bench_function("MatQ multiplication", |b| {
+        b.iter(|| matrix.mul_f64_unchecked(&matrix))
+    });
+}
+
+criterion_group!(benches, bench_mat_q_mul_f64_unchecked);

--- a/src/rational/mat_q/arithmetic/mul.rs
+++ b/src/rational/mat_q/arithmetic/mul.rs
@@ -14,7 +14,7 @@ use crate::integer::MatZ;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
 };
-use crate::traits::{GetNumColumns, GetNumRows};
+use crate::traits::{GetNumColumns, GetNumRows, SetEntry};
 use flint_sys::fmpq_mat::{fmpq_mat_mul, fmpq_mat_mul_fmpz_mat};
 use std::ops::Mul;
 
@@ -91,6 +91,53 @@ impl Mul<&MatZ> for &MatQ {
         let mut new = MatQ::new(self.get_num_rows(), other.get_num_columns());
         unsafe { fmpq_mat_mul_fmpz_mat(&mut new.matrix, &self.matrix, &other.matrix) };
         new
+    }
+}
+
+impl MatQ {
+    /// Multiplies the matrices `self` and `other` naively with each other
+    /// using their [`f64`] presentation, i.e. with a small loss of precision.
+    ///
+    /// This function can speed up multiplications of [`MatQ`]'s as it allows for
+    /// some loss of precision. The loss of precision depends on the size of the matrices
+    /// and how exact the entries could be represented by a [`f64`].
+    ///
+    /// **WARNING:** This function is less efficient than [`Mul`] for integer values
+    /// or entries with small numerators and denominators. This function becomes more
+    /// efficient once `self` or `other` has entries with large numerators and denominators
+    /// as FLINT's implementation does not allow any loss of precision.
+    /// Furthermore, this function is unchecked, i.e. the user is expected to align matrix
+    /// dimensions for multiplication.
+    ///  
+    /// # Example
+    /// ```
+    /// use qfall_math::integer::MatZ;
+    /// let mat = MatZ::sample_uniform(3, 3, -256, 256).unwrap().inverse().unwrap();
+    ///
+    /// let mat_inv_sqrd = mat.mul_f64_unchecked(&mat);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the dimensions of `self` and `other` do not match for multiplication.
+    pub fn mul_f64_unchecked(&self, other: &Self) -> MatQ {
+        let num_rows = self.get_num_rows() as usize;
+        let num_cols = other.get_num_columns() as usize;
+
+        let mat_self = self.collect_entries_f64();
+        let mat_other = other.collect_entries_f64();
+
+        let mut mat_out = MatQ::new(num_rows, num_cols);
+        for (i, row) in mat_self.iter().enumerate() {
+            for j in 0..num_cols {
+                let mut entry = 0.0;
+                for k in 0..self.get_num_columns() as usize {
+                    entry += row[k] * mat_other[k][j];
+                }
+                mat_out.set_entry(i, j, entry).unwrap();
+            }
+        }
+
+        mat_out
     }
 }
 
@@ -240,5 +287,56 @@ mod test_mul_matz {
         let mat_1 = MatQ::from_str("[[2/3, 1],[1/2, 2]]").unwrap();
         let mat_2 = MatZ::from_str("[[1, 0],[0, 1],[0, 0]]").unwrap();
         let _ = &mat_1 * &mat_2;
+    }
+}
+
+#[cfg(test)]
+mod test_mul_f64_unchecked {
+    use crate::{
+        rational::{MatQ, Q},
+        traits::{Distance, GetEntry},
+    };
+    use std::str::FromStr;
+
+    /// Ensures that the result of the multiplication is valid.
+    #[test]
+    fn correctness() {
+        // If the entries of the matrix are changed to fractions that can't be represented
+        // exactly by f64, the assertions need to be adapted to check for small losses.
+        let mat_0 = MatQ::from_str("[[1,0],[0,1]]").unwrap();
+        let mat_1 = MatQ::from_str("[[4,5],[5/10,-4/8],[-3,0]]").unwrap();
+        let mat_2 = MatQ::from_str("[[-3/-4],[1/2]]").unwrap();
+
+        assert_eq!(mat_0, mat_0.mul_f64_unchecked(&mat_0));
+        assert_eq!(&mat_1 * &mat_0, mat_1.mul_f64_unchecked(&mat_0));
+        assert_eq!(&mat_0 * &mat_2, mat_0.mul_f64_unchecked(&mat_2));
+    }
+
+    /// Ensures that the loss of precision is reasonable.
+    /// This test just showcases / gives an idea that the loss of precision
+    /// should be fairly irrelevant for most use-cases. Nevertheless,
+    /// the loss of precision depends on the dimensions of the matrices
+    /// and the loss of precision due to transforming to [`f64`].
+    #[test]
+    fn loss_of_precision() {
+        let mat = MatQ::from_str(&format!("[[1/{},0],[0,-1/{}]]", u64::MAX, i64::MAX)).unwrap();
+        let cmp_0 = Q::from((1, u64::MAX));
+        let cmp_1 = Q::from((1, i64::MAX));
+        let max_loss = Q::from((1, i64::MAX));
+
+        let res = mat.mul_f64_unchecked(&mat);
+
+        assert!(res.get_entry(0, 0).unwrap().distance(cmp_0) < max_loss);
+        assert!(res.get_entry(1, 1).unwrap().distance(cmp_1) < max_loss);
+    }
+
+    /// Ensures that the function panics if invalid dimensions are input.
+    #[test]
+    #[should_panic]
+    fn incorrect_dimensions() {
+        let mat_0 = MatQ::identity(2, 3);
+        let mat_1 = MatQ::new(1, 2);
+
+        let _ = mat_0.mul_f64_unchecked(&mat_1);
     }
 }

--- a/src/rational/mat_q/arithmetic/mul.rs
+++ b/src/rational/mat_q/arithmetic/mul.rs
@@ -106,7 +106,14 @@ impl MatQ {
     /// or entries with small numerators and denominators. This function becomes more
     /// efficient once `self` or `other` has entries with large numerators and denominators
     /// as FLINT's implementation does not allow any loss of precision.
-    /// Furthermore, this function is unchecked, i.e. the user is expected to align matrix
+    ///
+    /// **WARNING:** Please be aware that the deviation of the representation of the matrices' entries as [`f64`]
+    /// will scale with the size of the entries, e.g. an entry within the size of `2^{64}`
+    /// might deviate from the original value by a distance of `1_000`. This loss of precision
+    /// might be aggravated by this matrix multiplication with a factor of `self.get_num_columns()`
+    /// for each entry in the resulting matrix.
+    ///
+    /// **WARNING:** This function is unchecked, i.e. the user is expected to align matrix
     /// dimensions for multiplication.
     ///  
     /// # Example
@@ -119,6 +126,8 @@ impl MatQ {
     ///
     /// # Panics ...
     /// - if the dimensions of `self` and `other` do not match for multiplication.
+    /// - if any result during the naive computation of matrix multiplication
+    ///     is larger than [`f64::MAX`] or smaller than [`f64::MIN`].
     pub fn mul_f64_unchecked(&self, other: &Self) -> MatQ {
         let num_rows = self.get_num_rows() as usize;
         let num_cols = other.get_num_columns() as usize;

--- a/src/rational/mat_q/cholesky_decomp.rs
+++ b/src/rational/mat_q/cholesky_decomp.rs
@@ -112,15 +112,7 @@ impl MatQ {
         let mat_dimension = self.get_num_rows() as usize;
 
         let mut out = vec![vec![0.0; mat_dimension]; mat_dimension];
-        let mut mat = vec![vec![0.0; mat_dimension]; mat_dimension];
-
-        // extract `self` into a vector of vectors of `f64` values
-        // to avoid memory allocation and freeing during runtime
-        for (i, row) in mat.iter_mut().enumerate().take(mat_dimension) {
-            for (j, entry) in row.iter_mut().enumerate().take(mat_dimension) {
-                *entry = f64::from(&self.get_entry(i, j).unwrap());
-            }
-        }
+        let mat = self.collect_entries_f64();
 
         // This code snippet originates from [flint](https://github.com/flintlib/flint/blob/main/src/fmpz_mat/chol_d.c)
         // it is not part of [flint-sys] as it requires a specific data-type `d_mat_t`

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -274,7 +274,7 @@ impl MatQ {
     ///
     /// let mat = MatQ::from_str("[[1/1, 2],[3/1, 4],[5/1, 6]]").unwrap();
     ///
-    /// let fmpz_entries = mat.collect_entries();
+    /// let fmpq_entries = mat.collect_entries();
     /// ```
     pub(crate) fn collect_entries(&self) -> Vec<fmpq> {
         let mut entries: Vec<fmpq> = vec![];
@@ -284,6 +284,40 @@ impl MatQ {
                 // efficiently get entry without cloning the entry itself
                 let entry = unsafe { *fmpq_mat_entry(&self.matrix, row, col) };
                 entries.push(entry);
+            }
+        }
+
+        entries
+    }
+
+    /// Returns a copy of all entries of `self` as [`f64`] values in [`Vec`]tors s.t.
+    /// the resulting vector can be used as `entries_f64[i][j]` to
+    /// access the entry in row `i` and column `j`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::MatQ;
+    /// use std::str::FromStr;
+    ///
+    /// let mat = MatQ::from_str("[[1/1, 2],[3/1, 4],[5/1, 6]]").unwrap();
+    ///
+    /// let entries_f64 = mat.collect_entries_f64();
+    ///
+    /// assert_eq!(entries_f64[0][1], 2.0);
+    /// ```
+    pub fn collect_entries_f64(&self) -> Vec<Vec<f64>> {
+        let num_rows = self.get_num_rows() as usize;
+        let num_cols = self.get_num_columns() as usize;
+
+        let mut entries: Vec<Vec<f64>> = vec![vec![]; num_rows];
+
+        for (i, row) in entries.iter_mut().enumerate() {
+            for j in 0..num_cols {
+                // efficiently get entry without cloning the entry itself
+                let entry = unsafe {
+                    flint_sys::fmpq::fmpq_get_d(fmpq_mat_entry(&self.matrix, i as i64, j as i64))
+                };
+                row.push(entry);
             }
         }
 
@@ -683,5 +717,29 @@ mod test_collect_entries {
         assert_eq!(entries_2[0].den.0, 1);
         assert_eq!(entries_2[1].num.0, -1);
         assert_eq!(entries_2[1].den.0, 2);
+    }
+
+    #[test]
+    fn all_entries_collected_f64() {
+        let mat_1 =
+            MatQ::from_str(&format!("[[1/{}, 2],[-3, 4/5],[-3/-4, 4]]", i64::MAX,)).unwrap();
+        let mat_2 = MatQ::from_str("[[-1/1, 2/-4]]").unwrap();
+
+        let entries_1 = mat_1.collect_entries_f64();
+        let entries_2 = mat_2.collect_entries_f64();
+
+        assert_eq!(entries_1.len(), 3);
+        assert_eq!(entries_1[0].len(), 2);
+        assert_eq!(entries_1[0][0], 1.0 / i64::MAX as f64);
+        assert_eq!(entries_1[0][1], 2.0);
+        assert_eq!(entries_1[1][0], -3.0);
+        assert!((entries_1[1][1] - 0.8).abs() < 0.00001);
+        assert_eq!(entries_1[2][0], 0.75);
+        assert_eq!(entries_1[2][1], 4.0);
+
+        assert_eq!(entries_2.len(), 1);
+        assert_eq!(entries_2[0].len(), 2);
+        assert_eq!(entries_2[0][0], -1.0);
+        assert_eq!(entries_2[0][1], -0.5);
     }
 }

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -294,6 +294,11 @@ impl MatQ {
     /// the resulting vector can be used as `entries_f64[i][j]` to
     /// access the entry in row `i` and column `j`.
     ///
+    /// **WARNING:** The return is system dependent if any entry of the matrix is
+    /// is too large or too small to fit in an [`f64`], i.e. the value should be within
+    /// [`f64::MIN`] and [`f64::MAX`]. It the entry can't be represented exactly, it will
+    /// be rounded towards zero.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::rational::MatQ;
@@ -719,10 +724,17 @@ mod test_collect_entries {
         assert_eq!(entries_2[1].den.0, 2);
     }
 
+    /// Ensures that all entries from the matrices are actually collected
+    /// in [`MatQ::collect_entries_f64`].
     #[test]
     fn all_entries_collected_f64() {
-        let mat_1 =
-            MatQ::from_str(&format!("[[1/{}, 2],[-3, 4/5],[-3/-4, 4]]", i64::MAX,)).unwrap();
+        let mat_1 = MatQ::from_str(&format!(
+            "[[1/{}, 2],[{}, 4/5],[-3/-4, {}]]",
+            i64::MAX,
+            i64::MAX,
+            i64::MIN
+        ))
+        .unwrap();
         let mat_2 = MatQ::from_str("[[-1/1, 2/-4]]").unwrap();
 
         let entries_1 = mat_1.collect_entries_f64();
@@ -732,10 +744,10 @@ mod test_collect_entries {
         assert_eq!(entries_1[0].len(), 2);
         assert_eq!(entries_1[0][0], 1.0 / i64::MAX as f64);
         assert_eq!(entries_1[0][1], 2.0);
-        assert_eq!(entries_1[1][0], -3.0);
+        assert!((entries_1[1][0] - i64::MAX as f64).abs() < 1_025.0);
         assert!((entries_1[1][1] - 0.8).abs() < 0.00001);
         assert_eq!(entries_1[2][0], 0.75);
-        assert_eq!(entries_1[2][1], 4.0);
+        assert_eq!(entries_1[2][1], i64::MIN as f64);
 
         assert_eq!(entries_2.len(), 1);
         assert_eq!(entries_2[0].len(), 2);

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -164,6 +164,15 @@ impl From<&Q> for f64 {
     /// Convert a rational [`Q`] into an [`f64`].
     /// The value is rounded to the closest [`f64`] representation.
     ///
+    /// **WARNING:** The return is system dependent if `self` is
+    /// is too large or too small to fit in an [`f64`], i.e. the value should be within
+    /// [`f64::MIN`] and [`f64::MAX`]. It the entry can't be represented exactly, it will
+    /// be rounded towards zero.
+    ///
+    /// **WARNING:** Please be aware that the deviation of the representation of `self` as a [`f64`]
+    /// will scale with the size of `self`, e.g. a value within the size of `2^{64}`
+    /// might deviate from the original value by a distance of `1_000`.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::rational::Q;


### PR DESCRIPTION
**Description**

This PR implements...
- [x] `mul_f64_unchecked` 
- [x] `collect_entries_f64`
- [x] a benchmark for MatQ multiplication

for `MatQ`.

For matrices with larger nominators & denominators, the MatQ::mul that doesn't allow for small precision loss is sometimes too inefficient. `mul_f64_unchecked` changes this by allowing for some loss of precision. This is a naive implementation of matrix multiplication with f64. It performs in the provided benchmark roughly 95% better than MatQ::mul.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide