### PR TITLE
Decimal representation for `Q`,`MatQ` and `PolyOverQ`

### DIFF
--- a/src/rational/mat_q/to_string.rs
+++ b/src/rational/mat_q/to_string.rs
@@ -12,7 +12,11 @@
 //! This includes the [`Display`](std::fmt::Display) trait.
 
 use super::MatQ;
-use crate::{macros::for_others::implement_for_owned, utils::parse::matrix_to_string};
+use crate::{
+    macros::for_others::implement_for_owned,
+    traits::{GetEntry, GetNumColumns, GetNumRows},
+    utils::parse::matrix_to_string,
+};
 use core::fmt;
 
 impl From<&MatQ> for String {
@@ -64,6 +68,121 @@ impl fmt::Display for MatQ {
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", matrix_to_string(self))
+    }
+}
+
+impl MatQ {
+    /// Outputs a representation of [`MatQ`] with the decimal representation of each entry
+    /// with the specified number of decimal digits.
+    /// If an entry can't be represented exactly, it provides the
+    /// closest value representable with `nr_decimal_digits` rounded towards zero.
+    ///
+    /// **WARNING:** This function converts any entry into an [`f64`] before
+    /// outputting the decimal representation. Thus, values that can't be represented exactly
+    /// by a [`f64`] will lose some precision. For large values, e.g. of size `2^64`
+    /// the deviation to the original value might be within the size of `1_000`.
+    ///
+    /// Parameters:
+    /// - `nr_decimal_digits`: specifies the number of decimal digits
+    ///     that will be a part of the output [`String`]
+    ///
+    /// Returns the Matrix in form of a [`String`]. For matrix `[[1/2],[5/3]]`
+    /// the String looks like this `[[0.50],[1.66]]` if `nr_decimal_digits = 2`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::MatQ;
+    /// use std::str::FromStr;
+    /// let matrix = MatQ::from_str("[[5/2, 2],[-2/3, 4/3]]").unwrap();
+    ///
+    /// let decimal_repr = matrix.to_string_decimal(3);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if any entry of the matrix can't be represented as a [`f64`].
+    pub fn to_string_decimal(&self, nr_decimal_digits: usize) -> String {
+        let mut matrix_string = String::from("[");
+        let nr_rows = self.get_num_rows() - 1;
+        let nr_cols = self.get_num_columns() - 1;
+
+        for row in 0..nr_rows {
+            matrix_string.push('[');
+            for column in 0..nr_cols {
+                self.get_entry_and_push_str(&mut matrix_string, row, column, nr_decimal_digits);
+                matrix_string.push_str(", ");
+            }
+            self.get_entry_and_push_str(&mut matrix_string, row, nr_cols, nr_decimal_digits);
+            matrix_string.push_str("],\n");
+        }
+        matrix_string.push('[');
+        for column in 0..nr_cols {
+            self.get_entry_and_push_str(&mut matrix_string, nr_rows, column, nr_decimal_digits);
+            matrix_string.push_str(", ");
+        }
+        self.get_entry_and_push_str(&mut matrix_string, nr_rows, nr_cols, nr_decimal_digits);
+        matrix_string.push_str("]]");
+
+        matrix_string
+    }
+
+    /// Helper function to assemble a [`String`] for a matrix easily.
+    ///
+    /// Parameters:
+    /// - `matrix_string`: [`String`] to append the decimal representation of the matrices entry
+    /// - `row`: specifies the row, in which the desired entry is located
+    /// - `column`: specifies the column, in which the desired entry is located
+    /// - `nr_decimal_digits`: specifies how many digits the decimal representation of the entry should have
+    ///
+    /// # Examples
+    /// ```compile_fail
+    /// use qfall_math::rational::MatQ;
+    /// use std::str::FromStr;
+    /// let matrix = MatQ::from_str("[[5/2, 2],[-2/3, 4/3]]").unwrap();
+    /// let mut matrix_string = String::from("[[");
+    ///
+    /// matrix.get_entry_and_push_str(&mut matrix_string, 0, 0, 2);
+    ///
+    /// assert_eq!("[[2.50", matrix_string);
+    /// ```
+    fn get_entry_and_push_str(
+        &self,
+        matrix_string: &mut String,
+        row: i64,
+        column: i64,
+        nr_decimal_digits: usize,
+    ) {
+        // exchange with `get_entry_unchecked` once changes are on dev
+        let entry = self.get_entry(row, column).unwrap();
+        let entry_string = entry.to_string_decimal(nr_decimal_digits);
+        matrix_string.push_str(&entry_string);
+    }
+}
+
+#[cfg(test)]
+mod test_to_string_decimal {
+    use super::MatQ;
+    use std::str::FromStr;
+
+    /// Ensures that [`MatQ::to_string_decimal`] works for matrices of different dimensions.
+    #[test]
+    fn dimensions() {
+        let a = MatQ::from_str("[[3/2, 1/2],[-1, -7/3]]").unwrap();
+        let b = MatQ::from_str("[[3/2],[-7/3]]").unwrap();
+        let c = MatQ::from_str("[[3/2, 1/2, -7/3]]").unwrap();
+
+        let a_0 = a.to_string_decimal(0);
+        let a_1 = a.to_string_decimal(1);
+        let b_0 = b.to_string_decimal(0);
+        let b_2 = b.to_string_decimal(2);
+        let c_0 = c.to_string_decimal(0);
+        let c_1 = c.to_string_decimal(1);
+
+        assert_eq!("[[1, 0],\n[-1, -2]]", a_0);
+        assert_eq!("[[1.5, 0.5],\n[-1.0, -2.3]]", a_1);
+        assert_eq!("[[1],\n[-2]]", b_0);
+        assert_eq!("[[1.50],\n[-2.33]]", b_2);
+        assert_eq!("[[1, 0, -2]]", c_0);
+        assert_eq!("[[1.5, 0.5, -2.3]]", c_1);
     }
 }
 

--- a/src/rational/mat_q/to_string.rs
+++ b/src/rational/mat_q/to_string.rs
@@ -99,7 +99,7 @@ impl MatQ {
     /// ```
     ///
     /// # Panics ...
-    /// - if any entry of the matrix can't be represented as a [`f64`].
+    /// - if any entry of the matrix can't be represented as an [`f64`].
     pub fn to_string_decimal(&self, nr_decimal_digits: usize) -> String {
         let mut matrix_string = String::from("[");
         let nr_rows = self.get_num_rows() - 1;

--- a/src/rational/mat_q/to_string.rs
+++ b/src/rational/mat_q/to_string.rs
@@ -77,7 +77,7 @@ impl MatQ {
     /// If an entry can't be represented exactly, it provides the
     /// closest value representable with `nr_decimal_digits` rounded towards zero.
     ///
-    /// **WARNING:** This function converts any entry into an [`f64`] before
+    /// **WARNING:** This function converts every entry into an [`f64`] before
     /// outputting the decimal representation. Thus, values that can't be represented exactly
     /// by a [`f64`] will lose some precision. For large values, e.g. of size `2^64`
     /// the deviation to the original value might be within the size of `1_000`.
@@ -86,8 +86,8 @@ impl MatQ {
     /// - `nr_decimal_digits`: specifies the number of decimal digits
     ///     that will be a part of the output [`String`]
     ///
-    /// Returns the Matrix in form of a [`String`]. For matrix `[[1/2],[5/3]]`
-    /// the String looks like this `[[0.50],[1.66]]` if `nr_decimal_digits = 2`.
+    /// Returns the matrix in form of a [`String`]. For matrix `[[1/2],[5/3]]`
+    /// the [`String`] looks like this `[[0.50],[1.66]]` if `nr_decimal_digits = 2`.
     ///
     /// # Examples
     /// ```
@@ -158,6 +158,7 @@ impl MatQ {
     }
 }
 
+/// This module avoids tests already performed for [`crate::rational::Q::to_string_decimal`].
 #[cfg(test)]
 mod test_to_string_decimal {
     use super::MatQ;

--- a/src/rational/poly_over_q/to_string.rs
+++ b/src/rational/poly_over_q/to_string.rs
@@ -12,7 +12,7 @@
 //! This includes the [`Display`](std::fmt::Display) trait.
 
 use super::PolyOverQ;
-use crate::macros::for_others::implement_for_owned;
+use crate::{macros::for_others::implement_for_owned, traits::GetCoefficient};
 use core::fmt;
 use flint_sys::fmpq_poly::fmpq_poly_get_str;
 use std::ffi::CStr;
@@ -66,6 +66,83 @@ impl fmt::Display for PolyOverQ {
         // free the space allocated by the pointer
         unsafe { libc::free(c_str_ptr as *mut libc::c_void) };
         write!(f, "{return_str}")
+    }
+}
+
+impl PolyOverQ {
+    /// Outputs a representation of [`PolyOverQ`] with the decimal representation
+    /// of each coefficient with the specified number of decimal digits.
+    /// If a coefficient can't be represented exactly, it provides the
+    /// closest value representable with `nr_decimal_digits` rounded towards zero.
+    ///
+    /// **WARNING:** This function converts every coefficient into an [`f64`] before
+    /// outputting the decimal representation. Thus, values that can't be represented exactly
+    /// by a [`f64`] will lose some precision. For large values, e.g. of size `2^64`
+    /// the deviation to the original value might be within the size of `1_000`.
+    ///
+    /// Parameters:
+    /// - `nr_decimal_digits`: specifies the number of decimal digits
+    ///     that will be a part of the output [`String`]
+    ///
+    /// Returns the polynomial in form of a [`String`]. For polynomial `2  1/2 5/3`
+    /// the [`String`] looks like this `2  0.50 1.66` if `nr_decimal_digits = 2`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::PolyOverQ;
+    /// use std::str::FromStr;
+    /// let poly = PolyOverQ::from_str("4  5/2 2 -2/3 4/3").unwrap();
+    ///
+    /// let decimal_repr = poly.to_string_decimal(3);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if any entry of the polynomial can't be represented as a [`f64`].
+    pub fn to_string_decimal(&self, nr_decimal_digits: usize) -> String {
+        let degree = self.get_degree() + 1;
+        let mut poly_string = format!("{degree}  ");
+
+        for i in 0..degree {
+            // swap with get_coeff_unchecked once available
+            let entry = self.get_coeff(i).unwrap();
+            let entry_string = entry.to_string_decimal(nr_decimal_digits);
+
+            poly_string.push_str(&entry_string);
+            poly_string.push(' ');
+        }
+        poly_string = poly_string.trim().to_string();
+
+        poly_string
+    }
+}
+
+/// This module avoids tests already performed for [`crate::rational::Q::to_string_decimal`].
+#[cfg(test)]
+mod test_to_string_decimal {
+    use super::PolyOverQ;
+    use std::str::FromStr;
+
+    /// Ensures that [`PolyOverQ::to_string_decimal`] works for different degrees
+    /// and different `nr_decimal_digits`.
+    #[test]
+    fn different_degrees() {
+        let a = PolyOverQ::from_str("0").unwrap();
+        let b = PolyOverQ::from_str("1  1/3").unwrap();
+        let c = PolyOverQ::from_str("3  1/3 0 -5/3").unwrap();
+
+        let a_0 = a.to_string_decimal(0);
+        let a_1 = a.to_string_decimal(1);
+        let b_0 = b.to_string_decimal(0);
+        let b_2 = b.to_string_decimal(2);
+        let c_0 = c.to_string_decimal(0);
+        let c_1 = c.to_string_decimal(1);
+
+        assert_eq!("0", a_0);
+        assert_eq!("0", a_1);
+        assert_eq!("1  0", b_0);
+        assert_eq!("1  0.33", b_2);
+        assert_eq!("3  0 0 -1", c_0);
+        assert_eq!("3  0.3 0.0 -1.6", c_1);
     }
 }
 

--- a/src/rational/q/to_string.rs
+++ b/src/rational/q/to_string.rs
@@ -83,6 +83,132 @@ impl fmt::Display for Q {
     }
 }
 
+impl Q {
+    /// Outputs the decimal representation of a [`Q`] with
+    /// the specified number of decimal digits.
+    /// If `self` can't be represented exactly, it provides to the
+    /// closest value representable with `nr_decimal_digits` rounded towards zero.
+    ///
+    /// **WARNING:** This function converts the [`Q`] value into an [`f64`] before
+    /// outputting the decimal representation. Thus, values that can't be represented exactly
+    /// by a [`f64`] will lose some precision. For large values, e.g. of size `2^64`
+    /// the deviation to the original value might be within the size of `1_000`.
+    ///
+    /// Parameters:
+    /// - `nr_decimal_digits`: specifies the number of decimal digits
+    ///     that will be a part of the output [`String`]
+    ///
+    /// Returns a [`String`] of the form `"10.25"` if `nr_decimal_digits = 2`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::rational::Q;
+    /// use std::str::FromStr;
+    /// let rational = Q::from_str("6/7").unwrap();
+    ///
+    /// let decimal_repr = rational.to_string_decimal(3);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `self` can't be represented as a [`f64`].
+    pub fn to_string_decimal(&self, nr_decimal_digits: usize) -> String {
+        let value = f64::from(self);
+        let mut string = value.to_string();
+        let index_of_dot = string.find(".");
+
+        match (index_of_dot, nr_decimal_digits) {
+            (Some(index), 0) => string.truncate(index + nr_decimal_digits),
+            (Some(index), _) => {
+                if index + nr_decimal_digits + 1 > string.len() {
+                    string.push_str(&str::repeat(
+                        "0",
+                        index + nr_decimal_digits + 1 - string.len(),
+                    ));
+                } else {
+                    string.truncate(index + nr_decimal_digits + 1);
+                }
+            }
+            (None, 0) => (),
+            (None, _) => string.push_str(&format!(".{}", str::repeat("0", nr_decimal_digits))),
+        }
+
+        string
+    }
+}
+
+#[cfg(test)]
+mod test_to_string_decimal {
+    use super::Q;
+
+    /// Ensures that [`Q::to_string_decimal`] works for integer values as intended.
+    #[test]
+    fn integer() {
+        let a = Q::from((5, 1));
+        let b = Q::from((256, 8));
+        let c = Q::from((-1, 1));
+
+        let a_0 = a.to_string_decimal(0);
+        let a_1 = a.to_string_decimal(1);
+        let a_2 = a.to_string_decimal(2);
+        let b_0 = b.to_string_decimal(0);
+        let b_1 = b.to_string_decimal(1);
+        let b_5 = b.to_string_decimal(5);
+        let c_0 = c.to_string_decimal(0);
+        let c_1 = c.to_string_decimal(1);
+        let c_2 = c.to_string_decimal(2);
+
+        assert_eq!("5", a_0);
+        assert_eq!("5.0", a_1);
+        assert_eq!("5.00", a_2);
+        assert_eq!("32", b_0);
+        assert_eq!("32.0", b_1);
+        assert_eq!("32.00000", b_5);
+        assert_eq!("-1", c_0);
+        assert_eq!("-1.0", c_1);
+        assert_eq!("-1.00", c_2);
+    }
+
+    /// Ensures that [`Q::to_string_decimal`] works for rational / non-integer values as intended.
+    #[test]
+    fn non_integer() {
+        let a = Q::from((2, 3));
+        let b = Q::from((21, 2));
+        let c = Q::from((-1, 3));
+
+        let a_0 = a.to_string_decimal(0);
+        let a_1 = a.to_string_decimal(1);
+        let a_2 = a.to_string_decimal(2);
+        let b_0 = b.to_string_decimal(0);
+        let b_1 = b.to_string_decimal(1);
+        let b_2 = b.to_string_decimal(2);
+        let c_0 = c.to_string_decimal(0);
+        let c_1 = c.to_string_decimal(1);
+        let c_2 = c.to_string_decimal(2);
+
+        assert_eq!("0", a_0);
+        assert_eq!("0.6", a_1);
+        assert_eq!("0.66", a_2);
+        assert_eq!("10", b_0);
+        assert_eq!("10.5", b_1);
+        assert_eq!("10.50", b_2);
+        assert_eq!("-0", c_0);
+        assert_eq!("-0.3", c_1);
+        assert_eq!("-0.33", c_2);
+    }
+
+    /// Ensures that [`Q::to_string_decimal`] works for large numbers.
+    #[test]
+    fn large_number() {
+        let a = Q::from((i64::MAX, 1));
+
+        let a_0 = a.to_string_decimal(0);
+        let a_1 = a.to_string_decimal(1);
+
+        assert_eq!("9223372036854775000", a_0); // deviation of 807 from original value
+        assert_eq!("9223372036854775000.0", a_1);
+    }
+}
+
 #[cfg(test)]
 mod test_to_string {
     use crate::rational::Q;

--- a/src/rational/q/to_string.rs
+++ b/src/rational/q/to_string.rs
@@ -91,7 +91,7 @@ impl Q {
     ///
     /// **WARNING:** This function converts the [`Q`] value into an [`f64`] before
     /// outputting the decimal representation. Thus, values that can't be represented exactly
-    /// by a [`f64`] will lose some precision. For large values, e.g. of size `2^64`
+    /// by an [`f64`] will lose some precision. For large values, e.g. of size `2^64`
     /// the deviation to the original value might be within the size of `1_000`.
     ///
     /// Parameters:
@@ -110,7 +110,7 @@ impl Q {
     /// ```
     ///
     /// # Panics ...
-    /// - if `self` can't be represented as a [`f64`].
+    /// - if `self` can't be represented as an [`f64`].
     pub fn to_string_decimal(&self, nr_decimal_digits: usize) -> String {
         let value = f64::from(self);
         let mut string = value.to_string();

--- a/src/rational/q/to_string.rs
+++ b/src/rational/q/to_string.rs
@@ -86,7 +86,7 @@ impl fmt::Display for Q {
 impl Q {
     /// Outputs the decimal representation of a [`Q`] with
     /// the specified number of decimal digits.
-    /// If `self` can't be represented exactly, it provides to the
+    /// If `self` can't be represented exactly, it provides the
     /// closest value representable with `nr_decimal_digits` rounded towards zero.
     ///
     /// **WARNING:** This function converts the [`Q`] value into an [`f64`] before


### PR DESCRIPTION
**Description**
This PR implements...
- [x] to_string_decimal for `Q`, `MatQ` and `PolyOverQ` with specifiable number of decimal digits

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide