### PR TITLE
Optimize Uniform Sampling

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -16,6 +16,7 @@ pub mod integer;
 pub mod sample_z;
 pub mod sampling;
 pub mod solve;
+pub mod uniform;
 
 criterion_main! {
     integer::benches,
@@ -23,5 +24,6 @@ criterion_main! {
     sampling::benches,
     solve::benches,
     cholesky_decomposition::benches,
-    sample_z::benches
+    sample_z::benches,
+    uniform::benches,
 }

--- a/benches/uniform.rs
+++ b/benches/uniform.rs
@@ -1,0 +1,72 @@
+// Copyright © 2025 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Create benchmarks for uniform sampling in this file.
+
+use criterion::*;
+use qfall_math::{
+    integer::Z,
+    integer_mod_q::{MatZq, Zq},
+};
+
+/// benchmark creating an integer uniformly at random from a super wide interval
+pub fn bench_uniform_zq_superwide(c: &mut Criterion) {
+    let modulus = Z::from(u64::MAX) * 4 + 4;
+
+    c.bench_function("Uniform superwide single", |b| {
+        b.iter(|| Zq::sample_uniform(&modulus))
+    });
+}
+
+/// benchmark creating an integer uniformly at random from a wide interval
+pub fn bench_uniform_zq_wide(c: &mut Criterion) {
+    c.bench_function("Uniform wide single", |b| {
+        b.iter(|| Zq::sample_uniform(1048576))
+    });
+}
+
+/// benchmark creating an integer uniformly at random from a narrow interval
+pub fn bench_uniform_zq_narrow(c: &mut Criterion) {
+    c.bench_function("Uniform narrow single", |b| {
+        b.iter(|| Zq::sample_uniform(10))
+    });
+}
+
+/// benchmark creating a matrix uniformly at random from a super wide interval
+pub fn bench_uniform_matzq_superwide(c: &mut Criterion) {
+    let modulus = Z::from(u64::MAX) * 4 + 4;
+
+    c.bench_function("Uniform superwide 10,000", |b| {
+        b.iter(|| MatZq::sample_uniform(100, 100, &modulus))
+    });
+}
+
+/// benchmark creating a matrix uniformly at random from a wide interval
+pub fn bench_uniform_matzq_wide(c: &mut Criterion) {
+    c.bench_function("Uniform wide 10,000", |b| {
+        b.iter(|| MatZq::sample_uniform(100, 100, 1048576))
+    });
+}
+
+/// benchmark creating a matrix uniformly at random from a narrow interval
+pub fn bench_uniform_matzq_narrow(c: &mut Criterion) {
+    c.bench_function("Uniform narrow 10,000", |b| {
+        b.iter(|| MatZq::sample_uniform(100, 100, 10))
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().significance_level(0.1).sample_size(1000);
+    targets = bench_uniform_zq_superwide,
+    bench_uniform_zq_wide,
+    bench_uniform_zq_narrow,
+    bench_uniform_matzq_superwide,
+    bench_uniform_matzq_wide,
+    bench_uniform_matzq_narrow,
+);

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -12,7 +12,7 @@ use crate::{
     error::MathError,
     integer::{MatZ, Z},
     traits::{GetNumColumns, GetNumRows, SetEntry},
-    utils::sample::uniform::sample_uniform_rejection,
+    utils::sample::uniform::UniformIntegerSampler,
 };
 use std::fmt::Display;
 
@@ -62,9 +62,10 @@ impl MatZ {
         let mut matrix = MatZ::new(num_rows, num_cols);
 
         let interval_size = &upper_bound - &lower_bound;
+        let mut uis = UniformIntegerSampler::init(&interval_size)?;
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
-                let sample = sample_uniform_rejection(&interval_size)?;
+                let sample = uis.sample();
                 matrix.set_entry(row, col, &lower_bound + sample).unwrap();
             }
         }

--- a/src/integer/poly_over_z/sample/uniform.rs
+++ b/src/integer/poly_over_z/sample/uniform.rs
@@ -12,7 +12,7 @@ use crate::{
     error::MathError,
     integer::{PolyOverZ, Z},
     traits::SetCoefficient,
-    utils::{index::evaluate_index, sample::uniform::sample_uniform_rejection},
+    utils::{index::evaluate_index, sample::uniform::UniformIntegerSampler},
 };
 use std::fmt::Display;
 
@@ -59,10 +59,11 @@ impl PolyOverZ {
         let upper_bound: Z = upper_bound.into();
 
         let interval_size = &upper_bound - &lower_bound;
-        let mut poly_z = PolyOverZ::default();
+        let mut uis = UniformIntegerSampler::init(&interval_size)?;
 
+        let mut poly_z = PolyOverZ::default();
         for index in 0..=max_degree {
-            let sample = sample_uniform_rejection(&interval_size)?;
+            let sample = uis.sample();
             poly_z.set_coeff(index, &lower_bound + sample)?;
         }
         Ok(poly_z)

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -17,7 +17,7 @@ use crate::{
     macros::for_others::implement_empty_trait_owned_ref,
     traits::AsInteger,
 };
-use flint_sys::fmpz::{fmpz, fmpz_combit, fmpz_get_si, fmpz_set, fmpz_set_str};
+use flint_sys::fmpz::{fmpz, fmpz_get_si, fmpz_set, fmpz_set_str, fmpz_setbit};
 use std::{ffi::CString, str::FromStr};
 
 impl Z {
@@ -164,7 +164,7 @@ impl Z {
             for j in 0..u8::BITS {
                 // if j-th bit of `byte` is `1`, then set `i*8 + j`-th bit in fmpz to `1`
                 if ((byte >> j) & 1) % 2 == 1 {
-                    unsafe { fmpz_combit(&mut res.value, (i as u32 * u8::BITS + j) as u64) };
+                    unsafe { fmpz_setbit(&mut res.value, (i as u32 * u8::BITS + j) as u64) };
                 }
             }
         }
@@ -193,7 +193,7 @@ impl Z {
         let mut value = Z::default();
         for (i, bit) in bits.iter().enumerate() {
             if *bit {
-                unsafe { fmpz_combit(&mut value.value, i as u64) };
+                unsafe { fmpz_setbit(&mut value.value, i as u64) };
             }
         }
         value

--- a/src/integer/z/sample/uniform.rs
+++ b/src/integer/z/sample/uniform.rs
@@ -8,7 +8,7 @@
 
 //! This module contains algorithms for sampling according to the uniform distribution.
 
-use crate::{error::MathError, integer::Z, utils::sample::uniform::sample_uniform_rejection};
+use crate::{error::MathError, integer::Z, utils::sample::uniform::UniformIntegerSampler};
 
 impl Z {
     /// Chooses a [`Z`] instance uniformly at random
@@ -47,7 +47,9 @@ impl Z {
         let upper_bound: Z = upper_bound.into();
 
         let interval_size = &upper_bound - &lower_bound;
-        let sample = sample_uniform_rejection(&interval_size)?;
+        let mut uis = UniformIntegerSampler::init(&interval_size)?;
+
+        let sample = uis.sample();
         Ok(&lower_bound + sample)
     }
 
@@ -97,7 +99,8 @@ impl Z {
         }
 
         let interval_size = &upper_bound - &lower_bound;
-        let mut sample = &lower_bound + sample_uniform_rejection(&interval_size)?;
+        let mut uis = UniformIntegerSampler::init(&interval_size)?;
+        let mut sample = &lower_bound + uis.sample();
 
         // after 2 * size of interval many uniform random samples, a suitable prime should have been
         // found with high probability, if there is one prime in the interval
@@ -109,7 +112,7 @@ impl Z {
                         no prime was found. It is very likely, that no prime exists in this interval.
                         Please choose the interval larger.")));
             }
-            sample = &lower_bound + sample_uniform_rejection(&interval_size)?;
+            sample = &lower_bound + uis.sample();
             steps = steps - 1;
         }
 

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -12,7 +12,7 @@ use crate::{
     integer::Z,
     integer_mod_q::MatZq,
     traits::{GetNumColumns, GetNumRows, SetEntry},
-    utils::sample::uniform::sample_uniform_rejection,
+    utils::sample::uniform::{sample_uniform_rejection, UniformIntegerSampler},
 };
 use std::fmt::Display;
 
@@ -49,11 +49,12 @@ impl MatZq {
         modulus: impl Into<Z>,
     ) -> Self {
         let modulus: Z = modulus.into();
-        let mut matrix = MatZq::new(num_rows, num_cols, modulus.clone());
+        let mut uis = UniformIntegerSampler::init(&modulus).unwrap();
+        let mut matrix = MatZq::new(num_rows, num_cols, modulus);
 
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
-                let sample = sample_uniform_rejection(&modulus).unwrap();
+                let sample = uis.sample();
                 matrix.set_entry(row, col, sample).unwrap();
             }
         }

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -12,7 +12,7 @@ use crate::{
     integer::Z,
     integer_mod_q::MatZq,
     traits::{GetNumColumns, GetNumRows, SetEntry},
-    utils::sample::uniform::{sample_uniform_rejection, UniformIntegerSampler},
+    utils::sample::uniform::UniformIntegerSampler,
 };
 use std::fmt::Display;
 

--- a/src/integer_mod_q/poly_over_zq/sample/uniform.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/uniform.rs
@@ -13,7 +13,7 @@ use crate::{
     integer::Z,
     integer_mod_q::{Modulus, PolyOverZq},
     traits::SetCoefficient,
-    utils::{index::evaluate_index, sample::uniform::sample_uniform_rejection},
+    utils::{index::evaluate_index, sample::uniform::UniformIntegerSampler},
 };
 use std::fmt::Display;
 
@@ -59,8 +59,10 @@ impl PolyOverZq {
         let modulus = Modulus::from(&interval_size);
         let mut poly_zq = PolyOverZq::from(&modulus);
 
+        let mut uis = UniformIntegerSampler::init(&interval_size)?;
+
         for index in 0..=max_degree {
-            let sample = sample_uniform_rejection(&interval_size)?;
+            let sample = uis.sample();
             poly_zq.set_coeff(index, &sample)?;
         }
         Ok(poly_zq)

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -9,10 +9,7 @@
 //! This module contains sampling algorithms for uniform random sampling.
 
 use crate::{
-    error::MathError,
-    integer::Z,
-    integer_mod_q::Zq,
-    utils::sample::uniform::{sample_uniform_rejection, UniformIntegerSampler},
+    error::MathError, integer::Z, integer_mod_q::Zq, utils::sample::uniform::UniformIntegerSampler,
 };
 
 impl Zq {

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -9,8 +9,10 @@
 //! This module contains sampling algorithms for uniform random sampling.
 
 use crate::{
-    error::MathError, integer::Z, integer_mod_q::Zq,
-    utils::sample::uniform::sample_uniform_rejection,
+    error::MathError,
+    integer::Z,
+    integer_mod_q::Zq,
+    utils::sample::uniform::{sample_uniform_rejection, UniformIntegerSampler},
 };
 
 impl Zq {
@@ -40,8 +42,9 @@ impl Zq {
     ///     if the given modulus is smaller than or equal to `1`.
     pub fn sample_uniform(modulus: impl Into<Z>) -> Result<Self, MathError> {
         let modulus: Z = modulus.into();
+        let mut uis = UniformIntegerSampler::init(&modulus)?;
 
-        let random = sample_uniform_rejection(&modulus)?;
+        let random = uis.sample();
         Ok(Zq::from((random, modulus)))
     }
 }

--- a/src/utils/sample.rs
+++ b/src/utils/sample.rs
@@ -10,4 +10,4 @@
 
 pub(crate) mod binomial;
 pub mod discrete_gauss;
-pub(crate) mod uniform;
+pub mod uniform;

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -16,7 +16,7 @@
 //!     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
 //!     <https://citeseerx.ist.psu.edu/document?doi=d9f54077d568784c786f7b1d030b00493eb3ae35>
 
-use super::uniform::sample_uniform_rejection;
+use super::uniform::UniformIntegerSampler;
 use crate::{
     error::{MathError, StringConversionError},
     integer::{MatZ, Z},
@@ -152,9 +152,10 @@ impl DiscreteGaussianIntegerSampler {
     /// ```
     pub fn sample_z(&mut self) -> Z {
         let mut rng = rand::rng();
+        let mut uis = UniformIntegerSampler::init(&self.interval_size).unwrap();
         loop {
             // sample x in [c - s * log_2(n), c + s * log_2(n)]
-            let sample = &self.lower_bound + sample_uniform_rejection(&self.interval_size).unwrap();
+            let sample = &self.lower_bound + uis.sample();
 
             // grab value of Gauss function for sample if it exists
             let evaluated_gauss_function = self.table.get(&sample);

--- a/src/utils/sample/uniform.rs
+++ b/src/utils/sample/uniform.rs
@@ -11,7 +11,7 @@
 
 use crate::{error::MathError, integer::Z};
 use flint_sys::fmpz::{fmpz, fmpz_addmul_ui, fmpz_set_ui};
-use rand::{rngs::ThreadRng, RngCore, TryRngCore};
+use rand::{rngs::ThreadRng, RngCore};
 
 /// Enables uniformly random sampling a [`Z`] in `[0, interval_size)`.
 ///
@@ -168,128 +168,6 @@ impl UniformIntegerSampler {
     }
 }
 
-/// Computes a uniform at random chosen [`Z`] sample in `[0, interval_size)`.
-///
-/// Parameters:
-/// - `interval_size`: specifies the size of the interval
-///     over which the samples are drawn
-///
-/// Returns a uniform at random chosen [`Z`] instance in `[0, interval_size)` or a [`MathError`],
-/// if the interval size is chosen smaller than or equal to `1`.
-///
-/// # Examples
-/// ```compile_fail
-/// use qfall_math::utils::sample::sample_uniform_rejection;
-/// use qfall_math::integer::Z;
-/// let interval_size = Z::from(20);
-///
-/// let sample = sample_uniform_rejection(&interval_size).unwrap();
-///
-/// assert!(Z::ZERO <= sample);
-/// assert!(sample < interval_size);
-/// ```
-///
-/// # Errors and Failures
-/// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-///     if the interval is chosen smaller than or equal to `1`.
-pub(crate) fn sample_uniform_rejection(interval_size: &Z) -> Result<Z, MathError> {
-    if interval_size <= &Z::ONE {
-        return Err(MathError::InvalidInterval(format!(
-            "An invalid interval size {interval_size} was provided."
-        )));
-    }
-
-    let bit_size = interval_size.bits() as usize;
-
-    let mut random = Z::from(&sample_bits_uniform(bit_size));
-    while &random >= interval_size {
-        random = Z::from(&sample_bits_uniform(bit_size));
-    }
-    Ok(random)
-}
-
-/// Computes `nr_bits` many uniform at random chosen bits.
-///
-/// Parameters:
-/// - `nr_bits`: specifies the number of bits to be chosen uniform at random
-///
-/// Returns a [`Vec<u8>`] including `nr_bits` many uniform at random chosen bits,
-/// filled with `0` bits if needed for the last byte resp. [`u8`].
-///
-/// # Examples
-/// ```compile_fail
-/// use qfall_math::utils::sample::sample_bits_uniform;
-/// let nr_bits = 14;
-///
-/// let byte_vector = sample_bits_uniform(nr_bits);
-///
-/// assert_eq!(byte_vector[1] < 64);
-/// assert_eq!(2, byte_vector.len());
-/// ```
-fn sample_bits_uniform(nr_bits: usize) -> Vec<u8> {
-    let mut rng = rand::rng();
-
-    // sample ⌈ nr_bits / 8 ⌉ bytes
-    let mut byte_vector;
-    if nr_bits % 8 == 0 {
-        byte_vector = vec![0u8; nr_bits / 8];
-    } else {
-        byte_vector = vec![0u8; nr_bits / 8 + 1];
-    }
-    let mut res = rng.try_fill_bytes(&mut byte_vector);
-    while res.is_err() {
-        // Continue filling bytes at first zero byte found by binary search.
-        // This may potentially discard previously sampled values, but stays uniform in the distribution
-        let first_unfilled_byte = find_first_unfilled_byte(&byte_vector);
-        res = rng.try_fill_bytes(&mut byte_vector[first_unfilled_byte..]);
-    }
-
-    // set superfluous bits at the end to `0`
-    if nr_bits % 8 != 0 {
-        let last_index = byte_vector.len() - 1;
-        byte_vector[last_index] %= 2u8.pow(nr_bits as u32 % 8);
-    }
-
-    byte_vector
-}
-
-/// Binary search to find the first zero byte.
-///
-/// As we do not mark the filled bytes, the first zero byte is our
-/// best guess to identify a not yet randomly/ unfilled byte.
-///
-/// Parameters:
-/// - `byte_arr`: specifies the slice whose first zero byte is looked for
-///
-/// Returns the position of the first zero byte acc. to binary search.
-/// If no zero byte exists, the length of the slice is returned.
-///
-/// # Examples
-/// ```compile_fail
-/// use qfall_math::utils::sample::{find_first_unfilled_byte, sample_bits_uniform};
-/// let nr_bits = 256;
-/// let byte_vector = sample_bits_uniform(nr_bits);
-///
-/// let first_zero_byte = find_first_unfilled_byte(&byte_vector);
-/// ```
-fn find_first_unfilled_byte(byte_arr: &[u8]) -> usize {
-    let mut lower_bound = 0;
-    let mut upper_bound = byte_arr.len();
-    while upper_bound - lower_bound > 1 {
-        let index = lower_bound + (upper_bound - lower_bound) / 2;
-        if byte_arr[index] == 0x0 {
-            upper_bound = index;
-        } else {
-            lower_bound = index;
-        }
-    }
-    if byte_arr[lower_bound] == 0x0 {
-        lower_bound
-    } else {
-        upper_bound
-    }
-}
-
 #[cfg(test)]
 mod test_uis {
     use super::{UniformIntegerSampler, Z};
@@ -351,7 +229,11 @@ mod test_uis {
             }
             // if len(samples) == interval_size, then every element in [0, interval_size)
             // needs to be represented in samples
-            assert_eq!(interval_size, samples.len() as u32);
+            assert_eq!(
+                interval_size,
+                samples.len() as u32,
+                "This test may fail with low probability."
+            );
         }
     }
 

--- a/src/utils/sample/uniform.rs
+++ b/src/utils/sample/uniform.rs
@@ -10,7 +10,7 @@
 //! uniform random distribution.
 
 use crate::{error::MathError, integer::Z};
-use flint_sys::fmpz::{fmpz, fmpz_addmul_ui, fmpz_set_ui};
+use flint_sys::fmpz::{fmpz_addmul_ui, fmpz_set_ui};
 use rand::{rngs::ThreadRng, RngCore};
 
 /// Enables uniformly random sampling a [`Z`] in `[0, interval_size)`.
@@ -154,7 +154,7 @@ impl UniformIntegerSampler {
         for _ in 0..self.nr_iterations {
             let sample = self.rng.next_u32();
 
-            let mut res = Z { value: fmpz(0) };
+            let mut res = Z::default();
             unsafe {
                 fmpz_set_ui(&mut res.value, sample as u64);
                 // Sets res = res + value * 2^32 reusing the memory allocated of res

--- a/src/utils/sample/uniform.rs
+++ b/src/utils/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright © 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //
@@ -10,18 +10,69 @@
 //! uniform random distribution.
 
 use crate::{error::MathError, integer::Z};
-use flint_sys::fmpz::{fmpz, fmpz_addmul, fmpz_set_ui};
+use flint_sys::fmpz::{fmpz, fmpz_addmul_ui, fmpz_set_ui};
 use rand::{rngs::ThreadRng, RngCore, TryRngCore};
 
+/// Enables uniformly random sampling a [`Z`] in `[0, interval_size)`.
+///
+/// Attributes:
+/// - `interval_size`: defines the interval [0, interval_size), which we sample from
+/// - `two_pow_32`: is a helper to shift bits by 32-bits left by multiplication
+/// - `nr_iterations`: defines how many full samples of u32 are required
+/// - `upper_modulo`: is a power of two to remove superfluously sampled bits to increase
+///     the probability of accepting a sample to at least 1/2
+/// - `rng`: defines the [`ThreadRng`] that's used to sample uniform [u32] integers
+///
+/// # Examples
+/// ```
+/// use qfall_math::{utils::sample::uniform::UniformIntegerSampler, integer::Z};
+/// let interval_size = Z::from(20);
+///
+/// let mut uis = UniformIntegerSampler::init(&interval_size).unwrap();
+///
+/// let sample = uis.sample();
+///
+/// assert!(Z::ZERO <= sample);
+/// assert!(sample < interval_size);
+/// ```
+///
+/// # Errors and Failures
+/// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
+///     if the interval is chosen smaller than or equal to `1`.
 pub struct UniformIntegerSampler {
     interval_size: Z,
-    two_pow_64: Z,
+    two_pow_32: u64,
     nr_iterations: u32,
-    upper_modulo: u64,
+    upper_modulo: u32,
     rng: ThreadRng,
 }
 
 impl UniformIntegerSampler {
+    /// Initializes the [`UniformIntegerSampler`] with
+    /// - `interval_size` as `interval_size`,
+    /// - `two_pow_32` as a [u64] containing 2^32
+    /// - `nr_iterations` as `(interval_size - 1).bits() / 32` floored
+    /// - `upper_modulo` as 2^{(interval_size - 1).bits() mod 32}
+    /// - `rng` as a fresh [`ThreadRng`]
+    ///
+    /// Parameters:
+    /// - `interval_size`: specifies the interval `[0, interval_size)`
+    ///     from which the samples are drawn
+    ///
+    /// Returns a [`UniformIntegerSampler`] or a [`MathError`],
+    /// if the interval size is chosen smaller than or equal to `1`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{utils::sample::uniform::UniformIntegerSampler, integer::Z};
+    /// let interval_size = Z::from(20);
+    ///
+    /// let mut uis = UniformIntegerSampler::init(&interval_size).unwrap();
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
+    ///     if the interval is chosen smaller than or equal to `1`.
     pub fn init(interval_size: &Z) -> Result<Self, MathError> {
         if interval_size <= &Z::ONE {
             return Err(MathError::InvalidInterval(format!(
@@ -29,27 +80,47 @@ impl UniformIntegerSampler {
             )));
         }
 
-        let two_pow_64: Z = Z::from(u64::MAX) + 1;
+        // Compute 2^32 to be able to shift bits to the left
+        // by 32 bits using multiplication
+        let two_pow_32 = u32::MAX as u64 + 1;
 
-        let bit_size = interval_size.bits() as u32;
+        let bit_size = (interval_size - Z::ONE).bits() as u32;
 
-        // div rounds towards 0, i.e. div_floor in this case
-        let nr_iterations = bit_size / 64;
+        // div rounds towards 0, i.e. div_floor in this case, i.e. this is
+        // perfect for sampling the top one first and then iterating
+        // nr_iterations-many times
+        let nr_iterations = bit_size / 32;
 
-        // Set upper_modulo to 2^{bit_size mod 64} - defines how many bits will be discarded / have been sampled too much
-        let upper_modulo = 2_u64.pow(bit_size % 64);
+        // Set upper_modulo to 2^{bit_size mod 32}
+        // defines how many bits will be discarded / have been sampled too much
+        let upper_modulo = 2_u32.pow(bit_size % 32);
 
         let rng = rand::rng();
 
         Ok(Self {
             interval_size: interval_size.clone(),
-            two_pow_64,
+            two_pow_32,
             nr_iterations,
             upper_modulo,
             rng,
         })
     }
 
+    /// Computes a uniformly chosen [`Z`] sample in `[0, interval_size)`
+    /// using rejection sampling that accepts samples with probability at least 1/2.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{utils::sample::uniform::UniformIntegerSampler, integer::Z};
+    /// let interval_size = Z::from(20);
+    ///
+    /// let mut uis = UniformIntegerSampler::init(&interval_size).unwrap();
+    ///
+    /// let sample = uis.sample();
+    ///
+    /// assert!(Z::ZERO <= sample);
+    /// assert!(sample < interval_size);
+    /// ```
     pub fn sample(&mut self) -> Z {
         let mut sample = self.sample_bits_uniform();
         while sample >= self.interval_size {
@@ -59,27 +130,42 @@ impl UniformIntegerSampler {
         sample
     }
 
-    fn sample_bits_uniform(&mut self) -> Z {
-        let mut value = Z::from(self.rng.next_u64() % self.upper_modulo);
+    /// Computes `self.nr_iterations * 32 + upper_modulo` many uniformly chosen bits.
+    ///
+    /// Returns a [`Z`] containing `self.nr_iterations * 32 + upper_modulo`-many uniformly
+    /// chosen bits.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{utils::sample::uniform::UniformIntegerSampler, integer::Z};
+    /// let interval = Z::from(u16::MAX) + 1;
+    ///
+    /// let mut uis = UniformIntegerSampler::init(&interval).unwrap();
+    ///
+    /// let sample = uis.sample_bits_uniform();
+    ///
+    /// assert!(Z::ZERO <= sample);
+    /// assert!(sample < interval);
+    /// ```
+    pub fn sample_bits_uniform(&mut self) -> Z {
+        // remove superfluously sampled bits to increase chance of acception to at lest 1/2
+        let mut value = Z::from(self.rng.next_u32() % self.upper_modulo);
+
         for _ in 0..self.nr_iterations {
-            let sample = self.rng.next_u64();
+            let sample = self.rng.next_u32();
+
             let mut res = Z { value: fmpz(0) };
             unsafe {
-                fmpz_set_ui(&mut res.value, sample);
-                // Sets res = res + value * 2^64
-                fmpz_addmul(&mut res.value, &value.value, &self.two_pow_64.value);
+                fmpz_set_ui(&mut res.value, sample as u64);
+                // Sets res = res + value * 2^32 reusing the memory allocated of res
+                // could be optimized by shifting bits left by 32 bits once lshift is part of flint-sys
+                fmpz_addmul_ui(&mut res.value, &value.value, self.two_pow_32);
             };
             value = res;
         }
 
         value
     }
-}
-
-#[test]
-fn a() {
-    let modulus = (Z::from(u64::MAX) + 1) + 1;
-    let _ = crate::integer_mod_q::MatZq::sample_uniform(100, 100, &modulus);
 }
 
 /// Computes a uniform at random chosen [`Z`] sample in `[0, interval_size)`.
@@ -204,178 +290,101 @@ fn find_first_unfilled_byte(byte_arr: &[u8]) -> usize {
     }
 }
 
-// #[cfg(test)]
-// mod test_sample_uniform_rejection {
-//     use super::{sample_uniform_rejection, Z};
+#[cfg(test)]
+mod test_uis {
+    use super::{UniformIntegerSampler, Z};
+    use std::collections::HashSet;
 
-//     /// Ensures that the doc tests works correctly.
-//     #[test]
-//     fn doc_test() {
-//         let interval_size = Z::from(20);
+    /// Checks whether sampling works fine for small interval sizes.
+    #[test]
+    fn small_interval() {
+        let size_2 = Z::from(2);
+        let size_7 = Z::from(7);
 
-//         let sample = sample_uniform_rejection(&interval_size).unwrap();
+        let mut uis_2 = UniformIntegerSampler::init(&size_2).unwrap();
+        let mut uis_7 = UniformIntegerSampler::init(&size_7).unwrap();
 
-//         assert!(Z::ZERO <= sample);
-//         assert!(sample < interval_size);
-//     }
+        for _ in 0..3 {
+            let sample_2 = uis_2.sample();
+            let sample_7 = uis_7.sample();
 
-//     /// Checks whether sampling works fine for small interval sizes
-//     #[test]
-//     fn small_interval() {
-//         let size_2 = Z::from(2);
-//         let size_7 = Z::from(7);
+            assert!(Z::ZERO <= sample_2);
+            assert!(sample_2 < size_2);
+            assert!(Z::ZERO <= sample_7);
+            assert!(sample_7 < size_7)
+        }
+    }
 
-//         let sample_0 = sample_uniform_rejection(&size_2).unwrap();
-//         let sample_1 = sample_uniform_rejection(&size_2).unwrap();
-//         let sample_2 = sample_uniform_rejection(&size_2).unwrap();
-//         let sample_3 = sample_uniform_rejection(&size_7).unwrap();
-//         let sample_4 = sample_uniform_rejection(&size_7).unwrap();
-//         let sample_5 = sample_uniform_rejection(&size_7).unwrap();
+    /// Checks whether sampling works fine for large interval sizes.
+    #[test]
+    fn large_interval() {
+        let size_0 = Z::from(u64::MAX);
+        let size_1 = Z::from(u64::MAX) * 2 + 1;
 
-//         assert!(sample_0 >= Z::ZERO);
-//         assert!(sample_0 < size_2);
-//         assert!(sample_1 >= Z::ZERO);
-//         assert!(sample_1 < size_2);
-//         assert!(sample_2 >= Z::ZERO);
-//         assert!(sample_2 < size_2);
-//         assert!(sample_3 >= Z::ZERO);
-//         assert!(sample_3 < size_7);
-//         assert!(sample_4 >= Z::ZERO);
-//         assert!(sample_4 < size_7);
-//         assert!(sample_5 >= Z::ZERO);
-//         assert!(sample_5 < size_7);
-//     }
+        let mut uis_0 = UniformIntegerSampler::init(&size_0).unwrap();
+        let mut uis_1 = UniformIntegerSampler::init(&size_1).unwrap();
 
-//     /// Checks whether sampling works fine for large interval sizes
-//     #[test]
-//     fn large_interval() {
-//         let size = Z::from(i64::MAX);
+        for _i in 0..u8::MAX {
+            let sample_0 = uis_0.sample();
+            let sample_1 = uis_1.sample();
 
-//         for _i in 0..u8::MAX {
-//             let sample = sample_uniform_rejection(&size).unwrap();
+            assert!(Z::ZERO <= sample_0);
+            assert!(sample_0 < size_0);
+            assert!(Z::ZERO <= sample_1);
+            assert!(sample_1 < size_1);
+        }
+    }
 
-//             assert!(sample >= Z::ZERO);
-//             assert!(sample < size);
-//         }
-//     }
+    /// Checks whether it samples from the entire interval.
+    #[test]
+    fn entire_interval() {
+        let interval_sizes = vec![6, 7, 16];
 
-//     /// Checks whether interval sizes smaller than 2 result in an error
-//     #[test]
-//     fn invalid_interval() {
-//         assert!(sample_uniform_rejection(&Z::ONE).is_err());
-//         assert!(sample_uniform_rejection(&Z::ZERO).is_err());
-//         assert!(sample_uniform_rejection(&Z::MINUS_ONE).is_err());
-//     }
-// }
+        for interval_size in interval_sizes {
+            let interval = Z::from(interval_size);
 
-// #[cfg(test)]
-// mod test_sample_bits_uniform {
-//     use super::sample_bits_uniform;
+            let mut uis = UniformIntegerSampler::init(&interval).unwrap();
 
-//     /// Ensures that the doc tests works correctly.
-//     #[test]
-//     fn doc_test() {
-//         let nr_bits = 14;
+            let mut samples = HashSet::new();
+            for _ in 0..2_u32.pow(interval_size) {
+                samples.insert(uis.sample());
+            }
+            // if len(samples) == interval_size, then every element in [0, interval_size)
+            // needs to be represented in samples
+            assert_eq!(interval_size, samples.len() as u32);
+        }
+    }
 
-//         let byte_vector = sample_bits_uniform(nr_bits);
+    /// Checks whether interval sizes smaller than 2 result in an error.
+    #[test]
+    fn invalid_interval() {
+        assert!(UniformIntegerSampler::init(&Z::ONE).is_err());
+        assert!(UniformIntegerSampler::init(&Z::ZERO).is_err());
+        assert!(UniformIntegerSampler::init(&Z::MINUS_ONE).is_err());
+    }
 
-//         assert!(byte_vector[1] < 64);
-//         assert_eq!(2, byte_vector.len());
-//     }
+    /// Checks whether random bit sampling doesn't fill more bits than required.
+    #[test]
+    fn sample_bits_uniform_necessary_nr_bytes() {
+        let size_0 = Z::from(8);
+        let size_1 = Z::from(256);
+        let size_2 = Z::from(u32::MAX) + Z::ONE;
 
-//     /// Checks whether random bit sampling works appropriate for full byte orders
-//     #[test]
-//     fn full_bytes() {
-//         let bits_0 = sample_bits_uniform(8);
-//         let bits_1 = sample_bits_uniform(16);
-//         let bits_2 = sample_bits_uniform(256);
+        let mut uis_0 = UniformIntegerSampler::init(&size_0).unwrap();
+        let mut uis_1 = UniformIntegerSampler::init(&size_1).unwrap();
+        let mut uis_2 = UniformIntegerSampler::init(&size_2).unwrap();
 
-//         assert_eq!(1, bits_0.len());
-//         assert_eq!(2, bits_1.len());
-//         assert_eq!(32, bits_2.len());
-//     }
+        for _ in 0..u8::MAX {
+            let sample_0 = uis_0.sample_bits_uniform();
+            let sample_1 = uis_1.sample_bits_uniform();
+            let sample_2 = uis_2.sample_bits_uniform();
 
-//     /// Checks whether random bit sampling works appropriate for partial bytes
-//     /// and that superfluous bits are cutoff appropriately
-//     #[test]
-//     fn partial_bytes() {
-//         let bits_0 = sample_bits_uniform(7);
-//         let bits_1 = sample_bits_uniform(14);
-//         let bits_2 = sample_bits_uniform(250);
-
-//         assert_eq!(1, bits_0.len());
-//         assert!(128 > bits_0[0]);
-//         assert_eq!(2, bits_1.len());
-//         assert!(64 > bits_1[1]);
-//         assert_eq!(32, bits_2.len());
-//         assert!(4 > bits_2[31]);
-//     }
-
-//     /// Check whether all necessary bits are chosen uniform at random.
-//     /// This test could possibly fail with probability 2^-64
-//     #[test]
-//     fn random_bits() {
-//         let mut samples: Vec<u8> = vec![];
-//         for _i in 0..64 {
-//             samples.push(sample_bits_uniform(7)[0]);
-//         }
-
-//         for position in 0..7 {
-//             let mut found_1 = false;
-//             // check for all 64 samples whether the `position`-th bit is `1`
-//             for sample in &samples {
-//                 if (sample >> position & 1) % 2 == 1 {
-//                     found_1 = true;
-//                     break;
-//                 }
-//             }
-
-//             if !found_1 {
-//                 panic!(
-//                     "None of the inspected 64 random bits at position {position} was 1.
-//                     This seems suspicious."
-//                 );
-//             }
-//         }
-//     }
-// }
-
-// #[cfg(test)]
-// mod test_find_first_unfilled_byte {
-//     use super::{find_first_unfilled_byte, sample_bits_uniform};
-
-//     /// Ensures that the doc test works properly and that
-//     /// the boundaries of the slice length are respected
-//     #[test]
-//     fn doc_test() {
-//         let nr_bits = 256;
-//         let byte_vector = sample_bits_uniform(nr_bits);
-
-//         let first_zero_byte = find_first_unfilled_byte(&byte_vector);
-
-//         assert!(first_zero_byte <= 256);
-//     }
-
-//     /// Ensures correct computation of the first
-//     /// detectable zero bytes via binary search for static examples
-//     #[test]
-//     fn static_cases() {
-//         let mut vec_0 = vec![0x1; 5];
-//         let mut vec_1 = vec![0x0; 4];
-//         let arr_0: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 0];
-//         let arr_1: [u8; 7] = [1, 2, 0, 0, 0, 0, 0];
-
-//         let res_0 = find_first_unfilled_byte(&vec_0);
-//         let res_1 = find_first_unfilled_byte(&vec_1);
-//         vec_0.append(&mut vec_1);
-//         let res_2 = find_first_unfilled_byte(&vec_0);
-//         let res_3 = find_first_unfilled_byte(&arr_0);
-//         let res_4 = find_first_unfilled_byte(&arr_1);
-
-//         assert_eq!(5, res_0);
-//         assert_eq!(0, res_1);
-//         assert_eq!(5, res_2);
-//         assert_eq!(7, res_3);
-//         assert_eq!(2, res_4);
-//     }
-// }
+            assert!(Z::ZERO <= sample_0);
+            assert!(sample_0 < size_0);
+            assert!(Z::ZERO <= sample_1);
+            assert!(sample_1 < size_1);
+            assert!(Z::ZERO <= sample_2);
+            assert!(sample_2 < size_2);
+        }
+    }
+}

--- a/src/utils/sample/uniform.rs
+++ b/src/utils/sample/uniform.rs
@@ -10,7 +10,77 @@
 //! uniform random distribution.
 
 use crate::{error::MathError, integer::Z};
-use rand::TryRngCore;
+use flint_sys::fmpz::{fmpz, fmpz_addmul, fmpz_set_ui};
+use rand::{rngs::ThreadRng, RngCore, TryRngCore};
+
+pub struct UniformIntegerSampler {
+    interval_size: Z,
+    two_pow_64: Z,
+    nr_iterations: u32,
+    upper_modulo: u64,
+    rng: ThreadRng,
+}
+
+impl UniformIntegerSampler {
+    pub fn init(interval_size: &Z) -> Result<Self, MathError> {
+        if interval_size <= &Z::ONE {
+            return Err(MathError::InvalidInterval(format!(
+                "An invalid interval size {interval_size} was provided."
+            )));
+        }
+
+        let two_pow_64: Z = Z::from(u64::MAX) + 1;
+
+        let bit_size = interval_size.bits() as u32;
+
+        // div rounds towards 0, i.e. div_floor in this case
+        let nr_iterations = bit_size / 64;
+
+        // Set upper_modulo to 2^{bit_size mod 64} - defines how many bits will be discarded / have been sampled too much
+        let upper_modulo = 2_u64.pow(bit_size % 64);
+
+        let rng = rand::rng();
+
+        Ok(Self {
+            interval_size: interval_size.clone(),
+            two_pow_64,
+            nr_iterations,
+            upper_modulo,
+            rng,
+        })
+    }
+
+    pub fn sample(&mut self) -> Z {
+        let mut sample = self.sample_bits_uniform();
+        while sample >= self.interval_size {
+            sample = self.sample_bits_uniform();
+        }
+
+        sample
+    }
+
+    fn sample_bits_uniform(&mut self) -> Z {
+        let mut value = Z::from(self.rng.next_u64() % self.upper_modulo);
+        for _ in 0..self.nr_iterations {
+            let sample = self.rng.next_u64();
+            let mut res = Z { value: fmpz(0) };
+            unsafe {
+                fmpz_set_ui(&mut res.value, sample);
+                // Sets res = res + value * 2^64
+                fmpz_addmul(&mut res.value, &value.value, &self.two_pow_64.value);
+            };
+            value = res;
+        }
+
+        value
+    }
+}
+
+#[test]
+fn a() {
+    let modulus = (Z::from(u64::MAX) + 1) + 1;
+    let _ = crate::integer_mod_q::MatZq::sample_uniform(100, 100, &modulus);
+}
 
 /// Computes a uniform at random chosen [`Z`] sample in `[0, interval_size)`.
 ///
@@ -134,178 +204,178 @@ fn find_first_unfilled_byte(byte_arr: &[u8]) -> usize {
     }
 }
 
-#[cfg(test)]
-mod test_sample_uniform_rejection {
-    use super::{sample_uniform_rejection, Z};
+// #[cfg(test)]
+// mod test_sample_uniform_rejection {
+//     use super::{sample_uniform_rejection, Z};
 
-    /// Ensures that the doc tests works correctly.
-    #[test]
-    fn doc_test() {
-        let interval_size = Z::from(20);
+//     /// Ensures that the doc tests works correctly.
+//     #[test]
+//     fn doc_test() {
+//         let interval_size = Z::from(20);
 
-        let sample = sample_uniform_rejection(&interval_size).unwrap();
+//         let sample = sample_uniform_rejection(&interval_size).unwrap();
 
-        assert!(Z::ZERO <= sample);
-        assert!(sample < interval_size);
-    }
+//         assert!(Z::ZERO <= sample);
+//         assert!(sample < interval_size);
+//     }
 
-    /// Checks whether sampling works fine for small interval sizes
-    #[test]
-    fn small_interval() {
-        let size_2 = Z::from(2);
-        let size_7 = Z::from(7);
+//     /// Checks whether sampling works fine for small interval sizes
+//     #[test]
+//     fn small_interval() {
+//         let size_2 = Z::from(2);
+//         let size_7 = Z::from(7);
 
-        let sample_0 = sample_uniform_rejection(&size_2).unwrap();
-        let sample_1 = sample_uniform_rejection(&size_2).unwrap();
-        let sample_2 = sample_uniform_rejection(&size_2).unwrap();
-        let sample_3 = sample_uniform_rejection(&size_7).unwrap();
-        let sample_4 = sample_uniform_rejection(&size_7).unwrap();
-        let sample_5 = sample_uniform_rejection(&size_7).unwrap();
+//         let sample_0 = sample_uniform_rejection(&size_2).unwrap();
+//         let sample_1 = sample_uniform_rejection(&size_2).unwrap();
+//         let sample_2 = sample_uniform_rejection(&size_2).unwrap();
+//         let sample_3 = sample_uniform_rejection(&size_7).unwrap();
+//         let sample_4 = sample_uniform_rejection(&size_7).unwrap();
+//         let sample_5 = sample_uniform_rejection(&size_7).unwrap();
 
-        assert!(sample_0 >= Z::ZERO);
-        assert!(sample_0 < size_2);
-        assert!(sample_1 >= Z::ZERO);
-        assert!(sample_1 < size_2);
-        assert!(sample_2 >= Z::ZERO);
-        assert!(sample_2 < size_2);
-        assert!(sample_3 >= Z::ZERO);
-        assert!(sample_3 < size_7);
-        assert!(sample_4 >= Z::ZERO);
-        assert!(sample_4 < size_7);
-        assert!(sample_5 >= Z::ZERO);
-        assert!(sample_5 < size_7);
-    }
+//         assert!(sample_0 >= Z::ZERO);
+//         assert!(sample_0 < size_2);
+//         assert!(sample_1 >= Z::ZERO);
+//         assert!(sample_1 < size_2);
+//         assert!(sample_2 >= Z::ZERO);
+//         assert!(sample_2 < size_2);
+//         assert!(sample_3 >= Z::ZERO);
+//         assert!(sample_3 < size_7);
+//         assert!(sample_4 >= Z::ZERO);
+//         assert!(sample_4 < size_7);
+//         assert!(sample_5 >= Z::ZERO);
+//         assert!(sample_5 < size_7);
+//     }
 
-    /// Checks whether sampling works fine for large interval sizes
-    #[test]
-    fn large_interval() {
-        let size = Z::from(i64::MAX);
+//     /// Checks whether sampling works fine for large interval sizes
+//     #[test]
+//     fn large_interval() {
+//         let size = Z::from(i64::MAX);
 
-        for _i in 0..u8::MAX {
-            let sample = sample_uniform_rejection(&size).unwrap();
+//         for _i in 0..u8::MAX {
+//             let sample = sample_uniform_rejection(&size).unwrap();
 
-            assert!(sample >= Z::ZERO);
-            assert!(sample < size);
-        }
-    }
+//             assert!(sample >= Z::ZERO);
+//             assert!(sample < size);
+//         }
+//     }
 
-    /// Checks whether interval sizes smaller than 2 result in an error
-    #[test]
-    fn invalid_interval() {
-        assert!(sample_uniform_rejection(&Z::ONE).is_err());
-        assert!(sample_uniform_rejection(&Z::ZERO).is_err());
-        assert!(sample_uniform_rejection(&Z::MINUS_ONE).is_err());
-    }
-}
+//     /// Checks whether interval sizes smaller than 2 result in an error
+//     #[test]
+//     fn invalid_interval() {
+//         assert!(sample_uniform_rejection(&Z::ONE).is_err());
+//         assert!(sample_uniform_rejection(&Z::ZERO).is_err());
+//         assert!(sample_uniform_rejection(&Z::MINUS_ONE).is_err());
+//     }
+// }
 
-#[cfg(test)]
-mod test_sample_bits_uniform {
-    use super::sample_bits_uniform;
+// #[cfg(test)]
+// mod test_sample_bits_uniform {
+//     use super::sample_bits_uniform;
 
-    /// Ensures that the doc tests works correctly.
-    #[test]
-    fn doc_test() {
-        let nr_bits = 14;
+//     /// Ensures that the doc tests works correctly.
+//     #[test]
+//     fn doc_test() {
+//         let nr_bits = 14;
 
-        let byte_vector = sample_bits_uniform(nr_bits);
+//         let byte_vector = sample_bits_uniform(nr_bits);
 
-        assert!(byte_vector[1] < 64);
-        assert_eq!(2, byte_vector.len());
-    }
+//         assert!(byte_vector[1] < 64);
+//         assert_eq!(2, byte_vector.len());
+//     }
 
-    /// Checks whether random bit sampling works appropriate for full byte orders
-    #[test]
-    fn full_bytes() {
-        let bits_0 = sample_bits_uniform(8);
-        let bits_1 = sample_bits_uniform(16);
-        let bits_2 = sample_bits_uniform(256);
+//     /// Checks whether random bit sampling works appropriate for full byte orders
+//     #[test]
+//     fn full_bytes() {
+//         let bits_0 = sample_bits_uniform(8);
+//         let bits_1 = sample_bits_uniform(16);
+//         let bits_2 = sample_bits_uniform(256);
 
-        assert_eq!(1, bits_0.len());
-        assert_eq!(2, bits_1.len());
-        assert_eq!(32, bits_2.len());
-    }
+//         assert_eq!(1, bits_0.len());
+//         assert_eq!(2, bits_1.len());
+//         assert_eq!(32, bits_2.len());
+//     }
 
-    /// Checks whether random bit sampling works appropriate for partial bytes
-    /// and that superfluous bits are cutoff appropriately
-    #[test]
-    fn partial_bytes() {
-        let bits_0 = sample_bits_uniform(7);
-        let bits_1 = sample_bits_uniform(14);
-        let bits_2 = sample_bits_uniform(250);
+//     /// Checks whether random bit sampling works appropriate for partial bytes
+//     /// and that superfluous bits are cutoff appropriately
+//     #[test]
+//     fn partial_bytes() {
+//         let bits_0 = sample_bits_uniform(7);
+//         let bits_1 = sample_bits_uniform(14);
+//         let bits_2 = sample_bits_uniform(250);
 
-        assert_eq!(1, bits_0.len());
-        assert!(128 > bits_0[0]);
-        assert_eq!(2, bits_1.len());
-        assert!(64 > bits_1[1]);
-        assert_eq!(32, bits_2.len());
-        assert!(4 > bits_2[31]);
-    }
+//         assert_eq!(1, bits_0.len());
+//         assert!(128 > bits_0[0]);
+//         assert_eq!(2, bits_1.len());
+//         assert!(64 > bits_1[1]);
+//         assert_eq!(32, bits_2.len());
+//         assert!(4 > bits_2[31]);
+//     }
 
-    /// Check whether all necessary bits are chosen uniform at random.
-    /// This test could possibly fail with probability 2^-64
-    #[test]
-    fn random_bits() {
-        let mut samples: Vec<u8> = vec![];
-        for _i in 0..64 {
-            samples.push(sample_bits_uniform(7)[0]);
-        }
+//     /// Check whether all necessary bits are chosen uniform at random.
+//     /// This test could possibly fail with probability 2^-64
+//     #[test]
+//     fn random_bits() {
+//         let mut samples: Vec<u8> = vec![];
+//         for _i in 0..64 {
+//             samples.push(sample_bits_uniform(7)[0]);
+//         }
 
-        for position in 0..7 {
-            let mut found_1 = false;
-            // check for all 64 samples whether the `position`-th bit is `1`
-            for sample in &samples {
-                if (sample >> position & 1) % 2 == 1 {
-                    found_1 = true;
-                    break;
-                }
-            }
+//         for position in 0..7 {
+//             let mut found_1 = false;
+//             // check for all 64 samples whether the `position`-th bit is `1`
+//             for sample in &samples {
+//                 if (sample >> position & 1) % 2 == 1 {
+//                     found_1 = true;
+//                     break;
+//                 }
+//             }
 
-            if !found_1 {
-                panic!(
-                    "None of the inspected 64 random bits at position {position} was 1. 
-                    This seems suspicious."
-                );
-            }
-        }
-    }
-}
+//             if !found_1 {
+//                 panic!(
+//                     "None of the inspected 64 random bits at position {position} was 1.
+//                     This seems suspicious."
+//                 );
+//             }
+//         }
+//     }
+// }
 
-#[cfg(test)]
-mod test_find_first_unfilled_byte {
-    use super::{find_first_unfilled_byte, sample_bits_uniform};
+// #[cfg(test)]
+// mod test_find_first_unfilled_byte {
+//     use super::{find_first_unfilled_byte, sample_bits_uniform};
 
-    /// Ensures that the doc test works properly and that
-    /// the boundaries of the slice length are respected
-    #[test]
-    fn doc_test() {
-        let nr_bits = 256;
-        let byte_vector = sample_bits_uniform(nr_bits);
+//     /// Ensures that the doc test works properly and that
+//     /// the boundaries of the slice length are respected
+//     #[test]
+//     fn doc_test() {
+//         let nr_bits = 256;
+//         let byte_vector = sample_bits_uniform(nr_bits);
 
-        let first_zero_byte = find_first_unfilled_byte(&byte_vector);
+//         let first_zero_byte = find_first_unfilled_byte(&byte_vector);
 
-        assert!(first_zero_byte <= 256);
-    }
+//         assert!(first_zero_byte <= 256);
+//     }
 
-    /// Ensures correct computation of the first
-    /// detectable zero bytes via binary search for static examples
-    #[test]
-    fn static_cases() {
-        let mut vec_0 = vec![0x1; 5];
-        let mut vec_1 = vec![0x0; 4];
-        let arr_0: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 0];
-        let arr_1: [u8; 7] = [1, 2, 0, 0, 0, 0, 0];
+//     /// Ensures correct computation of the first
+//     /// detectable zero bytes via binary search for static examples
+//     #[test]
+//     fn static_cases() {
+//         let mut vec_0 = vec![0x1; 5];
+//         let mut vec_1 = vec![0x0; 4];
+//         let arr_0: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 0];
+//         let arr_1: [u8; 7] = [1, 2, 0, 0, 0, 0, 0];
 
-        let res_0 = find_first_unfilled_byte(&vec_0);
-        let res_1 = find_first_unfilled_byte(&vec_1);
-        vec_0.append(&mut vec_1);
-        let res_2 = find_first_unfilled_byte(&vec_0);
-        let res_3 = find_first_unfilled_byte(&arr_0);
-        let res_4 = find_first_unfilled_byte(&arr_1);
+//         let res_0 = find_first_unfilled_byte(&vec_0);
+//         let res_1 = find_first_unfilled_byte(&vec_1);
+//         vec_0.append(&mut vec_1);
+//         let res_2 = find_first_unfilled_byte(&vec_0);
+//         let res_3 = find_first_unfilled_byte(&arr_0);
+//         let res_4 = find_first_unfilled_byte(&arr_1);
 
-        assert_eq!(5, res_0);
-        assert_eq!(0, res_1);
-        assert_eq!(5, res_2);
-        assert_eq!(7, res_3);
-        assert_eq!(2, res_4);
-    }
-}
+//         assert_eq!(5, res_0);
+//         assert_eq!(0, res_1);
+//         assert_eq!(5, res_2);
+//         assert_eq!(7, res_3);
+//         assert_eq!(2, res_4);
+//     }
+// }


### PR DESCRIPTION
**Description**

This PR implements...
- [x] an optimized version of uniform sampling
- [x] benchmarks, tests, doc-comments, etc. for it.

It speeds uniform sampling up by roughly 65 to 80%. The problem with the old implementation was a slow conversion to Z, which is now much more efficient using u32 to u64 to Z conversion. This improvement outweights sampling more "unnecessary" bits. Furthermore, our benchmarks show that sampling u64's directly will decrease performance by roughly 20% (probably due to the  slow Z::mul in comparison to u64::mul.
Furthermore, uniform sampling is used in SampleZ, which speeds up its benchmarks by 20-50%.

Now, 75% of the time to sample a MatZq is determined by setting the entries in the matrix using MatZq::set_entry. Reducing the runtime of this by 2/3 can be done by using fmpz_mod_mat_set_entry after a quick test. This should be considered next

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide