### PR TITLE
`get_entry_unchecked` for all Matrix Types

### DIFF
--- a/src/integer/mat_poly_over_z/coefficient_embedding.rs
+++ b/src/integer/mat_poly_over_z/coefficient_embedding.rs
@@ -59,7 +59,7 @@ impl IntoCoefficientEmbedding<MatZ> for &MatPolyOverZ {
 
         for column in 0..num_columns {
             for row in 0..num_rows {
-                let entry: PolyOverZ = self.get_entry(row, column).unwrap();
+                let entry: PolyOverZ = unsafe { self.get_entry_unchecked(row, column) };
                 let length = entry.get_degree() + 1;
                 assert!(
                     size >= length,
@@ -125,10 +125,11 @@ impl FromCoefficientEmbedding<(&MatZ, i64)> for MatPolyOverZ {
             for column in 0..num_columns {
                 let mut poly = PolyOverZ::default();
                 for index in 0..(degree + 1) {
-                    let coeff: Z = embedding
-                        .0
-                        .get_entry(row * (degree + 1) + index, column)
-                        .unwrap();
+                    let coeff: Z = unsafe {
+                        embedding
+                            .0
+                            .get_entry_unchecked(row * (degree + 1) + index, column)
+                    };
                     poly.set_coeff(index, coeff).unwrap();
                 }
                 out.set_entry_unchecked(row, column, poly);

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -116,7 +116,7 @@ impl From<&MatZ> for MatPolyOverZ {
                 out.set_entry_unchecked(
                     row,
                     column,
-                    PolyOverZ::from(matrix.get_entry(row, column).unwrap()),
+                    PolyOverZ::from(unsafe { matrix.get_entry_unchecked(row, column) }),
                 );
             }
         }

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -96,7 +96,7 @@ impl GetEntry<PolyOverZ> for MatPolyOverZ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpz_poly_set` can successfully clone the
         // entry of the matrix. Therefore no memory leaks can appear.
-        Ok(self.get_entry_unchecked(row_i64, column_i64))
+        Ok(unsafe { self.get_entry_unchecked(row_i64, column_i64) })
     }
 
     /// Outputs the [`PolyOverZ`] value of a specific matrix entry
@@ -109,6 +109,11 @@ impl GetEntry<PolyOverZ> for MatPolyOverZ {
     /// Returns the [`PolyOverZ`] value of the matrix at the position of the given
     /// row and column.
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
@@ -117,13 +122,10 @@ impl GetEntry<PolyOverZ> for MatPolyOverZ {
     ///
     /// let matrix = MatPolyOverZ::from_str("[[1  1, 1  2],[1  3, 1  4],[0, 1  6]]").unwrap();
     ///
-    /// assert_eq!(PolyOverZ::from(2), matrix.get_entry_unchecked(0, 1));
-    /// assert_eq!(PolyOverZ::from(4), matrix.get_entry_unchecked(1, 1));
+    /// assert_eq!(PolyOverZ::from(2), unsafe { matrix.get_entry_unchecked(0, 1) });
+    /// assert_eq!(PolyOverZ::from(4), unsafe { matrix.get_entry_unchecked(1, 1) });
     /// ```
-    ///
-    /// # Panics ...
-    /// - if `row` or `column` are greater than the matrix size.
-    fn get_entry_unchecked(&self, row: i64, column: i64) -> PolyOverZ {
+    unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> PolyOverZ {
         let mut copy = PolyOverZ::default();
         let entry = unsafe { fmpz_poly_mat_entry(&self.matrix, row, column) };
         unsafe { fmpz_poly_set(&mut copy.poly, entry) };

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -96,11 +96,39 @@ impl GetEntry<PolyOverZ> for MatPolyOverZ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpz_poly_set` can successfully clone the
         // entry of the matrix. Therefore no memory leaks can appear.
+        Ok(self.get_entry_unchecked(row_i64, column_i64))
+    }
+
+    /// Outputs the [`PolyOverZ`] value of a specific matrix entry
+    /// without checking whether it's part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    ///
+    /// Returns the [`PolyOverZ`] value of the matrix at the position of the given
+    /// row and column.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
+    /// use qfall_math::traits::*;
+    /// use std::str::FromStr;
+    ///
+    /// let matrix = MatPolyOverZ::from_str("[[1  1, 1  2],[1  3, 1  4],[0, 1  6]]").unwrap();
+    ///
+    /// assert_eq!(PolyOverZ::from(2), matrix.get_entry_unchecked(0, 1));
+    /// assert_eq!(PolyOverZ::from(4), matrix.get_entry_unchecked(1, 1));
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `row` or `column` are greater than the matrix size.
+    fn get_entry_unchecked(&self, row: i64, column: i64) -> PolyOverZ {
         let mut copy = PolyOverZ::default();
-        let entry = unsafe { fmpz_poly_mat_entry(&self.matrix, row_i64, column_i64) };
+        let entry = unsafe { fmpz_poly_mat_entry(&self.matrix, row, column) };
         unsafe { fmpz_poly_set(&mut copy.poly, entry) };
 
-        Ok(copy)
+        copy
     }
 }
 

--- a/src/integer/mat_poly_over_z/properties.rs
+++ b/src/integer/mat_poly_over_z/properties.rs
@@ -90,7 +90,9 @@ impl MatPolyOverZ {
         }
         for row in 0..self.get_num_rows() {
             for column in 0..row {
-                if self.get_entry(row, column).unwrap() != self.get_entry(column, row).unwrap() {
+                if unsafe {
+                    self.get_entry_unchecked(row, column) != self.get_entry_unchecked(column, row)
+                } {
                     return false;
                 }
             }

--- a/src/integer/mat_poly_over_z/tensor.rs
+++ b/src/integer/mat_poly_over_z/tensor.rs
@@ -48,7 +48,7 @@ impl Tensor for MatPolyOverZ {
 
         for i in 0..self.get_num_rows() {
             for j in 0..self.get_num_columns() {
-                let entry = self.get_entry(i, j).unwrap();
+                let entry = unsafe { self.get_entry_unchecked(i, j) };
 
                 if !entry.is_zero() {
                     unsafe { set_matrix_window_mul(&mut out, i, j, entry, other) }

--- a/src/integer/mat_poly_over_z/vector/norm.rs
+++ b/src/integer/mat_poly_over_z/vector/norm.rs
@@ -52,7 +52,7 @@ impl MatPolyOverZ {
 
         for row in 0..self.get_num_rows() {
             for column in 0..self.get_num_columns() {
-                result += self.get_entry(row, column).unwrap().norm_eucl_sqrd();
+                result += unsafe { self.get_entry_unchecked(row, column) }.norm_eucl_sqrd();
             }
         }
 
@@ -94,7 +94,9 @@ impl MatPolyOverZ {
 
         for row in 0..self.get_num_rows() {
             for column in 0..self.get_num_columns() {
-                let entry_norm = self.get_entry(row, column).unwrap().norm_infty().abs();
+                let entry_norm = unsafe { self.get_entry_unchecked(row, column) }
+                    .norm_infty()
+                    .abs();
                 if result < entry_norm {
                     result = entry_norm;
                 }

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -94,11 +94,40 @@ impl GetEntry<Z> for MatZ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpz_set` can successfully clone the
         // entry of the matrix. Therefore no memory leaks can appear.
+        Ok(self.get_entry_unchecked(row_i64, column_i64))
+    }
+
+    /// Outputs the [`Z`] value of a specific matrix entry without checking
+    /// whether it's part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    ///
+    /// Returns the [`Z`] value of the matrix at the position of the given
+    /// row and column.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::{MatZ, Z};
+    /// use qfall_math::traits::GetEntry;
+    /// use std::str::FromStr;
+    ///
+    /// let matrix = MatZ::from_str("[[1, 2, 3],[4, 5, 6],[7, 8, 9]]").unwrap();
+    ///
+    /// assert_eq!(matrix.get_entry_unchecked(0, 2), Z::from(3));
+    /// assert_eq!(matrix.get_entry_unchecked(2, 1), Z::from(8));
+    /// assert_eq!(matrix.get_entry_unchecked(2, 1), Z::from(8));
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `row` or `column` is negative or is greater than the matrix size.
+    fn get_entry_unchecked(&self, row: i64, column: i64) -> Z {
         let mut copy = fmpz(0);
-        let entry = unsafe { fmpz_mat_entry(&self.matrix, row_i64, column_i64) };
+        let entry = unsafe { fmpz_mat_entry(&self.matrix, row, column) };
         unsafe { fmpz_set(&mut copy, entry) };
 
-        Ok(Z { value: copy })
+        Z { value: copy }
     }
 }
 

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -94,7 +94,7 @@ impl GetEntry<Z> for MatZ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpz_set` can successfully clone the
         // entry of the matrix. Therefore no memory leaks can appear.
-        Ok(self.get_entry_unchecked(row_i64, column_i64))
+        unsafe { Ok(self.get_entry_unchecked(row_i64, column_i64)) }
     }
 
     /// Outputs the [`Z`] value of a specific matrix entry without checking
@@ -107,6 +107,11 @@ impl GetEntry<Z> for MatZ {
     /// Returns the [`Z`] value of the matrix at the position of the given
     /// row and column.
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer::{MatZ, Z};
@@ -115,14 +120,11 @@ impl GetEntry<Z> for MatZ {
     ///
     /// let matrix = MatZ::from_str("[[1, 2, 3],[4, 5, 6],[7, 8, 9]]").unwrap();
     ///
-    /// assert_eq!(matrix.get_entry_unchecked(0, 2), Z::from(3));
-    /// assert_eq!(matrix.get_entry_unchecked(2, 1), Z::from(8));
-    /// assert_eq!(matrix.get_entry_unchecked(2, 1), Z::from(8));
+    /// assert_eq!(unsafe { matrix.get_entry_unchecked(0, 2) }, Z::from(3));
+    /// assert_eq!(unsafe { matrix.get_entry_unchecked(2, 1) }, Z::from(8));
+    /// assert_eq!(unsafe { matrix.get_entry_unchecked(2, 1) }, Z::from(8));
     /// ```
-    ///
-    /// # Panics ...
-    /// - if `row` or `column` is negative or is greater than the matrix size.
-    fn get_entry_unchecked(&self, row: i64, column: i64) -> Z {
+    unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> Z {
         let mut copy = fmpz(0);
         let entry = unsafe { fmpz_mat_entry(&self.matrix, row, column) };
         unsafe { fmpz_set(&mut copy, entry) };

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -127,7 +127,7 @@ impl GetEntry<Z> for MatZ {
     unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> Z {
         let mut copy = fmpz(0);
         let entry = unsafe { fmpz_mat_entry(&self.matrix, row, column) };
-        unsafe { fmpz_set(&mut copy, entry) };
+        unsafe { fmpz_init_set(&mut copy, entry) };
 
         Z { value: copy }
     }

--- a/src/integer/mat_z/properties.rs
+++ b/src/integer/mat_z/properties.rs
@@ -81,7 +81,9 @@ impl MatZ {
         }
         for row in 0..self.get_num_rows() {
             for column in 0..row {
-                if self.get_entry(row, column).unwrap() != self.get_entry(column, row).unwrap() {
+                if unsafe {
+                    self.get_entry_unchecked(row, column) != self.get_entry_unchecked(column, row)
+                } {
                     return false;
                 }
             }

--- a/src/integer/mat_z/to_string.rs
+++ b/src/integer/mat_z/to_string.rs
@@ -106,7 +106,7 @@ impl MatZ {
         // Fill byte vector
         for row in 0..self.get_num_rows() as usize {
             for col in 0..self.get_num_columns() as usize {
-                let entry_value = self.get_entry(row, col).unwrap();
+                let entry_value = unsafe { self.get_entry_unchecked(row as i64, col as i64) };
                 let entry_bytes = entry_value.to_bytes();
 
                 // Find maximum length of bytes in one entry of the matrix

--- a/src/integer/poly_over_z/coefficient_embedding.rs
+++ b/src/integer/poly_over_z/coefficient_embedding.rs
@@ -100,7 +100,7 @@ impl FromCoefficientEmbedding<&MatZ> for PolyOverZ {
         );
         let mut out = PolyOverZ::default();
         for i in 0..embedding.get_num_rows() {
-            out.set_coeff(i, embedding.get_entry(i, 0).unwrap())
+            out.set_coeff(i, unsafe { embedding.get_entry_unchecked(i, 0) })
                 .unwrap()
         }
         out

--- a/src/integer_mod_q/mat_polynomial_ring_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/coefficient_embedding.rs
@@ -62,7 +62,7 @@ impl IntoCoefficientEmbedding<(MatZq, ModulusPolynomialRingZq)> for &MatPolynomi
 
         for column in 0..num_columns {
             for row in 0..num_rows {
-                let entry: PolyOverZ = self.get_entry(row, column).unwrap();
+                let entry: PolyOverZ = unsafe { self.get_entry_unchecked(row, column) };
                 let length = entry.get_degree() + 1;
                 assert!(
                     size >= length,
@@ -137,10 +137,11 @@ impl FromCoefficientEmbedding<(&MatZq, &ModulusPolynomialRingZq, i64)> for MatPo
             for column in 0..num_columns {
                 let mut poly = PolyOverZ::default();
                 for index in 0..(degree + 1) {
-                    let coeff: Z = embedding
-                        .0
-                        .get_entry(row * (degree + 1) + index, column)
-                        .unwrap();
+                    let coeff: Z = unsafe {
+                        embedding
+                            .0
+                            .get_entry_unchecked(row * (degree + 1) + index, column)
+                    };
                     poly.set_coeff(index, coeff).unwrap();
                 }
                 out.set_entry(row, column, poly).unwrap();

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -162,6 +162,11 @@ impl GetEntry<PolyOverZ> for MatPolynomialRingZq {
     /// Returns the [`PolyOverZ`] value of the matrix at the position of the given
     /// row and column.
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
@@ -173,17 +178,14 @@ impl GetEntry<PolyOverZ> for MatPolynomialRingZq {
     /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
     /// let poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
     ///
-    /// let entry_1: PolyOverZ = poly_ring_mat.get_entry_unchecked(1, 0);
-    /// let entry_2: PolyOverZ = poly_ring_mat.get_entry_unchecked(0, 1);
+    /// let entry_1: PolyOverZ = unsafe { poly_ring_mat.get_entry_unchecked(1, 0) };
+    /// let entry_2: PolyOverZ = unsafe { poly_ring_mat.get_entry_unchecked(0, 1) };
     ///
     ///
     /// assert_eq!(entry_1, PolyOverZ::from(0));
     /// assert_eq!(entry_2, PolyOverZ::from(42));
     /// ```
-    ///
-    /// # Panics ...
-    /// - if `row` or `column` are greater than the matrix size.
-    fn get_entry_unchecked(&self, row: i64, column: i64) -> PolyOverZ {
+    unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> PolyOverZ {
         self.matrix.get_entry_unchecked(row, column)
     }
 }
@@ -245,6 +247,11 @@ impl GetEntry<PolynomialRingZq> for MatPolynomialRingZq {
     /// Returns the [`PolynomialRingZq`] value of the matrix at the position of the given
     /// row and column.
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq, PolynomialRingZq};
@@ -256,17 +263,14 @@ impl GetEntry<PolynomialRingZq> for MatPolynomialRingZq {
     /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
     /// let poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
     ///
-    /// let entry_1: PolynomialRingZq = poly_ring_mat.get_entry_unchecked(0, 1);
-    /// let entry_2: PolynomialRingZq = poly_ring_mat.get_entry_unchecked(0, 1);
+    /// let entry_1: PolynomialRingZq = unsafe { poly_ring_mat.get_entry_unchecked(0, 1) };
+    /// let entry_2: PolynomialRingZq = unsafe { poly_ring_mat.get_entry_unchecked(0, 1) };
     ///
     /// let value_cmp = PolynomialRingZq::from((&PolyOverZ::from(42), &modulus));
     /// assert_eq!(entry_1, value_cmp);
     /// assert_eq!(entry_1, entry_2);
     /// ```
-    ///
-    /// # Panics ...
-    /// - if `row` or `column` are greater than the matrix size.
-    fn get_entry_unchecked(&self, row: i64, column: i64) -> PolynomialRingZq {
+    unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> PolynomialRingZq {
         PolynomialRingZq {
             poly: self.matrix.get_entry_unchecked(row, column),
             modulus: self.get_mod(),

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -151,6 +151,41 @@ impl GetEntry<PolyOverZ> for MatPolynomialRingZq {
     ) -> Result<PolyOverZ, MathError> {
         self.matrix.get_entry(row, column)
     }
+
+    /// Outputs the [`PolyOverZ`] value of a specific matrix entry
+    /// without checking whether it's part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    ///
+    /// Returns the [`PolyOverZ`] value of the matrix at the position of the given
+    /// row and column.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
+    /// use qfall_math::traits::*;
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 50").unwrap();
+    /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
+    /// let poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
+    ///
+    /// let entry_1: PolyOverZ = poly_ring_mat.get_entry_unchecked(1, 0);
+    /// let entry_2: PolyOverZ = poly_ring_mat.get_entry_unchecked(0, 1);
+    ///
+    ///
+    /// assert_eq!(entry_1, PolyOverZ::from(0));
+    /// assert_eq!(entry_2, PolyOverZ::from(42));
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `row` or `column` are greater than the matrix size.
+    fn get_entry_unchecked(&self, row: i64, column: i64) -> PolyOverZ {
+        self.matrix.get_entry_unchecked(row, column)
+    }
 }
 
 impl GetEntry<PolynomialRingZq> for MatPolynomialRingZq {
@@ -198,6 +233,44 @@ impl GetEntry<PolynomialRingZq> for MatPolynomialRingZq {
             poly: self.matrix.get_entry(row, column)?,
             modulus: self.get_mod(),
         })
+    }
+
+    /// Outputs the [`PolynomialRingZq`] value of a specific matrix entry
+    /// without checking whether it's part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    ///
+    /// Returns the [`PolynomialRingZq`] value of the matrix at the position of the given
+    /// row and column.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq, PolynomialRingZq};
+    /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
+    /// use qfall_math::traits::*;
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 50").unwrap();
+    /// let poly_mat = MatPolyOverZ::from_str("[[4  -1 0 1 1, 1  42],[0, 2  1 2]]").unwrap();
+    /// let poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
+    ///
+    /// let entry_1: PolynomialRingZq = poly_ring_mat.get_entry_unchecked(0, 1);
+    /// let entry_2: PolynomialRingZq = poly_ring_mat.get_entry_unchecked(0, 1);
+    ///
+    /// let value_cmp = PolynomialRingZq::from((&PolyOverZ::from(42), &modulus));
+    /// assert_eq!(entry_1, value_cmp);
+    /// assert_eq!(entry_1, entry_2);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `row` or `column` are greater than the matrix size.
+    fn get_entry_unchecked(&self, row: i64, column: i64) -> PolynomialRingZq {
+        PolynomialRingZq {
+            poly: self.matrix.get_entry_unchecked(row, column),
+            modulus: self.get_mod(),
+        }
     }
 }
 

--- a/src/integer_mod_q/mat_polynomial_ring_zq/properties.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/properties.rs
@@ -107,9 +107,10 @@ impl MatPolynomialRingZq {
         }
         for row in 0..self.get_num_rows() {
             for column in 0..row {
-                if GetEntry::<PolyOverZ>::get_entry(self, row, column).unwrap()
-                    != GetEntry::<PolyOverZ>::get_entry(self, column, row).unwrap()
-                {
+                if unsafe {
+                    GetEntry::<PolyOverZ>::get_entry_unchecked(self, row, column)
+                        != GetEntry::<PolyOverZ>::get_entry_unchecked(self, column, row)
+                } {
                     return false;
                 }
             }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/tensor.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/tensor.rs
@@ -97,7 +97,7 @@ impl MatPolynomialRingZq {
 
         for i in 0..self.get_num_rows() {
             for j in 0..self.get_num_columns() {
-                let entry: PolyOverZ = self.get_entry(i, j).unwrap();
+                let entry: PolyOverZ = unsafe { self.get_entry_unchecked(i, j) };
 
                 if !entry.is_zero() {
                     unsafe { set_matrix_window_mul(&mut out, i, j, entry, other) }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector/norm.rs
@@ -57,7 +57,7 @@ impl MatPolynomialRingZq {
 
         for row in 0..self.get_num_rows() {
             for column in 0..self.get_num_columns() {
-                let entry: PolynomialRingZq = self.get_entry(row, column).unwrap();
+                let entry: PolynomialRingZq = unsafe { self.get_entry_unchecked(row, column) };
                 result += entry.norm_eucl_sqrd();
             }
         }
@@ -104,7 +104,7 @@ impl MatPolynomialRingZq {
 
         for row in 0..self.get_num_rows() {
             for column in 0..self.get_num_columns() {
-                let entry: PolynomialRingZq = self.get_entry(row, column).unwrap();
+                let entry: PolynomialRingZq = unsafe { self.get_entry_unchecked(row, column) };
                 let entry_norm = entry.norm_infty().abs();
                 if result < entry_norm {
                     result = entry_norm;

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector/norm.rs
@@ -58,7 +58,7 @@ impl MatPolynomialRingZq {
         for row in 0..self.get_num_rows() {
             for column in 0..self.get_num_columns() {
                 let entry: PolynomialRingZq = self.get_entry(row, column).unwrap();
-                result = result + entry.norm_eucl_sqrd();
+                result += entry.norm_eucl_sqrd();
             }
         }
 

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -441,7 +441,7 @@ impl GetEntry<Z> for MatZq {
     unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> Z {
         let mut out = Z::default();
         let entry = unsafe { fmpz_mod_mat_entry(&self.matrix, row, column) };
-        unsafe { fmpz_set(&mut out.value, entry) };
+        unsafe { fmpz_init_set(&mut out.value, entry) };
 
         out
     }
@@ -517,7 +517,7 @@ impl GetEntry<Zq> for MatZq {
     unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> Zq {
         let mut out = Zq::from((0, &self.modulus));
         let entry = unsafe { fmpz_mod_mat_entry(&self.matrix, row, column) };
-        unsafe { fmpz_set(&mut out.value.value, entry) };
+        unsafe { fmpz_init_set(&mut out.value.value, entry) };
 
         out
     }

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -88,7 +88,7 @@ impl MatZq {
 
         for row in 0..self.get_num_rows() {
             for column in 0..self.get_num_columns() {
-                let entry: Z = self.get_entry(row, column).unwrap();
+                let entry: Z = unsafe { self.get_entry_unchecked(row, column) };
 
                 // Not using Zq::distance for performance reasons.
                 if entry > modulus_half {

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -403,10 +403,45 @@ impl GetEntry<Z> for MatZq {
     ) -> Result<Z, MathError> {
         let (row_i64, column_i64) = evaluate_indices_for_matrix(self, row, column)?;
 
+        Ok(self.get_entry_unchecked(row_i64, column_i64))
+    }
+
+    /// Outputs the [`Z`] value of a specific matrix entry
+    /// without checking whether it's part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    ///
+    /// Returns the [`Z`] value of the matrix at the position of the given
+    /// row and column.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use qfall_math::integer_mod_q::MatZq;
+    /// use qfall_math::traits::GetEntry;
+    /// use qfall_math::integer::Z;
+    /// use std::str::FromStr;
+    ///
+    /// let matrix = MatZq::from_str("[[1, 2, 3],[4, 5, 6],[7, 8, 9]] mod 10").unwrap();
+    ///
+    /// let entry_1 :Z = matrix.get_entry_unchecked(0, 2);
+    /// let entry_2 :Z = matrix.get_entry_unchecked(2, 1);
+    /// let entry_3 :Z = matrix.get_entry_unchecked(2, 1);
+    ///
+    /// assert_eq!(3, entry_1);
+    /// assert_eq!(8, entry_2);
+    /// assert_eq!(8, entry_3);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `row` or `column` are greater than the matrix size.
+    fn get_entry_unchecked(&self, row: i64, column: i64) -> Z {
         let mut out = Z::default();
-        let entry = unsafe { fmpz_mod_mat_entry(&self.matrix, row_i64, column_i64) };
+        let entry = unsafe { fmpz_mod_mat_entry(&self.matrix, row, column) };
         unsafe { fmpz_set(&mut out.value, entry) };
-        Ok(out)
+
+        out
     }
 }
 
@@ -445,9 +480,42 @@ impl GetEntry<Zq> for MatZq {
         row: impl TryInto<i64> + Display,
         column: impl TryInto<i64> + Display,
     ) -> Result<Zq, MathError> {
-        let value: Z = self.get_entry(row, column)?;
+        let (row_i64, column_i64) = evaluate_indices_for_matrix(self, row, column)?;
 
-        Ok(Zq::from((value, &self.modulus)))
+        Ok(self.get_entry_unchecked(row_i64, column_i64))
+    }
+
+    /// Outputs the [`Zq`] value of a specific matrix entry
+    /// without checking whether it's part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    ///
+    /// Returns the [`Zq`] value of the matrix at the position of the given
+    /// row and column.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use qfall_math::integer_mod_q::{MatZq, Zq};
+    /// use qfall_math::traits::GetEntry;
+    /// use std::str::FromStr;
+    ///
+    /// let matrix = MatZq::from_str("[[1, 2, 3],[4, 5, 6],[7, 8, 9]] mod 10").unwrap();
+    ///
+    /// assert_eq!(Zq::from((3, 10)), matrix.get_entry_unchecked(0, 2));
+    /// assert_eq!(Zq::from((8, 10)), matrix.get_entry_unchecked(2, 1));
+    /// assert_eq!(Zq::from((8, 10)), matrix.get_entry_unchecked(2, 1));
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `row` or `column` are greater than the matrix size.
+    fn get_entry_unchecked(&self, row: i64, column: i64) -> Zq {
+        let mut out = Zq::from((0, &self.modulus));
+        let entry = unsafe { fmpz_mod_mat_entry(&self.matrix, row, column) };
+        unsafe { fmpz_set(&mut out.value.value, entry) };
+
+        out
     }
 }
 

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -403,7 +403,7 @@ impl GetEntry<Z> for MatZq {
     ) -> Result<Z, MathError> {
         let (row_i64, column_i64) = evaluate_indices_for_matrix(self, row, column)?;
 
-        Ok(self.get_entry_unchecked(row_i64, column_i64))
+        Ok(unsafe { self.get_entry_unchecked(row_i64, column_i64) })
     }
 
     /// Outputs the [`Z`] value of a specific matrix entry
@@ -416,6 +416,11 @@ impl GetEntry<Z> for MatZq {
     /// Returns the [`Z`] value of the matrix at the position of the given
     /// row and column.
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```rust
     /// use qfall_math::integer_mod_q::MatZq;
@@ -425,18 +430,15 @@ impl GetEntry<Z> for MatZq {
     ///
     /// let matrix = MatZq::from_str("[[1, 2, 3],[4, 5, 6],[7, 8, 9]] mod 10").unwrap();
     ///
-    /// let entry_1 :Z = matrix.get_entry_unchecked(0, 2);
-    /// let entry_2 :Z = matrix.get_entry_unchecked(2, 1);
-    /// let entry_3 :Z = matrix.get_entry_unchecked(2, 1);
+    /// let entry_1 :Z = unsafe { matrix.get_entry_unchecked(0, 2) };
+    /// let entry_2 :Z = unsafe { matrix.get_entry_unchecked(2, 1) };
+    /// let entry_3 :Z = unsafe { matrix.get_entry_unchecked(2, 1) };
     ///
     /// assert_eq!(3, entry_1);
     /// assert_eq!(8, entry_2);
     /// assert_eq!(8, entry_3);
     /// ```
-    ///
-    /// # Panics ...
-    /// - if `row` or `column` are greater than the matrix size.
-    fn get_entry_unchecked(&self, row: i64, column: i64) -> Z {
+    unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> Z {
         let mut out = Z::default();
         let entry = unsafe { fmpz_mod_mat_entry(&self.matrix, row, column) };
         unsafe { fmpz_set(&mut out.value, entry) };
@@ -482,7 +484,7 @@ impl GetEntry<Zq> for MatZq {
     ) -> Result<Zq, MathError> {
         let (row_i64, column_i64) = evaluate_indices_for_matrix(self, row, column)?;
 
-        Ok(self.get_entry_unchecked(row_i64, column_i64))
+        Ok(unsafe { self.get_entry_unchecked(row_i64, column_i64) })
     }
 
     /// Outputs the [`Zq`] value of a specific matrix entry
@@ -495,6 +497,11 @@ impl GetEntry<Zq> for MatZq {
     /// Returns the [`Zq`] value of the matrix at the position of the given
     /// row and column.
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```rust
     /// use qfall_math::integer_mod_q::{MatZq, Zq};
@@ -503,14 +510,11 @@ impl GetEntry<Zq> for MatZq {
     ///
     /// let matrix = MatZq::from_str("[[1, 2, 3],[4, 5, 6],[7, 8, 9]] mod 10").unwrap();
     ///
-    /// assert_eq!(Zq::from((3, 10)), matrix.get_entry_unchecked(0, 2));
-    /// assert_eq!(Zq::from((8, 10)), matrix.get_entry_unchecked(2, 1));
-    /// assert_eq!(Zq::from((8, 10)), matrix.get_entry_unchecked(2, 1));
+    /// assert_eq!(Zq::from((3, 10)), unsafe { matrix.get_entry_unchecked(0, 2) } );
+    /// assert_eq!(Zq::from((8, 10)), unsafe { matrix.get_entry_unchecked(2, 1) } );
+    /// assert_eq!(Zq::from((8, 10)), unsafe { matrix.get_entry_unchecked(2, 1) } );
     /// ```
-    ///
-    /// # Panics ...
-    /// - if `row` or `column` are greater than the matrix size.
-    fn get_entry_unchecked(&self, row: i64, column: i64) -> Zq {
+    unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> Zq {
         let mut out = Zq::from((0, &self.modulus));
         let entry = unsafe { fmpz_mod_mat_entry(&self.matrix, row, column) };
         unsafe { fmpz_set(&mut out.value.value, entry) };

--- a/src/integer_mod_q/mat_zq/properties.rs
+++ b/src/integer_mod_q/mat_zq/properties.rs
@@ -93,9 +93,10 @@ impl MatZq {
         }
         for row in 0..self.get_num_rows() {
             for column in 0..row {
-                if GetEntry::<Z>::get_entry(self, row, column).unwrap()
-                    != GetEntry::<Z>::get_entry(self, column, row).unwrap()
-                {
+                if unsafe {
+                    GetEntry::<Z>::get_entry_unchecked(self, row, column)
+                        != GetEntry::<Z>::get_entry_unchecked(self, column, row)
+                } {
                     return false;
                 }
             }

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -87,7 +87,7 @@ impl MatZq {
             } else if let Some(row_nr) =
                 find_not_invertible_entry_column(&matrix, column_nr, &used_rows)
             {
-                let entry: Z = matrix.get_entry(row_nr, column_nr).unwrap();
+                let entry: Z = unsafe { matrix.get_entry_unchecked(row_nr, column_nr) };
 
                 // Factorize the modulus with the found entry, compute solutions
                 // for the system under the split modulus and use the
@@ -100,7 +100,7 @@ impl MatZq {
         // Set the entries of the output vector using the indices vector.
         let mut out = MatZq::new(self.get_num_columns(), 1, matrix.get_mod());
         for (i, j) in indices.iter() {
-            let entry: Z = matrix.get_entry(*i, -1).unwrap();
+            let entry: Z = unsafe { matrix.get_entry_unchecked(*i, matrix.get_num_columns() - 1) };
             out.set_entry_unchecked(*j, 0, entry);
         }
 
@@ -123,7 +123,7 @@ impl MatZq {
         // Set all other entries in that column to `0` (gaussian elimination).
         for row_nr in (0..self.get_num_rows()).filter(|x| *x != row_nr) {
             let old_row = self.get_row(row_nr).unwrap();
-            let entry: Z = old_row.get_entry(0, column_nr).unwrap();
+            let entry: Z = unsafe { old_row.get_entry_unchecked(0, column_nr) };
             if !entry.is_zero() {
                 let new_row = &old_row - entry * &row;
                 self.set_row(row_nr, &new_row, 0).unwrap();
@@ -295,9 +295,8 @@ impl MatZq {
                 // for the system under the split modulus and use the
                 // Chinese Remainder Theorem to compute a solution based on these
                 // sub-solutions.
-                let entry: Z = matrix_identity_base_gauss
-                    .get_entry(row_nr, column_nr)
-                    .unwrap();
+                let entry: Z =
+                    unsafe { matrix_identity_base_gauss.get_entry_unchecked(row_nr, column_nr) };
                 self.factorization_and_crt(y, entry);
             }
         }
@@ -361,7 +360,7 @@ impl MatZq {
 
         let mut out = MatZq::new(self.get_num_columns(), 1, self.get_mod());
         for (current_row_x, (_row_nr, column_nr)) in indices.into_iter().enumerate() {
-            let entry: Z = x.get_entry(current_row_x, 0).unwrap();
+            let entry: Z = unsafe { x.get_entry_unchecked(current_row_x as i64, 0) };
             out.set_entry_unchecked(column_nr, 0, entry);
         }
 
@@ -387,7 +386,7 @@ fn find_invertible_entry_column(
     used_rows: &[i64],
 ) -> Option<(i64, Zq)> {
     for i in (0..matrix.get_num_rows()).filter(|x| !used_rows.contains(x)) {
-        let entry: Zq = matrix.get_entry(i, column).unwrap();
+        let entry: Zq = unsafe { matrix.get_entry_unchecked(i, column) };
         if let Ok(inv) = entry.pow(-1) {
             return Some((i, inv));
         }
@@ -408,7 +407,7 @@ fn find_invertible_entry_column(
 /// that is not 0, and `None` if there is no such element
 fn find_not_invertible_entry_column(matrix: &MatZq, column: i64, used_rows: &[i64]) -> Option<i64> {
     for i in (0..matrix.get_num_rows()).filter(|x| !used_rows.contains(x)) {
-        let entry: Zq = matrix.get_entry(i, column).unwrap();
+        let entry: Zq = unsafe { matrix.get_entry_unchecked(i, column) };
         if !entry.is_zero() {
             if let Err(_inv) = entry.pow(-1) {
                 return Some(i);

--- a/src/integer_mod_q/mat_zq/to_string.rs
+++ b/src/integer_mod_q/mat_zq/to_string.rs
@@ -108,7 +108,7 @@ impl MatZq {
         // Fill byte vector
         for row in 0..self.get_num_rows() as usize {
             for col in 0..self.get_num_columns() as usize {
-                let entry_value: Z = self.get_entry(row, col).unwrap();
+                let entry_value: Z = unsafe { self.get_entry_unchecked(row as i64, col as i64) };
                 let entry_bytes = entry_value.to_bytes();
 
                 // Find maximum length of bytes in one entry of the matrix

--- a/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
@@ -101,7 +101,7 @@ impl FromCoefficientEmbedding<&MatZq> for PolyOverZq {
         );
         let mut out = PolyOverZq::from(&embedding.get_mod());
         for i in 0..embedding.get_num_rows() {
-            let entry: Z = embedding.get_entry(i, 0).unwrap();
+            let entry: Z = unsafe { embedding.get_entry_unchecked(i, 0) };
             out.set_coeff(i, &entry).unwrap()
         }
         out

--- a/src/integer_mod_q/polynomial_ring_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/coefficient_embedding.rs
@@ -111,7 +111,7 @@ impl FromCoefficientEmbedding<(&MatZq, &ModulusPolynomialRingZq)> for Polynomial
         );
         let mut out = PolynomialRingZq::from((0, embedding.1));
         for i in 0..embedding.0.get_num_rows() {
-            let entry: Z = embedding.0.get_entry(i, 0).unwrap();
+            let entry: Z = unsafe { embedding.0.get_entry_unchecked(i, 0) };
             out.set_coeff(i, &entry).unwrap()
         }
         out

--- a/src/rational/mat_q/cholesky_decomp.rs
+++ b/src/rational/mat_q/cholesky_decomp.rs
@@ -48,7 +48,7 @@ impl MatQ {
 
         for i in 0..n {
             // get first entry and ith column
-            let a_ii = a.get_entry(0, 0).unwrap();
+            let a_ii = unsafe { a.get_entry_unchecked(0, 0) };
             assert!(a_ii > Q::ZERO, "The matrix is not positive-definite.");
             let column_a_i = match i {
                 0 => a.get_column(0).unwrap(),

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -93,7 +93,7 @@ impl GetEntry<Q> for MatQ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpq_set` can successfully clone the
         // entry of the matrix. Therefore no memory leaks can appear.
-        Ok(self.get_entry_unchecked(row_i64, column_i64))
+        Ok(unsafe { self.get_entry_unchecked(row_i64, column_i64) })
     }
 
     /// Outputs the [`Q`] value of a specific matrix entry
@@ -106,6 +106,11 @@ impl GetEntry<Q> for MatQ {
     /// Returns the [`Q`] value of the matrix at the position of the given
     /// row and column.
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::rational::{MatQ, Q};
@@ -114,14 +119,11 @@ impl GetEntry<Q> for MatQ {
     ///
     /// let matrix = MatQ::from_str("[[1, 2, 3/4],[4, 5, 6],[7, 8, 9]]").unwrap();
     ///
-    /// assert_eq!(matrix.get_entry_unchecked(0, 2), Q::from((3, 4)));
-    /// assert_eq!(matrix.get_entry_unchecked(2, 1), Q::from(8));
-    /// assert_eq!(matrix.get_entry_unchecked(2, 1), Q::from(8));
+    /// assert_eq!(unsafe { matrix.get_entry_unchecked(0, 2) }, Q::from((3, 4)));
+    /// assert_eq!(unsafe { matrix.get_entry_unchecked(2, 1) }, Q::from(8));
+    /// assert_eq!(unsafe { matrix.get_entry_unchecked(2, 1) }, Q::from(8));
     /// ```
-    ///
-    /// # Panics ...
-    /// - if `row` or `column` are greater than the matrix size.
-    fn get_entry_unchecked(&self, row: i64, column: i64) -> Q {
+    unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> Q {
         let mut copy = Q::default();
         let entry = unsafe { fmpq_mat_entry(&self.matrix, row, column) };
         unsafe { fmpq_set(&mut copy.value, entry) };

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -93,11 +93,40 @@ impl GetEntry<Q> for MatQ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpq_set` can successfully clone the
         // entry of the matrix. Therefore no memory leaks can appear.
+        Ok(self.get_entry_unchecked(row_i64, column_i64))
+    }
+
+    /// Outputs the [`Q`] value of a specific matrix entry
+    /// without checking whether it's part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located
+    /// - `column`: specifies the column in which the entry is located
+    ///
+    /// Returns the [`Q`] value of the matrix at the position of the given
+    /// row and column.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::{MatQ, Q};
+    /// use qfall_math::traits::GetEntry;
+    /// use std::str::FromStr;
+    ///
+    /// let matrix = MatQ::from_str("[[1, 2, 3/4],[4, 5, 6],[7, 8, 9]]").unwrap();
+    ///
+    /// assert_eq!(matrix.get_entry_unchecked(0, 2), Q::from((3, 4)));
+    /// assert_eq!(matrix.get_entry_unchecked(2, 1), Q::from(8));
+    /// assert_eq!(matrix.get_entry_unchecked(2, 1), Q::from(8));
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `row` or `column` are greater than the matrix size.
+    fn get_entry_unchecked(&self, row: i64, column: i64) -> Q {
         let mut copy = Q::default();
-        let entry = unsafe { fmpq_mat_entry(&self.matrix, row_i64, column_i64) };
+        let entry = unsafe { fmpq_mat_entry(&self.matrix, row, column) };
         unsafe { fmpq_set(&mut copy.value, entry) };
 
-        Ok(copy)
+        copy
     }
 }
 

--- a/src/rational/mat_q/properties.rs
+++ b/src/rational/mat_q/properties.rs
@@ -86,7 +86,9 @@ impl MatQ {
         }
         for row in 0..self.get_num_rows() {
             for column in 0..row {
-                if self.get_entry(row, column).unwrap() != self.get_entry(column, row).unwrap() {
+                if unsafe {
+                    self.get_entry_unchecked(row, column) != self.get_entry_unchecked(column, row)
+                } {
                     return false;
                 }
             }

--- a/src/rational/mat_q/rounding.rs
+++ b/src/rational/mat_q/rounding.rs
@@ -36,7 +36,7 @@ impl MatQ {
         let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns());
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
-                let entry = self.get_entry(i, j).unwrap().floor();
+                let entry = unsafe { self.get_entry_unchecked(i, j) }.floor();
                 out.set_entry_unchecked(i, j, entry);
             }
         }
@@ -62,7 +62,7 @@ impl MatQ {
         let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns());
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
-                let entry = self.get_entry(i, j).unwrap().ceil();
+                let entry = unsafe { self.get_entry_unchecked(i, j) }.ceil();
                 out.set_entry_unchecked(i, j, entry);
             }
         }
@@ -88,7 +88,7 @@ impl MatQ {
         let mut out = MatZ::new(self.get_num_rows(), self.get_num_columns());
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
-                let entry = self.get_entry(i, j).unwrap().round();
+                let entry = unsafe { self.get_entry_unchecked(i, j) }.round();
                 out.set_entry_unchecked(i, j, entry);
             }
         }
@@ -159,7 +159,7 @@ impl MatQ {
 
         for i in 0..self.get_num_rows() {
             for j in 0..self.get_num_columns() {
-                let entry = self.get_entry(i, j).unwrap();
+                let entry = unsafe { self.get_entry_unchecked(i, j) };
                 let simplified_entry = entry.simplify(&precision);
                 out.set_entry_unchecked(i, j, simplified_entry);
             }
@@ -203,7 +203,8 @@ impl MatQ {
         let n = n.into();
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
-                let entry = self.get_entry(i, j).unwrap().randomized_rounding(&r, &n)?;
+                let entry =
+                    unsafe { self.get_entry_unchecked(i, j) }.randomized_rounding(&r, &n)?;
                 out.set_entry_unchecked(i, j, entry);
             }
         }

--- a/src/rational/poly_over_q/coefficient_embedding.rs
+++ b/src/rational/poly_over_q/coefficient_embedding.rs
@@ -100,7 +100,7 @@ impl FromCoefficientEmbedding<&MatQ> for PolyOverQ {
         );
         let mut out = PolyOverQ::default();
         for i in 0..embedding.get_num_rows() {
-            out.set_coeff(i, embedding.get_entry(i, 0).unwrap())
+            out.set_coeff(i, unsafe { embedding.get_entry_unchecked(i, 0) })
                 .unwrap()
         }
         out

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -76,6 +76,15 @@ pub trait GetEntry<T> {
         row: impl TryInto<i64> + Display,
         column: impl TryInto<i64> + Display,
     ) -> Result<T, MathError>;
+
+    /// Returns the value of a specific matrix entry
+    /// without performing any checks, e.g. checking whether the entry is
+    /// part of the matrix.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row in which the entry is located.
+    /// - `column`: specifies the column in which the entry is located.
+    fn get_entry_unchecked(&self, row: i64, column: i64) -> T;
 }
 
 /// Is implemented by matrices to set entries.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -84,7 +84,12 @@ pub trait GetEntry<T> {
     /// Parameters:
     /// - `row`: specifies the row in which the entry is located.
     /// - `column`: specifies the column in which the entry is located.
-    fn get_entry_unchecked(&self, row: i64, column: i64) -> T;
+    ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> T;
 }
 
 /// Is implemented by matrices to set entries.


### PR DESCRIPTION
**Description**
This PR implements...
- [x] `get_entry_unchecked` for all matrices.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)

No additional tests required as `get_entry` now uses `get_entry_unchecked`, which makes every test for `get_entry` a test for `get_entry_unchecked`.

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide