### PR TITLE
Implement `AddAssign` for simple types

### DIFF
--- a/benches/integer.rs
+++ b/benches/integer.rs
@@ -86,7 +86,9 @@ pub fn bench_z_add_small(c: &mut Criterion) {
     let mut value_0 = Z::from(15);
     let value_1 = Z::from(5);
 
-    c.bench_function("Z add small", |b| b.iter(|| add(&mut value_0, &value_1)));
+    c.bench_function("Z add small", |b| {
+        b.iter(|| add_z_z(&mut value_0, &value_1))
+    });
 }
 
 /// benchmark [Z::add] for large numbers
@@ -94,10 +96,25 @@ pub fn bench_z_add_large(c: &mut Criterion) {
     let mut value_0 = Z::from(i64::MAX);
     let value_1 = Z::from(u64::MAX);
 
-    c.bench_function("Z add large", |b| b.iter(|| add(&mut value_0, &value_1)));
+    c.bench_function("Z add large", |b| {
+        b.iter(|| add_z_z(&mut value_0, &value_1))
+    });
 }
 
-fn add(value_0: &mut Z, value_1: &Z) {
+/// benchmark [Z::add] for large numbers
+pub fn bench_z_add_u64(c: &mut Criterion) {
+    let mut value_0 = Z::from(i64::MAX);
+
+    c.bench_function("Z add u64", |b| {
+        b.iter(|| add_z_u64(&mut value_0, u64::MAX))
+    });
+}
+
+fn add_z_z(value_0: &mut Z, value_1: &Z) {
+    Z::add_assign(value_0, value_1);
+}
+
+fn add_z_u64(value_0: &mut Z, value_1: u64) {
     Z::add_assign(value_0, value_1);
 }
 
@@ -106,5 +123,6 @@ criterion_group!(
     bench_mat_z_4_4,
     bench_mat_z_100_100,
     bench_z_add_small,
-    bench_z_add_large
+    bench_z_add_large,
+    bench_z_add_u64,
 );

--- a/benches/integer.rs
+++ b/benches/integer.rs
@@ -14,7 +14,7 @@ use qfall_math::{
     integer::*,
     traits::{GetEntry, SetEntry},
 };
-use std::str::FromStr;
+use std::{ops::AddAssign, str::FromStr};
 
 /// Create matrices of size 4x4 and vectors of size 4.
 /// 1. initialize them.
@@ -81,4 +81,30 @@ pub fn bench_mat_z_100_100(c: &mut Criterion) {
     c.bench_function("MatZ 100x100", |b| b.iter(mat_z_100_100));
 }
 
-criterion_group!(benches, bench_mat_z_4_4, bench_mat_z_100_100);
+/// benchmark [Z::add] for small numbers
+pub fn bench_z_add_small(c: &mut Criterion) {
+    let mut value_0 = Z::from(15);
+    let value_1 = Z::from(5);
+
+    c.bench_function("Z add small", |b| b.iter(|| add(&mut value_0, &value_1)));
+}
+
+/// benchmark [Z::add] for large numbers
+pub fn bench_z_add_large(c: &mut Criterion) {
+    let mut value_0 = Z::from(i64::MAX);
+    let value_1 = Z::from(u64::MAX);
+
+    c.bench_function("Z add large", |b| b.iter(|| add(&mut value_0, &value_1)));
+}
+
+fn add(value_0: &mut Z, value_1: &Z) {
+    Z::add_assign(value_0, value_1);
+}
+
+criterion_group!(
+    benches,
+    bench_mat_z_4_4,
+    bench_mat_z_100_100,
+    bench_z_add_small,
+    bench_z_add_large
+);

--- a/src/integer/mat_poly_over_z/vector/norm.rs
+++ b/src/integer/mat_poly_over_z/vector/norm.rs
@@ -52,7 +52,7 @@ impl MatPolyOverZ {
 
         for row in 0..self.get_num_rows() {
             for column in 0..self.get_num_columns() {
-                result = result + self.get_entry(row, column).unwrap().norm_eucl_sqrd();
+                result += self.get_entry(row, column).unwrap().norm_eucl_sqrd();
             }
         }
 

--- a/src/integer/poly_over_z/arithmetic/add.rs
+++ b/src/integer/poly_over_z/arithmetic/add.rs
@@ -22,9 +22,9 @@ impl AddAssign<&PolyOverZ> for PolyOverZ {
     /// the memory of `self`.
     ///
     /// Parameters:
-    /// - `other`: specifies the value to add to `self`
+    /// - `other`: specifies the polynomial to add to `self`
     ///
-    /// Returns the sum of both numbers as a [`Z`].
+    /// Returns the sum of both polynomials as a [`PolyOverZ`].
     ///
     /// # Examples
     /// ```

--- a/src/integer/poly_over_z/arithmetic/add.rs
+++ b/src/integer/poly_over_z/arithmetic/add.rs
@@ -11,10 +11,38 @@
 use super::super::PolyOverZ;
 use crate::integer::Z;
 use crate::macros::arithmetics::{
-    arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+    arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
+    arithmetic_trait_mixed_borrowed_owned,
 };
 use flint_sys::{fmpz::fmpz_add, fmpz_poly::fmpz_poly_add};
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&PolyOverZ> for PolyOverZ {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both numbers as a [`Z`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::PolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let mut a = PolyOverZ::from_str("3  1 2 -3").unwrap();
+    /// let b = PolyOverZ::from_str("5  1 2 -3 0 8").unwrap();
+    ///
+    /// a += &b;
+    /// a += b;
+    /// ```
+    fn add_assign(&mut self, other: &Self) {
+        unsafe { fmpz_poly_add(&mut self.poly, &self.poly, &other.poly) };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, PolyOverZ, PolyOverZ);
 
 impl Add for &PolyOverZ {
     type Output = PolyOverZ;
@@ -92,6 +120,48 @@ impl Add<&Z> for &PolyOverZ {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, PolyOverZ, Z, PolyOverZ);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, PolyOverZ, Z, PolyOverZ);
+
+#[cfg(test)]
+mod test_add_assign {
+    use super::PolyOverZ;
+    use std::str::FromStr;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = PolyOverZ::from_str("3  -1 2 -3").unwrap();
+        let b = PolyOverZ::from_str("5  1 2 5 1 2").unwrap();
+        let cmp = PolyOverZ::from_str("5  0 4 2 1 2").unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a =
+            PolyOverZ::from_str(&format!("3  {} {} {}", u32::MAX, i32::MIN, i32::MAX)).unwrap();
+        let b = PolyOverZ::from_str(&format!("2  {} {}", u32::MAX, i32::MAX)).unwrap();
+        let cmp = PolyOverZ::from_str(&format!("3  {} -1 {}", u64::from(u32::MAX) * 2, i32::MAX))
+            .unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = PolyOverZ::from_str("3  1 2 -3").unwrap();
+        let b = PolyOverZ::from_str("3  -1 -2 3").unwrap();
+
+        a += &b;
+        a += b;
+    }
+}
 
 #[cfg(test)]
 mod test_add {

--- a/src/integer/poly_over_z/norm.rs
+++ b/src/integer/poly_over_z/norm.rs
@@ -37,7 +37,7 @@ impl PolyOverZ {
 
         for i in 0..=self.get_degree() {
             let coeff = self.get_coeff(i).unwrap();
-            res = res + coeff.pow(2).unwrap();
+            res += coeff.pow(2).unwrap();
         }
         res
     }

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -21,14 +21,14 @@ use crate::{
 };
 use flint_sys::{
     fmpq::fmpq_add_fmpz,
-    fmpz::{fmpz, fmpz_add},
+    fmpz::{fmpz, fmpz_add, fmpz_add_si, fmpz_add_ui},
     fmpz_mod::fmpz_mod_add_fmpz,
 };
 use std::ops::{Add, AddAssign};
 
 impl AddAssign<&Z> for Z {
-    /// Implements the [`AddAssign`] trait for [`Z`] in combination with any type
-    /// satisfying [`Into<Z>`].
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
     ///
     /// Parameters:
     /// - `other`: specifies the value to add to `self`
@@ -50,9 +50,22 @@ impl AddAssign<&Z> for Z {
         unsafe { fmpz_add(&mut self.value, &self.value, &other.value) };
     }
 }
+impl AddAssign<i64> for Z {
+    /// Documentation at [`Z::add_assign`].
+    fn add_assign(&mut self, other: i64) {
+        unsafe { fmpz_add_si(&mut self.value, &self.value, other) };
+    }
+}
+impl AddAssign<u64> for Z {
+    /// Documentation at [`Z::add_assign`].
+    fn add_assign(&mut self, other: u64) {
+        unsafe { fmpz_add_ui(&mut self.value, &self.value, other) };
+    }
+}
 
 arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, Z, Z);
-arithmetic_assign_between_types!(AddAssign, add_assign, Z, Z, i64 i32 i16 i8 u64 u32 u16 u8);
+arithmetic_assign_between_types!(AddAssign, add_assign, Z, i64, i32 i16 i8);
+arithmetic_assign_between_types!(AddAssign, add_assign, Z, u64, u32 u16 u8);
 
 impl Add for &Z {
     type Output = Z;
@@ -211,6 +224,63 @@ impl Add<&PolyOverZ> for &Z {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, Z, PolyOverZ, PolyOverZ);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Z, PolyOverZ, PolyOverZ);
+
+#[cfg(test)]
+mod test_add_assign {
+    use crate::integer::Z;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a: Z = Z::MINUS_ONE;
+        let b = Z::MINUS_ONE;
+        let c = Z::ONE;
+
+        a += &b;
+        assert_eq!(-2, a);
+        a += &c;
+        assert_eq!(-1, a);
+        a += &c;
+        assert_eq!(0, a);
+        a += &c;
+        assert_eq!(1, a);
+        a += &c;
+        assert_eq!(2, a);
+        a += 2 * b;
+        assert_eq!(0, a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a: Z = Z::from(i64::MAX);
+        let b = Z::from(i64::MIN);
+        let c = Z::from(u64::MAX);
+
+        a += b;
+        assert_eq!(-1, a);
+        a += c;
+        assert_eq!(u64::MAX - 1, a);
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a: Z = Z::from(42);
+        let b: Z = Z::from(1);
+
+        a += &b;
+        a += b;
+        a += 1_u8;
+        a += 1_u16;
+        a += 1_u32;
+        a += 1_u64;
+        a += 1_i8;
+        a += 1_i16;
+        a += 1_i32;
+        a += 1_i64;
+    }
+}
 
 #[cfg(test)]
 mod test_add_between_types {

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -13,6 +13,7 @@ use crate::{
     integer::PolyOverZ,
     integer_mod_q::Zq,
     macros::arithmetics::{
+        arithmetic_assign_between_types, arithmetic_assign_trait_borrowed_to_owned,
         arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
         arithmetic_trait_mixed_borrowed_owned,
     },
@@ -23,7 +24,35 @@ use flint_sys::{
     fmpz::{fmpz, fmpz_add},
     fmpz_mod::fmpz_mod_add_fmpz,
 };
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&Z> for Z {
+    /// Implements the [`AddAssign`] trait for [`Z`] in combination with any type
+    /// satisfying [`Into<Z>`].
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both numbers as a [`Z`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::Z;
+    ///
+    /// let mut a: Z = Z::from(42);
+    /// let b: Z = Z::from(24);
+    ///
+    /// a += &b;
+    /// a += b;
+    /// a += 5;
+    /// ```
+    fn add_assign(&mut self, other: &Self) {
+        unsafe { fmpz_add(&mut self.value, &self.value, &other.value) };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, Z, Z);
+arithmetic_assign_between_types!(AddAssign, add_assign, Z, Z, i64 i32 i16 i8 u64 u32 u16 u8);
 
 impl Add for &Z {
     type Output = Z;

--- a/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
@@ -29,7 +29,7 @@ impl AddAssign<&PolyOverZq> for PolyOverZq {
     /// Parameters:
     /// - `other`: specifies the polynomial to add to `self`
     ///
-    /// Returns the sum of both polynomials as a [`PolyOverZq`].
+    /// Returns the sum of both polynomials modulo `q` as a [`PolyOverZq`].
     ///
     /// # Examples
     /// ```
@@ -42,7 +42,18 @@ impl AddAssign<&PolyOverZq> for PolyOverZq {
     /// a += &b;
     /// a += b;
     /// ```
+    ///
+    /// # Panics ...
+    /// - if the moduli of both [`PolyOverZq`] mismatch.
     fn add_assign(&mut self, other: &Self) {
+        if self.modulus != other.modulus {
+            panic!(
+                "Tried to add polynomial with modulus '{}' and polynomial with modulus '{}'.
+            If the modulus should be ignored please convert into a PolyOverZ beforehand.",
+                self.modulus, other.modulus
+            );
+        }
+
         unsafe {
             fmpz_mod_poly_add(
                 &mut self.poly,
@@ -183,6 +194,16 @@ mod test_add_assign {
         let b = PolyOverZq::from_str("3  -1 -2 3 mod 5").unwrap();
 
         a += &b;
+        a += b;
+    }
+
+    /// Ensures that mismatching moduli result in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_moduli() {
+        let mut a: PolyOverZq = PolyOverZq::from_str("3  -5 4 1 mod 7").unwrap();
+        let b: PolyOverZq = PolyOverZq::from_str("3  -5 4 1 mod 8").unwrap();
+
         a += b;
     }
 }

--- a/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
@@ -12,11 +12,49 @@ use super::super::PolyOverZq;
 use crate::{
     error::MathError,
     macros::arithmetics::{
-        arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+        arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
     },
 };
 use flint_sys::fmpz_mod_poly::fmpz_mod_poly_add;
-use std::{ops::Add, str::FromStr};
+use std::{
+    ops::{Add, AddAssign},
+    str::FromStr,
+};
+
+impl AddAssign<&PolyOverZq> for PolyOverZq {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the polynomial to add to `self`
+    ///
+    /// Returns the sum of both polynomials as a [`PolyOverZq`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::PolyOverZq;
+    /// use std::str::FromStr;
+    ///
+    /// let mut a = PolyOverZq::from_str("3  1 2 3 mod 7").unwrap();
+    /// let b = PolyOverZq::from_str("5  1 2 -3 0 4 mod 7").unwrap();
+    ///
+    /// a += &b;
+    /// a += b;
+    /// ```
+    fn add_assign(&mut self, other: &Self) {
+        unsafe {
+            fmpz_mod_poly_add(
+                &mut self.poly,
+                &self.poly,
+                &other.poly,
+                self.modulus.get_fmpz_mod_ctx_struct(),
+            )
+        };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, PolyOverZq, PolyOverZq);
 
 impl Add for &PolyOverZq {
     type Output = PolyOverZq;
@@ -94,6 +132,60 @@ impl PolyOverZq {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, PolyOverZq, PolyOverZq, PolyOverZq);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, PolyOverZq, PolyOverZq, PolyOverZq);
+
+#[cfg(test)]
+mod test_add_assign {
+    use super::PolyOverZq;
+    use std::str::FromStr;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = PolyOverZq::from_str("3  6 2 -3 mod 7").unwrap();
+        let b = PolyOverZq::from_str("5  1 2 5 1 2 mod 7").unwrap();
+        let cmp = PolyOverZq::from_str("5  0 4 2 1 2 mod 7").unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a = PolyOverZq::from_str(&format!(
+            "3  {} {} {} mod {}",
+            u32::MAX,
+            i32::MIN,
+            i32::MAX,
+            u64::MAX
+        ))
+        .unwrap();
+        let b = PolyOverZq::from_str(&format!("2  {} {} mod {}", u32::MAX, i32::MAX, u64::MAX))
+            .unwrap();
+        let cmp = PolyOverZq::from_str(&format!(
+            "3  {} -1 {} mod {}",
+            u64::from(u32::MAX) * 2,
+            i32::MAX,
+            u64::MAX
+        ))
+        .unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = PolyOverZq::from_str("3  1 2 -3 mod 5").unwrap();
+        let b = PolyOverZq::from_str("3  -1 -2 3 mod 5").unwrap();
+
+        a += &b;
+        a += b;
+    }
+}
 
 #[cfg(test)]
 mod test_add {

--- a/src/integer_mod_q/poly_over_zq/norm.rs
+++ b/src/integer_mod_q/poly_over_zq/norm.rs
@@ -40,10 +40,9 @@ impl PolyOverZq {
         let mut res = Z::ZERO;
         for i in 0..=self.get_degree() {
             let coeff: Z = self.get_coeff(i).unwrap();
-            res = res
-                + length(&coeff.value, &self.modulus.get_fmpz_mod_ctx_struct().n[0])
-                    .pow(2)
-                    .unwrap();
+            res += length(&coeff.value, &self.modulus.get_fmpz_mod_ctx_struct().n[0])
+                .pow(2)
+                .unwrap();
         }
         res
     }

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/add.rs
@@ -13,11 +13,66 @@ use crate::{
     error::MathError,
     integer::PolyOverZ,
     macros::arithmetics::{
-        arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+        arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
     },
 };
 use flint_sys::fq::fq_add;
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&PolynomialRingZq> for PolynomialRingZq {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the polynomial to add to `self`
+    ///
+    /// Returns the sum of both polynomials modulo `Z_q[X]` as a [`PolynomialRingZq`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::PolynomialRingZq;
+    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
+    /// use qfall_math::integer::PolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+    /// let poly_1 = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
+    /// let mut a = PolynomialRingZq::from((&poly_1, &modulus));
+    /// let poly_2 = PolyOverZ::from_str("4  2 0 3 1").unwrap();
+    /// let b = PolynomialRingZq::from((&poly_2, &modulus));
+    ///
+    /// a += &b;
+    /// a += b;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the moduli of both [`PolynomialRingZq`] mismatch.
+    fn add_assign(&mut self, other: &Self) {
+        if self.modulus != other.modulus {
+            panic!(
+                "Tried to add polynomial with modulus '{}' and polynomial with modulus '{}'.",
+                self.modulus, other.modulus
+            );
+        }
+
+        unsafe {
+            fq_add(
+                &mut self.poly.poly,
+                &self.poly.poly,
+                &other.poly.poly,
+                self.modulus.get_fq_ctx(),
+            );
+        };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(
+    AddAssign,
+    add_assign,
+    PolynomialRingZq,
+    PolynomialRingZq
+);
 
 impl Add for &PolynomialRingZq {
     type Output = PolynomialRingZq;
@@ -116,6 +171,79 @@ arithmetic_trait_mixed_borrowed_owned!(
     PolynomialRingZq,
     PolynomialRingZq
 );
+
+#[cfg(test)]
+mod test_add_assign {
+    use super::PolyOverZ;
+    use crate::integer_mod_q::{ModulusPolynomialRingZq, PolynomialRingZq};
+    use std::str::FromStr;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+        let poly_1 = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
+        let mut a = PolynomialRingZq::from((&poly_1, &modulus));
+        let poly_2 = PolyOverZ::from_str("4  2 0 3 -1").unwrap();
+        let b = PolynomialRingZq::from((&poly_2, &modulus));
+        let cmp = PolynomialRingZq::from((&PolyOverZ::from_str("3  1 0 4").unwrap(), &modulus));
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let modulus = ModulusPolynomialRingZq::from_str(&format!(
+            "4  {} 0 0 {} mod {}",
+            u64::MAX,
+            i64::MIN,
+            u64::MAX - 58
+        ))
+        .unwrap();
+        let poly_1 = PolyOverZ::from_str(&format!("4  {} 0 1 {}", u64::MAX, i64::MIN)).unwrap();
+        let mut a = PolynomialRingZq::from((&poly_1, &modulus));
+        let poly_2 = PolyOverZ::from_str(&format!("4  {} 0 -1 {}", i64::MAX, i64::MAX)).unwrap();
+        let b = PolynomialRingZq::from((&poly_2, &modulus));
+        let cmp = PolynomialRingZq::from((
+            &PolyOverZ::from_str(&format!("4  {} 0 0 {}", (u64::MAX - 1) / 2 + 58, -1)).unwrap(),
+            &modulus,
+        ));
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+        let poly_1 = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
+        let mut a = PolynomialRingZq::from((&poly_1, &modulus));
+        let poly_2 = PolyOverZ::from_str("4  2 0 3 1").unwrap();
+        let b = PolynomialRingZq::from((&poly_2, &modulus));
+
+        a += &b;
+        a += b;
+    }
+
+    /// Ensures that mismatching moduli result in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_moduli() {
+        let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();
+        let poly_1 = PolyOverZ::from_str("4  -1 0 1 1").unwrap();
+        let mut a = PolynomialRingZq::from((&poly_1, &modulus));
+        let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 2 mod 17").unwrap();
+        let poly_2 = PolyOverZ::from_str("4  2 0 3 1").unwrap();
+        let b = PolynomialRingZq::from((&poly_2, &modulus));
+
+        a += b;
+    }
+}
 
 #[cfg(test)]
 mod test_add {

--- a/src/integer_mod_q/polynomial_ring_zq/norm.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/norm.rs
@@ -41,10 +41,9 @@ impl PolynomialRingZq {
         let mut res = Z::ZERO;
         for i in 0..=self.get_degree() {
             let coeff: Z = self.get_coeff(i).unwrap();
-            res = res
-                + length(&coeff.value, &self.modulus.get_fq_ctx().ctxp[0].n[0])
-                    .pow(2)
-                    .unwrap();
+            res += length(&coeff.value, &self.modulus.get_fq_ctx().ctxp[0].n[0])
+                .pow(2)
+                .unwrap();
         }
         res
     }

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -13,15 +13,101 @@ use crate::{
     error::MathError,
     integer::Z,
     macros::arithmetics::{
+        arithmetic_assign_between_types, arithmetic_assign_trait_borrowed_to_owned,
         arithmetic_between_types_zq, arithmetic_trait_borrowed_to_owned,
         arithmetic_trait_mixed_borrowed_owned,
     },
 };
 use flint_sys::{
     fmpz::fmpz,
-    fmpz_mod::{fmpz_mod_add, fmpz_mod_add_fmpz},
+    fmpz_mod::{fmpz_mod_add, fmpz_mod_add_fmpz, fmpz_mod_add_si, fmpz_mod_add_ui},
 };
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&Zq> for Zq {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both numbers as a [`Zq`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer_mod_q::Zq, integer::Z};
+    ///
+    /// let mut a: Zq = Zq::from((23, 42));
+    /// let b: Zq = Zq::from((1, 42));
+    /// let c: Z = Z::from(5);
+    ///
+    /// a += &b;
+    /// a += b;
+    /// a += 5;
+    /// a += c;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the moduli of both [`Zq`] mismatch.
+    fn add_assign(&mut self, other: &Self) {
+        if self.modulus != other.modulus {
+            panic!("Tried to add '{self}' and '{other}'. If the modulus should be ignored please convert into a Z beforehand.");
+        }
+
+        unsafe {
+            fmpz_mod_add(
+                &mut self.value.value,
+                &self.value.value,
+                &other.value.value,
+                self.modulus.get_fmpz_mod_ctx_struct(),
+            )
+        };
+    }
+}
+impl AddAssign<i64> for Zq {
+    /// Documentation at [`Zq::add_assign`].
+    fn add_assign(&mut self, other: i64) {
+        unsafe {
+            fmpz_mod_add_si(
+                &mut self.value.value,
+                &self.value.value,
+                other,
+                self.modulus.get_fmpz_mod_ctx_struct(),
+            )
+        };
+    }
+}
+impl AddAssign<u64> for Zq {
+    /// Documentation at [`Zq::add_assign`].
+    fn add_assign(&mut self, other: u64) {
+        unsafe {
+            fmpz_mod_add_ui(
+                &mut self.value.value,
+                &self.value.value,
+                other,
+                self.modulus.get_fmpz_mod_ctx_struct(),
+            )
+        };
+    }
+}
+impl AddAssign<&Z> for Zq {
+    /// Documentation at [`Zq::add_assign`].
+    fn add_assign(&mut self, other: &Z) {
+        unsafe {
+            fmpz_mod_add_fmpz(
+                &mut self.value.value,
+                &self.value.value,
+                &other.value,
+                self.modulus.get_fmpz_mod_ctx_struct(),
+            )
+        };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, Zq, Zq);
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, Zq, Z);
+arithmetic_assign_between_types!(AddAssign, add_assign, Zq, i64, i32 i16 i8);
+arithmetic_assign_between_types!(AddAssign, add_assign, Zq, u64, u32 u16 u8);
 
 impl Add for &Zq {
     type Output = Zq;
@@ -143,6 +229,76 @@ impl Add<&Z> for &Zq {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, Zq, Z, Zq);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Zq, Z, Zq);
+
+#[cfg(test)]
+mod test_add_assign {
+    use crate::{integer::Z, integer_mod_q::Zq};
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a: Zq = Zq::from((-1, 7));
+        let b = Zq::from((-1, 7));
+        let c = Zq::from((1, 7));
+
+        a += &b;
+        assert_eq!(Zq::from((5, 7)), a);
+        a += &c;
+        assert_eq!(Zq::from((6, 7)), a);
+        a += &c;
+        assert_eq!(Zq::from((0, 7)), a);
+        a += &c;
+        assert_eq!(Zq::from((1, 7)), a);
+        a += &c;
+        assert_eq!(Zq::from((2, 7)), a);
+        a += 2 * b;
+        assert_eq!(Zq::from((0, 7)), a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a = Zq::from((i64::MAX, u64::MAX));
+        let b = Zq::from((i64::MIN + 2, u64::MAX));
+        let c = Zq::from((u64::MAX - 1, u64::MAX));
+
+        a += b;
+        assert_eq!(Zq::from((1, u64::MAX)), a);
+        a += c;
+        assert_eq!(Zq::from((0, u64::MAX)), a);
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = Zq::from((3, 7));
+        let b = Zq::from((1, 7));
+        let c = Z::from(1);
+
+        a += &b;
+        a += b;
+        a += &c;
+        a += c;
+        a += 1_u8;
+        a += 1_u16;
+        a += 1_u32;
+        a += 1_u64;
+        a += 1_i8;
+        a += 1_i16;
+        a += 1_i32;
+        a += 1_i64;
+    }
+
+    /// Ensures that mismatching moduli result in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_moduli() {
+        let mut a = Zq::from((3, 7));
+        let b = Zq::from((1, 8));
+
+        a += b;
+    }
+}
 
 #[cfg(test)]
 mod test_add {

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -31,7 +31,7 @@ impl AddAssign<&Zq> for Zq {
     /// Parameters:
     /// - `other`: specifies the value to add to `self`
     ///
-    /// Returns the sum of both numbers as a [`Zq`].
+    /// Returns the sum of both numbers modulo `q` as a [`Zq`].
     ///
     /// # Examples
     /// ```

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -258,3 +258,58 @@ macro_rules! arithmetic_between_types_zq {
 }
 
 pub(crate) use arithmetic_between_types_zq;
+
+// TRAITS for Arithmetic Assign traits
+
+/// Implements the `*trait*` for `*type*`, using the `*trait*` for
+/// `&*type*`.
+///
+/// Parameters:
+/// - `trait`: the trait that is implemented
+///     (e.g. [`Add`](std::ops::Add),[`Sub`](std::ops::Sub), ...).
+/// - `trait_function`: the function the trait implements
+///     (e.g. add for [`Add`](std::ops::Add), ...).
+/// - `type`: the type the trait is implemented for
+///     (e.g. [`Z`](crate::integer::Z),[`Q`](crate::rational::Q))
+/// - `other_type`: the type the second part of the computation.
+/// - `output_type`: the type of the result.
+///
+/// Returns the owned Implementation code for the `*trait*`
+/// trait with the signature:
+///
+/// ```impl *trait<*other_type*>* for *type*```
+macro_rules! arithmetic_assign_trait_borrowed_to_owned {
+    ($trait:ident, $trait_function:ident, $type:ident, $other_type:ident) => {
+        #[doc(hidden)]
+        impl $trait<$other_type> for $type {
+            paste::paste! {
+                #[doc = "Documentation at [`" $type "::" $trait_function "`]."]
+                fn $trait_function(&mut self, other: $other_type) {
+                    self.$trait_function(&other)
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use arithmetic_assign_trait_borrowed_to_owned;
+
+macro_rules! arithmetic_assign_between_types {
+    ($trait:ident, $trait_function:ident, $type:ident, $transfer_type:ident, $($other_type:ident)*) => {
+        $(
+            #[doc = "Documentation at"]
+            impl $trait<$other_type> for $type {
+                paste::paste! {
+                    #[doc = "Documentation at [`Zq::" $trait_function "`]."]
+                    fn $trait_function(&mut self, other: $other_type) {
+                        let other: $transfer_type = other.into();
+
+                        self.$trait_function(&other);
+                    }
+                }
+            }
+        )*
+    };
+}
+
+pub(crate) use arithmetic_assign_between_types;

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -262,7 +262,7 @@ pub(crate) use arithmetic_between_types_zq;
 // TRAITS for Arithmetic Assign traits
 
 /// Implements the `*trait*` for `*type*`, using the `*trait*` for
-/// `&*type*`.
+/// `*type*`. Can be used for traits without an output.
 ///
 /// Parameters:
 /// - `trait`: the trait that is implemented
@@ -272,7 +272,6 @@ pub(crate) use arithmetic_between_types_zq;
 /// - `type`: the type the trait is implemented for
 ///     (e.g. [`Z`](crate::integer::Z),[`Q`](crate::rational::Q))
 /// - `other_type`: the type the second part of the computation.
-/// - `output_type`: the type of the result.
 ///
 /// Returns the owned Implementation code for the `*trait*`
 /// trait with the signature:
@@ -280,7 +279,6 @@ pub(crate) use arithmetic_between_types_zq;
 /// ```impl *trait<*other_type*>* for *type*```
 macro_rules! arithmetic_assign_trait_borrowed_to_owned {
     ($trait:ident, $trait_function:ident, $type:ident, $other_type:ident) => {
-        #[doc(hidden)]
         impl $trait<$other_type> for $type {
             paste::paste! {
                 #[doc = "Documentation at [`" $type "::" $trait_function "`]."]
@@ -294,17 +292,33 @@ macro_rules! arithmetic_assign_trait_borrowed_to_owned {
 
 pub(crate) use arithmetic_assign_trait_borrowed_to_owned;
 
+/// Implements the `*trait*` for `*type*`, using the `*trait*` for
+/// `*type*`. Can be used for traits without an output.
+///
+/// Parameters:
+/// - `trait`: the trait that is implemented
+///     (e.g. [`Add`](std::ops::Add),[`Sub`](std::ops::Sub), ...).
+/// - `trait_function`: the function the trait implements
+///     (e.g. add for [`Add`](std::ops::Add), ...).
+/// - `type`: the type the trait is implemented for
+///     (e.g. [`Z`](crate::integer::Z),[`Q`](crate::rational::Q))
+/// - `transfer_type`: the type to convert `other_type` to before
+///     it's input to the `trait_function`
+///     (e.g. [`i64`] or [`u64`])
+/// - `other_type`: the type the second part of the computation.
+///
+/// Returns the Implementation code for the `*trait*`
+/// trait with the signature:
+///
+/// ```impl *trait<*other_type*>* for *type*```
 macro_rules! arithmetic_assign_between_types {
     ($trait:ident, $trait_function:ident, $type:ident, $transfer_type:ident, $($other_type:ident)*) => {
         $(
-            #[doc = "Documentation at"]
             impl $trait<$other_type> for $type {
                 paste::paste! {
-                    #[doc = "Documentation at [`Zq::" $trait_function "`]."]
+                    #[doc = "Documentation at [` " $type "::" $trait_function "`]."]
                     fn $trait_function(&mut self, other: $other_type) {
-                        let other: $transfer_type = other.into();
-
-                        self.$trait_function(&other);
+                        self.$trait_function(other as $transfer_type);
                     }
                 }
             }

--- a/src/rational/poly_over_q/arithmetic/add.rs
+++ b/src/rational/poly_over_q/arithmetic/add.rs
@@ -10,10 +10,38 @@
 
 use super::super::PolyOverQ;
 use crate::macros::arithmetics::{
-    arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+    arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
+    arithmetic_trait_mixed_borrowed_owned,
 };
 use flint_sys::fmpq_poly::fmpq_poly_add;
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&PolyOverQ> for PolyOverQ {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the polynomial to add to `self`
+    ///
+    /// Returns the sum of both polynomials as a [`PolyOverQ`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::PolyOverQ;
+    /// use std::str::FromStr;
+    ///
+    /// let mut a = PolyOverQ::from_str("3  1 2/3 -3/4").unwrap();
+    /// let b = PolyOverQ::from_str("5  1 2 -3 0 8/9").unwrap();
+    ///
+    /// a += &b;
+    /// a += b;
+    /// ```
+    fn add_assign(&mut self, other: &Self) {
+        unsafe { fmpq_poly_add(&mut self.poly, &self.poly, &other.poly) };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, PolyOverQ, PolyOverQ);
 
 impl Add for &PolyOverQ {
     type Output = PolyOverQ;
@@ -49,6 +77,60 @@ impl Add for &PolyOverQ {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, PolyOverQ, PolyOverQ, PolyOverQ);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, PolyOverQ, PolyOverQ, PolyOverQ);
+
+#[cfg(test)]
+mod test_add_assign {
+    use super::PolyOverQ;
+    use crate::rational::Q;
+    use std::str::FromStr;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = PolyOverQ::from_str("3  1/7 2/7 -3").unwrap();
+        let b = PolyOverQ::from_str("3  1 -2/7 3").unwrap();
+        let cmp = PolyOverQ::from_str("1  8/7").unwrap();
+
+        a += &b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a: PolyOverQ = PolyOverQ::from_str(&format!(
+            "3  {} {}/{} {}",
+            u64::MAX,
+            i64::MIN,
+            u128::MAX,
+            i64::MAX
+        ))
+        .unwrap();
+        let b = PolyOverQ::from_str(&format!("2  {} {}", u64::MAX, i64::MAX)).unwrap();
+        let cmp = PolyOverQ::from_str(&format!(
+            "3  {} {} {}",
+            u128::from(u64::MAX) * 2,
+            (Q::from_str(&format!("{}/{}", i64::MIN, u128::MAX)).unwrap() + Q::from(i64::MAX)),
+            i64::MAX
+        ))
+        .unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = PolyOverQ::from_str("3  1 2 -3").unwrap();
+        let b = PolyOverQ::from_str("3  -1 -2 3").unwrap();
+
+        a += &b;
+        a += b;
+    }
+}
 
 #[cfg(test)]
 mod test_add {

--- a/src/rational/poly_over_q/norm.rs
+++ b/src/rational/poly_over_q/norm.rs
@@ -37,7 +37,7 @@ impl PolyOverQ {
 
         for i in 0..=self.get_degree() {
             let coeff = self.get_coeff(i).unwrap();
-            res = res + coeff.pow(2).unwrap();
+            res += coeff.pow(2).unwrap();
         }
         res
     }

--- a/src/rational/q/arithmetic/add.rs
+++ b/src/rational/q/arithmetic/add.rs
@@ -12,12 +12,72 @@ use super::super::Q;
 use crate::{
     integer::Z,
     macros::arithmetics::{
+        arithmetic_assign_between_types, arithmetic_assign_trait_borrowed_to_owned,
         arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
         arithmetic_trait_mixed_borrowed_owned,
     },
 };
-use flint_sys::fmpq::{fmpq_add, fmpq_add_fmpz};
-use std::ops::Add;
+use flint_sys::fmpq::{fmpq_add, fmpq_add_fmpz, fmpq_add_si, fmpq_add_ui};
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&Q> for Q {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both rationals as a [`Q`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{rational::Q, integer::Z};
+    ///
+    /// let mut a: Q = Q::from(42);
+    /// let b: Q = Q::from((-42, 2));
+    /// let c: Z = Z::from(5);
+    ///
+    /// a += &b;
+    /// a += b;
+    /// a += 5;
+    /// a += c;
+    /// ```
+    fn add_assign(&mut self, other: &Self) {
+        unsafe { fmpq_add(&mut self.value, &self.value, &other.value) };
+    }
+}
+impl AddAssign<&Z> for Q {
+    /// Documentation at [`Q::add_assign`].
+    fn add_assign(&mut self, other: &Z) {
+        unsafe { fmpq_add_fmpz(&mut self.value, &self.value, &other.value) };
+    }
+}
+impl AddAssign<i64> for Q {
+    /// Documentation at [`Q::add_assign`].
+    fn add_assign(&mut self, other: i64) {
+        unsafe { fmpq_add_si(&mut self.value, &self.value, other) };
+    }
+}
+impl AddAssign<u64> for Q {
+    /// Documentation at [`Q::add_assign`].
+    fn add_assign(&mut self, other: u64) {
+        unsafe { fmpq_add_ui(&mut self.value, &self.value, other) };
+    }
+}
+impl AddAssign<f64> for Q {
+    /// Documentation at [`Q::add_assign`].
+    fn add_assign(&mut self, other: f64) {
+        let other = Q::from(other);
+
+        unsafe { fmpq_add(&mut self.value, &self.value, &other.value) };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, Q, Q);
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, Q, Z);
+arithmetic_assign_between_types!(AddAssign, add_assign, Q, i64, i32 i16 i8);
+arithmetic_assign_between_types!(AddAssign, add_assign, Q, u64, u32 u16 u8);
+arithmetic_assign_between_types!(AddAssign, add_assign, Q, f64, f32);
 
 impl Add for &Q {
     type Output = Q;
@@ -92,6 +152,71 @@ impl Add<&Z> for &Q {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, Q, Z, Q);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, Q, Z, Q);
+
+#[cfg(test)]
+mod test_add_assign {
+    use crate::{integer::Z, rational::Q};
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = Q::MINUS_ONE;
+        let b = Q::MINUS_ONE;
+        let c = Q::ONE;
+        let d = Q::from((1, 2));
+
+        a += &b;
+        assert_eq!(-2, a);
+        a += &c;
+        assert_eq!(-1, a);
+        a += &c;
+        assert_eq!(0, a);
+        a += &c;
+        assert_eq!(1, a);
+        a += &c;
+        assert_eq!(2, a);
+        a += 2 * b;
+        assert_eq!(0, a);
+        a += d;
+        assert_eq!(Q::from((1, 2)), a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a = Q::from(i64::MAX);
+        let b = Q::from(i64::MIN);
+        let c = Q::from(u64::MAX);
+
+        a += b;
+        assert_eq!(-1, a);
+        a += c;
+        assert_eq!(u64::MAX - 1, a);
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = Q::from((1, 2));
+        let b = Q::from((4, 5));
+        let c = Z::ONE;
+
+        a += &b;
+        a += b;
+        a += &c;
+        a += c;
+        a += 0.5_f64;
+        a += 0.5_f32;
+        a += 1_u8;
+        a += 1_u16;
+        a += 1_u32;
+        a += 1_u64;
+        a += 1_i8;
+        a += 1_i16;
+        a += 1_i32;
+        a += 1_i64;
+    }
+}
 
 #[cfg(test)]
 mod test_add {


### PR DESCRIPTION
**Description**
This PR implements...
- [x] add_assign for `Z`
- [x] add_assign for `Zq`
- [x] add_assign for `Q`
- [x] add_assign for `PolyOverZ`
- [x] add_assign for `PolyOverZq`
- [x] add_assign for `PolynomialRingZq`
- [x] add_assign for `PolyOverQ`

`AddAssign` is more than 70% quicker than `Add` for `Z`. It should yield at least the same improvement for any other type.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide