### PR TITLE
Add `set_entry_unchecked`

### DIFF
--- a/src/integer/mat_poly_over_z/coefficient_embedding.rs
+++ b/src/integer/mat_poly_over_z/coefficient_embedding.rs
@@ -166,7 +166,7 @@ impl IntoCoefficientEmbedding<MatZ> for &MatPolyOverZ {
         for (i, entry) in poly.iter().enumerate() {
             for j in 0..size {
                 match entry.get_coeff(j) {
-                    Ok(value) => out.set_entry(j, i, value).unwrap(),
+                    Ok(value) => out.set_entry_unchecked(j, i as i64, value),
                     Err(_) => break,
                 }
             }
@@ -207,7 +207,7 @@ impl FromCoefficientEmbedding<&MatZ> for MatPolyOverZ {
         for i in 0..embedding.get_num_columns() {
             let col_vec = embedding.get_column(i).unwrap();
             let entry = PolyOverZ::from_coefficient_embedding(&col_vec);
-            out.set_entry(0, i, entry).unwrap();
+            out.set_entry_unchecked(0, i, entry);
         }
         out
     }

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -113,12 +113,11 @@ impl From<&MatZ> for MatPolyOverZ {
 
         for row in 0..num_rows {
             for column in 0..num_columns {
-                out.set_entry(
+                out.set_entry_unchecked(
                     row,
                     column,
                     PolyOverZ::from(matrix.get_entry(row, column).unwrap()),
-                )
-                .unwrap();
+                );
             }
         }
 

--- a/src/integer/mat_poly_over_z/sample/binomial.rs
+++ b/src/integer/mat_poly_over_z/sample/binomial.rs
@@ -114,7 +114,7 @@ impl MatPolyOverZ {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = PolyOverZ::sample_binomial_with_offset(max_degree, &offset, &n, &p)?;
-                matrix.set_entry(row, col, sample).unwrap();
+                matrix.set_entry_unchecked(row, col, sample);
             }
         }
 

--- a/src/integer/mat_poly_over_z/sample/uniform.rs
+++ b/src/integer/mat_poly_over_z/sample/uniform.rs
@@ -72,7 +72,7 @@ impl MatPolyOverZ {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = PolyOverZ::sample_uniform(max_degree, &lower_bound, &upper_bound)?;
-                matrix.set_entry(row, col, sample).unwrap();
+                matrix.set_entry_unchecked(row, col, sample);
             }
         }
 

--- a/src/integer/mat_poly_over_z/set.rs
+++ b/src/integer/mat_poly_over_z/set.rs
@@ -69,12 +69,38 @@ impl SetEntry<&PolyOverZ> for MatPolyOverZ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpz_set` can successfully clone the
         // value inside the matrix. Therefore no memory leaks can appear.
-        unsafe {
-            let entry = fmpz_poly_mat_entry(&self.matrix, row_i64, column_i64);
-            fmpz_poly_set(entry, &value.poly)
-        };
+        self.set_entry_unchecked(row_i64, column_i64, value);
 
         Ok(())
+    }
+
+    /// Sets the value of a specific matrix entry according to a given `value` of type [`PolyOverZ`]
+    /// without checking whether the coordinate is part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    /// - `value`: specifies the value to which the entry is set
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
+    /// use qfall_math::traits::SetEntry;
+    /// use std::str::FromStr;
+    ///
+    /// let mut matrix = MatPolyOverZ::new(2, 2);
+    /// let value = PolyOverZ::from_str("2  1 1").unwrap();
+    ///
+    /// matrix.set_entry_unchecked(0, 1, &value);
+    /// matrix.set_entry_unchecked(1, 0, &PolyOverZ::from(2));
+    ///
+    /// assert_eq!("[[0, 2  1 1],[1  2, 0]]", matrix.to_string());
+    /// ```
+    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &PolyOverZ) {
+        unsafe {
+            let entry = fmpz_poly_mat_entry(&self.matrix, row, column);
+            fmpz_poly_set(entry, &value.poly)
+        };
     }
 }
 

--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -127,7 +127,7 @@ impl MatZ {
                     &byte_vector[offset_row + nr_bytes_per_entry * col
                         ..offset_row + nr_bytes_per_entry * (col + 1)],
                 );
-                mat.set_entry(row, col, entry_value).unwrap();
+                mat.set_entry_unchecked(row as i64, col as i64, entry_value);
             }
         }
 

--- a/src/integer/mat_z/sample/binomial.rs
+++ b/src/integer/mat_z/sample/binomial.rs
@@ -109,7 +109,7 @@ impl MatZ {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = sample_binomial(&n, &p)?;
-                matrix.set_entry(row, col, &offset + sample).unwrap();
+                matrix.set_entry_unchecked(row, col, &offset + sample);
             }
         }
 

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -66,7 +66,7 @@ impl MatZ {
         for row in 0..out.get_num_rows() {
             for col in 0..out.get_num_columns() {
                 let sample = dgis.sample_z();
-                out.set_entry(row, col, sample)?;
+                out.set_entry_unchecked(row, col, sample);
             }
         }
 

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -66,7 +66,7 @@ impl MatZ {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = uis.sample();
-                matrix.set_entry(row, col, &lower_bound + sample).unwrap();
+                matrix.set_entry_unchecked(row, col, &lower_bound + sample);
             }
         }
 

--- a/src/integer/mat_z/set.rs
+++ b/src/integer/mat_z/set.rs
@@ -66,19 +66,44 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZ {
         column: impl TryInto<i64> + Display,
         value: Integer,
     ) -> Result<(), MathError> {
-        let value = value.into();
         let (row_i64, column_i64) = evaluate_indices_for_matrix(self, row, column)?;
 
         // since `self` is a correct matrix and both row and column
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpz_set` can successfully clone the
         // value inside the matrix. Therefore no memory leaks can appear.
-        unsafe {
-            let entry = fmpz_mat_entry(&self.matrix, row_i64, column_i64);
-            fmpz_set(entry, &value.value)
-        };
+        self.set_entry_unchecked(row_i64, column_i64, value);
 
         Ok(())
+    }
+
+    /// Sets the value of a specific matrix entry according to the provided value
+    /// without checking whether the coordinate is part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    /// - `value`: specifies the value to which the entry is set
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::{MatZ, Z};
+    /// use qfall_math::traits::SetEntry;
+    ///
+    /// let mut matrix = MatZ::new(3, 3);
+    ///
+    /// matrix.set_entry_unchecked(0, 1, 5);
+    /// matrix.set_entry_unchecked(2, 2, 9);
+    ///
+    /// assert_eq!("[[0, 5, 0],[0, 0, 0],[0, 0, 9]]", matrix.to_string());
+    /// ```
+    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: Integer) {
+        let value: Z = value.into();
+
+        unsafe {
+            let entry = fmpz_mat_entry(&self.matrix, row, column);
+            fmpz_set(entry, &value.value)
+        };
     }
 }
 

--- a/src/integer/poly_over_z/coefficient_embedding.rs
+++ b/src/integer/poly_over_z/coefficient_embedding.rs
@@ -58,7 +58,7 @@ impl IntoCoefficientEmbedding<MatZ> for &PolyOverZ {
         let mut out = MatZ::new(size, 1);
         for j in 0..size {
             match self.get_coeff(j) {
-                Ok(value) => out.set_entry(j, 0, value).unwrap(),
+                Ok(value) => out.set_entry_unchecked(j, 0, value),
                 Err(_) => break,
             }
         }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -63,6 +63,40 @@ impl SetEntry<&PolyOverZ> for MatPolynomialRingZq {
 
         self.set_entry(row, column, value)
     }
+
+    /// Sets the value of a specific matrix entry according to a given `value` of type [`PolyOverZ`]
+    /// without checking whether the coordinate is part of the matrix, if the moduli match
+    /// or if the entry is reduced.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    /// - `value`: specifies the value to which the entry is set
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
+    /// use crate::qfall_math::traits::*;
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+    /// let poly_mat = MatPolyOverZ::from_str("[[0, 1  42],[0, 2  1 2]]").unwrap();
+    /// let mut poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
+    /// let value = PolyOverZ::default();
+    ///
+    /// poly_ring_mat.set_entry_unchecked(0, 1, &value);
+    /// poly_ring_mat.set_entry_unchecked(1, 1, &value);
+    ///
+    /// let mat_cmp = MatPolynomialRingZq::from((&MatPolyOverZ::new(2, 2), &modulus));
+    /// assert_eq!(poly_ring_mat, mat_cmp);
+    /// ```
+    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &PolyOverZ) {
+        unsafe {
+            let entry = fmpz_poly_mat_entry(&self.matrix.matrix, row, column);
+            fmpz_poly_set(entry, &value.poly)
+        };
+    }
 }
 
 impl SetEntry<&PolynomialRingZq> for MatPolynomialRingZq {
@@ -120,12 +154,42 @@ impl SetEntry<&PolynomialRingZq> for MatPolynomialRingZq {
 
         let (row_i64, column_i64) = evaluate_indices_for_matrix(self, row, column)?;
 
-        unsafe {
-            let entry = fmpz_poly_mat_entry(&self.matrix.matrix, row_i64, column_i64);
-            fmpz_poly_set(entry, &value.poly.poly)
-        };
+        self.set_entry_unchecked(row_i64, column_i64, value);
 
         Ok(())
+    }
+
+    /// Sets the value of a specific matrix entry according to a given `value` of type [`PolynomialRingZq`]
+    /// without checking whether the coordinate is part of the matrix or if the moduli match.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    /// - `value`: specifies the value to which the entry is set
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq, PolynomialRingZq};
+    /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
+    /// use crate::qfall_math::traits::*;
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+    /// let poly_mat = MatPolyOverZ::from_str("[[0, 1  42],[0, 2  1 2]]").unwrap();
+    /// let mut poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
+    /// let value = PolynomialRingZq::from((&PolyOverZ::default(), &modulus));
+    ///
+    /// poly_ring_mat.set_entry_unchecked(0, 1, &value);
+    /// poly_ring_mat.set_entry_unchecked(1, 1, &value);
+    ///
+    /// let mat_cmp = MatPolynomialRingZq::from((&MatPolyOverZ::new(2, 2), &modulus));
+    /// assert_eq!(poly_ring_mat, mat_cmp);
+    /// ```
+    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &PolynomialRingZq) {
+        unsafe {
+            let entry = fmpz_poly_mat_entry(&self.matrix.matrix, row, column);
+            fmpz_poly_set(entry, &value.poly.poly)
+        };
     }
 }
 

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -230,7 +230,7 @@ impl MatZq {
                         ..offset_row + nr_bytes_per_entry * (col + 1)],
                 );
                 if modulus_as_z > entry_value {
-                    mat.set_entry(row, col, entry_value).unwrap();
+                    mat.set_entry_unchecked(row as i64, col as i64, entry_value);
                 } else {
                     return Err(MathError::ConversionError(
                         "The provided modulus is smaller than the UTF8-Encoding of your message."

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -92,9 +92,9 @@ impl MatZq {
 
                 // Not using Zq::distance for performance reasons.
                 if entry > modulus_half {
-                    out.set_entry(row, column, entry - &modulus).unwrap();
+                    out.set_entry_unchecked(row, column, entry - &modulus);
                 } else {
-                    out.set_entry(row, column, entry).unwrap();
+                    out.set_entry_unchecked(row, column, entry);
                 }
             }
         }

--- a/src/integer_mod_q/mat_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_zq/sample/binomial.rs
@@ -116,7 +116,7 @@ impl MatZq {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = sample_binomial(&n, &p)?;
-                matrix.set_entry(row, col, &offset + sample).unwrap();
+                matrix.set_entry_unchecked(row, col, &offset + sample);
             }
         }
 

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -69,7 +69,7 @@ impl MatZq {
         for row in 0..out.get_num_rows() {
             for col in 0..out.get_num_columns() {
                 let sample = dgis.sample_z();
-                out.set_entry(row, col, sample).unwrap();
+                out.set_entry_unchecked(row, col, sample);
             }
         }
 

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -55,7 +55,7 @@ impl MatZq {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = uis.sample();
-                matrix.set_entry(row, col, sample).unwrap();
+                matrix.set_entry_unchecked(row, col, sample);
             }
         }
 

--- a/src/integer_mod_q/mat_zq/set.rs
+++ b/src/integer_mod_q/mat_zq/set.rs
@@ -74,6 +74,36 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZq {
 
         self.set_entry(row, column, value)
     }
+
+    /// Sets the value of a specific matrix entry according to a given `value`
+    /// that implements [`Into<Z>`] without checking whether the coordinate is part of the matrix,
+    /// if the moduli match or the entry is reduced.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    /// - `value`: specifies the value to which the entry is set
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::MatZq;
+    /// use qfall_math::traits::*;
+    ///
+    /// let mut matrix = MatZq::new(3, 3, 10);
+    ///
+    /// matrix.set_entry_unchecked(0, 1, 5);
+    /// matrix.set_entry_unchecked(2, 2, 19);
+    ///
+    /// assert_eq!("[[0, 5, 0],[0, 0, 0],[0, 0, 19]] mod 10", matrix.to_string());
+    /// ```
+    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: Integer) {
+        let value: Z = value.into();
+
+        unsafe {
+            // get entry and replace the pointed at value with the specified value
+            fmpz_mod_mat_set_entry(&mut self.matrix, row, column, &value.value)
+        };
+    }
 }
 
 impl SetEntry<&Zq> for MatZq {
@@ -127,12 +157,38 @@ impl SetEntry<&Zq> for MatZq {
             )));
         }
 
-        unsafe {
-            // get entry and replace the pointed at value with the specified value
-            fmpz_mod_mat_set_entry(&mut self.matrix, row_i64, column_i64, &value.value.value)
-        }
+        self.set_entry_unchecked(row_i64, column_i64, value);
 
         Ok(())
+    }
+
+    /// Sets the value of a specific matrix entry according to a given `value` of type [`Zq`]
+    /// without checking whether the coordinate is part of the matrix,
+    /// if the moduli match or the entry is reduced.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    /// - `value`: specifies the value to which the entry is set
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatZq, Zq};
+    /// use qfall_math::traits::*;
+    ///
+    /// let mut matrix = MatZq::new(3, 3, 10);
+    /// let value = Zq::from((5, 10));
+    ///
+    /// matrix.set_entry_unchecked(0, 1, &value);
+    /// matrix.set_entry_unchecked(2, 2, Zq::from((19, 10)));
+    ///
+    /// assert_eq!("[[0, 5, 0],[0, 0, 0],[0, 0, 9]] mod 10", matrix.to_string());
+    /// ```
+    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &Zq) {
+        unsafe {
+            // get entry and replace the pointed at value with the specified value
+            fmpz_mod_mat_set_entry(&mut self.matrix, row, column, &value.value.value)
+        };
     }
 }
 

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -101,7 +101,7 @@ impl MatZq {
         let mut out = MatZq::new(self.get_num_columns(), 1, matrix.get_mod());
         for (i, j) in indices.iter() {
             let entry: Z = matrix.get_entry(*i, -1).unwrap();
-            out.set_entry(*j, 0, entry).unwrap();
+            out.set_entry_unchecked(*j, 0, entry);
         }
 
         Some(out)
@@ -362,7 +362,7 @@ impl MatZq {
         let mut out = MatZq::new(self.get_num_columns(), 1, self.get_mod());
         for (current_row_x, (_row_nr, column_nr)) in indices.into_iter().enumerate() {
             let entry: Z = x.get_entry(current_row_x, 0).unwrap();
-            out.set_entry(column_nr, 0, entry).unwrap();
+            out.set_entry_unchecked(column_nr, 0, entry);
         }
 
         Some(out)

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/coefficient_embedding.rs
@@ -57,7 +57,7 @@ impl IntoCoefficientEmbedding<MatZq> for &ModulusPolynomialRingZq {
         for j in 0..size {
             let coeff: Result<Z, _> = self.get_coeff(j);
             match coeff {
-                Ok(value) => out.set_entry(j, 0, value).unwrap(),
+                Ok(value) => out.set_entry_unchecked(j, 0, value),
                 Err(_) => break,
             }
         }

--- a/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
@@ -60,7 +60,7 @@ impl IntoCoefficientEmbedding<MatZq> for &PolyOverZq {
         for j in 0..size {
             let coeff: Result<Z, _> = self.get_coeff(j);
             match coeff {
-                Ok(value) => out.set_entry(j, 0, value).unwrap(),
+                Ok(value) => out.set_entry_unchecked(j, 0, value),
                 Err(_) => break,
             }
         }

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -168,14 +168,24 @@ macro_rules! implement_for_owned {
         impl SetEntry<$source_type> for $type {
             paste::paste! {
                 #[doc = "Documentation can be found at [`" $type "::set_entry`] for &[`" $source_type "`]."]
-            fn set_entry(
-                &mut self,
-                row: impl TryInto<i64> + Display,
-                column: impl TryInto<i64> + Display,
-                value: $source_type,
-            ) -> Result<(), MathError> {
-                self.set_entry(row, column, &value)
-            }
+                fn set_entry(
+                    &mut self,
+                    row: impl TryInto<i64> + Display,
+                    column: impl TryInto<i64> + Display,
+                    value: $source_type,
+                ) -> Result<(), MathError> {
+                    self.set_entry(row, column, &value)
+                }
+
+                #[doc = "Documentation can be found at [`" $type "::set_entry`] for &[`" $source_type "`]."]
+                fn set_entry_unchecked(
+                    &mut self,
+                    row: i64,
+                    column: i64,
+                    value: $source_type,
+                ) {
+                    self.set_entry_unchecked(row, column, &value);
+                }
             }
         }
     };

--- a/src/rational/mat_q/cholesky_decomp.rs
+++ b/src/rational/mat_q/cholesky_decomp.rs
@@ -149,7 +149,7 @@ impl MatQ {
         let mut res = MatQ::new(mat_dimension, mat_dimension);
         for (i, row) in out.iter().enumerate().take(mat_dimension) {
             for (j, entry) in row.iter().enumerate().take(mat_dimension) {
-                res.set_entry(i, j, *entry).unwrap();
+                res.set_entry_unchecked(i as i64, j as i64, *entry);
             }
         }
 

--- a/src/rational/mat_q/rounding.rs
+++ b/src/rational/mat_q/rounding.rs
@@ -37,7 +37,7 @@ impl MatQ {
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
                 let entry = self.get_entry(i, j).unwrap().floor();
-                out.set_entry(i, j, entry).unwrap();
+                out.set_entry_unchecked(i, j, entry);
             }
         }
         out
@@ -63,7 +63,7 @@ impl MatQ {
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
                 let entry = self.get_entry(i, j).unwrap().ceil();
-                out.set_entry(i, j, entry).unwrap();
+                out.set_entry_unchecked(i, j, entry);
             }
         }
         out
@@ -89,7 +89,7 @@ impl MatQ {
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
                 let entry = self.get_entry(i, j).unwrap().round();
-                out.set_entry(i, j, entry).unwrap();
+                out.set_entry_unchecked(i, j, entry);
             }
         }
         out
@@ -161,7 +161,7 @@ impl MatQ {
             for j in 0..self.get_num_columns() {
                 let entry = self.get_entry(i, j).unwrap();
                 let simplified_entry = entry.simplify(&precision);
-                out.set_entry(i, j, simplified_entry).unwrap();
+                out.set_entry_unchecked(i, j, simplified_entry);
             }
         }
 
@@ -204,7 +204,7 @@ impl MatQ {
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
                 let entry = self.get_entry(i, j).unwrap().randomized_rounding(&r, &n)?;
-                out.set_entry(i, j, entry).unwrap();
+                out.set_entry_unchecked(i, j, entry);
             }
         }
         Ok(out)

--- a/src/rational/mat_q/sample/gauss.rs
+++ b/src/rational/mat_q/sample/gauss.rs
@@ -46,7 +46,7 @@ impl MatQ {
             for j in 0..out.get_num_columns() {
                 let center_entry_ij = center.get_entry(i, j)?;
                 let sample = Q::sample_gauss(center_entry_ij, sigma)?;
-                out.set_entry(i, j, sample)?
+                out.set_entry_unchecked(i, j, sample);
             }
         }
 
@@ -94,7 +94,7 @@ impl MatQ {
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
                 let sample = Q::sample_gauss(&center, sigma)?;
-                out.set_entry(i, j, sample)?
+                out.set_entry_unchecked(i, j, sample);
             }
         }
 

--- a/src/rational/mat_q/set.rs
+++ b/src/rational/mat_q/set.rs
@@ -76,12 +76,41 @@ impl<Rational: Into<Q>> SetEntry<Rational> for MatQ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpq_set` can successfully clone the
         // value inside the matrix. Therefore no memory leaks can appear.
-        unsafe {
-            let entry = fmpq_mat_entry(&self.matrix, row_i64, column_i64);
-            fmpq_set(entry, &value.value)
-        };
+        self.set_entry_unchecked(row_i64, column_i64, value);
 
         Ok(())
+    }
+
+    /// Sets the value of a specific matrix entry according to a given `value`
+    /// that implements [`Into<Q>`] without checking whether the coordinate is part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    /// - `value`: specifies the value to which the entry is set
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::MatQ;
+    /// use qfall_math::rational::Q;
+    /// use qfall_math::traits::*;
+    ///
+    /// let mut matrix = MatQ::new(3, 3);
+    /// let value = Q::from((5, 2));
+    ///
+    /// matrix.set_entry_unchecked(0, 1, &value);
+    /// matrix.set_entry_unchecked(2, 2, 5);
+    /// matrix.set_entry_unchecked(0, 2, (2, 3));
+    ///
+    /// assert_eq!("[[0, 5/2, 2/3],[0, 0, 0],[0, 0, 5]]", matrix.to_string());
+    /// ```
+    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: Rational) {
+        let value: Q = value.into();
+
+        unsafe {
+            let entry = fmpq_mat_entry(&self.matrix, row, column);
+            fmpq_set(entry, &value.value)
+        };
     }
 }
 

--- a/src/rational/poly_over_q/coefficient_embedding.rs
+++ b/src/rational/poly_over_q/coefficient_embedding.rs
@@ -58,7 +58,7 @@ impl IntoCoefficientEmbedding<MatQ> for &PolyOverQ {
         let mut out = MatQ::new(size, 1);
         for j in 0..size {
             match self.get_coeff(j) {
-                Ok(value) => out.set_entry(j, 0, value).unwrap(),
+                Ok(value) => out.set_entry_unchecked(j, 0, value),
                 Err(_) => break,
             }
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -95,6 +95,16 @@ pub trait SetEntry<T> {
         column: impl TryInto<i64> + Display,
         value: T,
     ) -> Result<(), MathError>;
+
+    /// Sets the value of a specific matrix entry according to a given value
+    /// without performing any checks, e.g. checking whether the entry is
+    /// part of the matrix or if the moduli of the matrices match.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located.
+    /// - `column`: specifies the column in which the entry is located.
+    /// - `value`: specifies the value to which the entry is set.
+    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: T);
 }
 
 /// Is implemented by matrices to compute the tensor product.


### PR DESCRIPTION
**Description**

This PR implements...
- [x] set_entry_unchecked for all matrix types
- [x] an additional entry in the `SetEntry` trait
- [x] an update version of the `SetEntry` macro
- [x] update all calls to set_entry (that are not parts of tests) which are unwrapped directly or could've been unwrapped directly

This PR enables quicker filling of matrices, which is important for e.g. MatZ::sample_uniform, whose benchmarks execute faster by a factor of 40-60%. The same works for SampleZ benchmarks of MatZq::sample_discrete_gauss, which is quicker by ~10%.

**Testing**
No additional tests required as the `set_entry` functions now call the `set_entry_unchecked` function. Hence, any test for `set_entry` is automatically a test of `set_entry_unchecked`.

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide