### PR TITLE
Make `set_entry_unchecked` unsafe

### DIFF
--- a/src/integer/mat_poly_over_z/coefficient_embedding.rs
+++ b/src/integer/mat_poly_over_z/coefficient_embedding.rs
@@ -70,7 +70,7 @@ impl IntoCoefficientEmbedding<MatZ> for &MatPolyOverZ {
 
                 for index in 0..size {
                     let coeff: Z = entry.get_coeff(index).unwrap();
-                    out.set_entry_unchecked(row * size + index, column, coeff)
+                    unsafe { out.set_entry_unchecked(row * size + index, column, coeff) }
                 }
             }
         }
@@ -132,7 +132,7 @@ impl FromCoefficientEmbedding<(&MatZ, i64)> for MatPolyOverZ {
                     };
                     poly.set_coeff(index, coeff).unwrap();
                 }
-                out.set_entry_unchecked(row, column, poly);
+                unsafe { out.set_entry_unchecked(row, column, poly) };
             }
         }
 

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -113,11 +113,13 @@ impl From<&MatZ> for MatPolyOverZ {
 
         for row in 0..num_rows {
             for column in 0..num_columns {
-                out.set_entry_unchecked(
-                    row,
-                    column,
-                    PolyOverZ::from(unsafe { matrix.get_entry_unchecked(row, column) }),
-                );
+                unsafe {
+                    out.set_entry_unchecked(
+                        row,
+                        column,
+                        PolyOverZ::from(unsafe { matrix.get_entry_unchecked(row, column) }),
+                    )
+                };
             }
         }
 

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -117,7 +117,7 @@ impl From<&MatZ> for MatPolyOverZ {
                     out.set_entry_unchecked(
                         row,
                         column,
-                        PolyOverZ::from(unsafe { matrix.get_entry_unchecked(row, column) }),
+                        PolyOverZ::from(matrix.get_entry_unchecked(row, column)),
                     )
                 };
             }

--- a/src/integer/mat_poly_over_z/sample/binomial.rs
+++ b/src/integer/mat_poly_over_z/sample/binomial.rs
@@ -114,7 +114,7 @@ impl MatPolyOverZ {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = PolyOverZ::sample_binomial_with_offset(max_degree, &offset, &n, &p)?;
-                matrix.set_entry_unchecked(row, col, sample);
+                unsafe { matrix.set_entry_unchecked(row, col, sample) };
             }
         }
 

--- a/src/integer/mat_poly_over_z/sample/uniform.rs
+++ b/src/integer/mat_poly_over_z/sample/uniform.rs
@@ -72,7 +72,7 @@ impl MatPolyOverZ {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = PolyOverZ::sample_uniform(max_degree, &lower_bound, &upper_bound)?;
-                matrix.set_entry_unchecked(row, col, sample);
+                unsafe { matrix.set_entry_unchecked(row, col, sample) };
             }
         }
 

--- a/src/integer/mat_poly_over_z/set.rs
+++ b/src/integer/mat_poly_over_z/set.rs
@@ -69,7 +69,7 @@ impl SetEntry<&PolyOverZ> for MatPolyOverZ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpz_set` can successfully clone the
         // value inside the matrix. Therefore no memory leaks can appear.
-        self.set_entry_unchecked(row_i64, column_i64, value);
+        unsafe { self.set_entry_unchecked(row_i64, column_i64, value) };
 
         Ok(())
     }
@@ -82,6 +82,11 @@ impl SetEntry<&PolyOverZ> for MatPolyOverZ {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer::{MatPolyOverZ, PolyOverZ};
@@ -91,12 +96,14 @@ impl SetEntry<&PolyOverZ> for MatPolyOverZ {
     /// let mut matrix = MatPolyOverZ::new(2, 2);
     /// let value = PolyOverZ::from_str("2  1 1").unwrap();
     ///
-    /// matrix.set_entry_unchecked(0, 1, &value);
-    /// matrix.set_entry_unchecked(1, 0, &PolyOverZ::from(2));
+    /// unsafe {
+    ///     matrix.set_entry_unchecked(0, 1, &value);
+    ///     matrix.set_entry_unchecked(1, 0, &PolyOverZ::from(2));
+    /// }
     ///
     /// assert_eq!("[[0, 2  1 1],[1  2, 0]]", matrix.to_string());
     /// ```
-    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &PolyOverZ) {
+    unsafe fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &PolyOverZ) {
         unsafe {
             let entry = fmpz_poly_mat_entry(&self.matrix, row, column);
             fmpz_poly_set(entry, &value.poly)

--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -127,7 +127,7 @@ impl MatZ {
                     &byte_vector[offset_row + nr_bytes_per_entry * col
                         ..offset_row + nr_bytes_per_entry * (col + 1)],
                 );
-                mat.set_entry_unchecked(row as i64, col as i64, entry_value);
+                unsafe { mat.set_entry_unchecked(row as i64, col as i64, entry_value) };
             }
         }
 

--- a/src/integer/mat_z/sample/binomial.rs
+++ b/src/integer/mat_z/sample/binomial.rs
@@ -109,7 +109,7 @@ impl MatZ {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = sample_binomial(&n, &p)?;
-                matrix.set_entry_unchecked(row, col, &offset + sample);
+                unsafe { matrix.set_entry_unchecked(row, col, &offset + sample) };
             }
         }
 

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -66,7 +66,7 @@ impl MatZ {
         for row in 0..out.get_num_rows() {
             for col in 0..out.get_num_columns() {
                 let sample = dgis.sample_z();
-                out.set_entry_unchecked(row, col, sample);
+                unsafe { out.set_entry_unchecked(row, col, sample) };
             }
         }
 

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -66,7 +66,7 @@ impl MatZ {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = uis.sample();
-                matrix.set_entry_unchecked(row, col, &lower_bound + sample);
+                unsafe { matrix.set_entry_unchecked(row, col, &lower_bound + sample) };
             }
         }
 

--- a/src/integer/mat_z/set.rs
+++ b/src/integer/mat_z/set.rs
@@ -72,7 +72,7 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpz_set` can successfully clone the
         // value inside the matrix. Therefore no memory leaks can appear.
-        self.set_entry_unchecked(row_i64, column_i64, value);
+        unsafe { self.set_entry_unchecked(row_i64, column_i64, value) };
 
         Ok(())
     }
@@ -85,6 +85,11 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZ {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer::{MatZ, Z};
@@ -92,12 +97,14 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZ {
     ///
     /// let mut matrix = MatZ::new(3, 3);
     ///
-    /// matrix.set_entry_unchecked(0, 1, 5);
-    /// matrix.set_entry_unchecked(2, 2, 9);
+    /// unsafe {
+    ///     matrix.set_entry_unchecked(0, 1, 5);
+    ///     matrix.set_entry_unchecked(2, 2, 9);
+    /// }
     ///
     /// assert_eq!("[[0, 5, 0],[0, 0, 0],[0, 0, 9]]", matrix.to_string());
     /// ```
-    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: Integer) {
+    unsafe fn set_entry_unchecked(&mut self, row: i64, column: i64, value: Integer) {
         let value: Z = value.into();
 
         unsafe {

--- a/src/integer/poly_over_z/coefficient_embedding.rs
+++ b/src/integer/poly_over_z/coefficient_embedding.rs
@@ -58,7 +58,7 @@ impl IntoCoefficientEmbedding<MatZ> for &PolyOverZ {
         let mut out = MatZ::new(size, 1);
         for j in 0..size {
             let coeff = self.get_coeff(j).unwrap();
-            out.set_entry_unchecked(j, 0, coeff);
+            unsafe { out.set_entry_unchecked(j, 0, coeff) };
         }
 
         out

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -73,6 +73,11 @@ impl SetEntry<&PolyOverZ> for MatPolynomialRingZq {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
@@ -85,13 +90,15 @@ impl SetEntry<&PolyOverZ> for MatPolynomialRingZq {
     /// let mut poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
     /// let value = PolyOverZ::default();
     ///
-    /// poly_ring_mat.set_entry_unchecked(0, 1, &value);
-    /// poly_ring_mat.set_entry_unchecked(1, 1, &value);
+    /// unsafe {
+    ///     poly_ring_mat.set_entry_unchecked(0, 1, &value);
+    ///     poly_ring_mat.set_entry_unchecked(1, 1, &value);
+    /// }
     ///
     /// let mat_cmp = MatPolynomialRingZq::from((&MatPolyOverZ::new(2, 2), &modulus));
     /// assert_eq!(poly_ring_mat, mat_cmp);
     /// ```
-    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &PolyOverZ) {
+    unsafe fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &PolyOverZ) {
         unsafe {
             let entry = fmpz_poly_mat_entry(&self.matrix.matrix, row, column);
             fmpz_poly_set(entry, &value.poly)
@@ -154,7 +161,7 @@ impl SetEntry<&PolynomialRingZq> for MatPolynomialRingZq {
 
         let (row_i64, column_i64) = evaluate_indices_for_matrix(self, row, column)?;
 
-        self.set_entry_unchecked(row_i64, column_i64, value);
+        unsafe { self.set_entry_unchecked(row_i64, column_i64, value) };
 
         Ok(())
     }
@@ -166,6 +173,11 @@ impl SetEntry<&PolynomialRingZq> for MatPolynomialRingZq {
     /// - `row`: specifies the row in which the entry is located
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
+    ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
     ///
     /// # Examples
     /// ```
@@ -179,13 +191,15 @@ impl SetEntry<&PolynomialRingZq> for MatPolynomialRingZq {
     /// let mut poly_ring_mat = MatPolynomialRingZq::from((&poly_mat, &modulus));
     /// let value = PolynomialRingZq::from((&PolyOverZ::default(), &modulus));
     ///
-    /// poly_ring_mat.set_entry_unchecked(0, 1, &value);
-    /// poly_ring_mat.set_entry_unchecked(1, 1, &value);
+    /// unsafe {
+    ///     poly_ring_mat.set_entry_unchecked(0, 1, &value);
+    ///     poly_ring_mat.set_entry_unchecked(1, 1, &value);
+    /// }
     ///
     /// let mat_cmp = MatPolynomialRingZq::from((&MatPolyOverZ::new(2, 2), &modulus));
     /// assert_eq!(poly_ring_mat, mat_cmp);
     /// ```
-    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &PolynomialRingZq) {
+    unsafe fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &PolynomialRingZq) {
         unsafe {
             let entry = fmpz_poly_mat_entry(&self.matrix.matrix, row, column);
             fmpz_poly_set(entry, &value.poly.poly)

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -230,7 +230,7 @@ impl MatZq {
                         ..offset_row + nr_bytes_per_entry * (col + 1)],
                 );
                 if modulus_as_z > entry_value {
-                    mat.set_entry_unchecked(row as i64, col as i64, entry_value);
+                    unsafe { mat.set_entry_unchecked(row as i64, col as i64, entry_value) };
                 } else {
                     return Err(MathError::ConversionError(
                         "The provided modulus is smaller than the UTF8-Encoding of your message."

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -92,9 +92,9 @@ impl MatZq {
 
                 // Not using Zq::distance for performance reasons.
                 if entry > modulus_half {
-                    out.set_entry_unchecked(row, column, entry - &modulus);
+                    unsafe { out.set_entry_unchecked(row, column, entry - &modulus) };
                 } else {
-                    out.set_entry_unchecked(row, column, entry);
+                    unsafe { out.set_entry_unchecked(row, column, entry) };
                 }
             }
         }

--- a/src/integer_mod_q/mat_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_zq/sample/binomial.rs
@@ -116,7 +116,7 @@ impl MatZq {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = sample_binomial(&n, &p)?;
-                matrix.set_entry_unchecked(row, col, &offset + sample);
+                unsafe { matrix.set_entry_unchecked(row, col, &offset + sample) };
             }
         }
 

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -69,7 +69,7 @@ impl MatZq {
         for row in 0..out.get_num_rows() {
             for col in 0..out.get_num_columns() {
                 let sample = dgis.sample_z();
-                out.set_entry_unchecked(row, col, sample);
+                unsafe { out.set_entry_unchecked(row, col, sample) };
             }
         }
 

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -55,7 +55,7 @@ impl MatZq {
         for row in 0..matrix.get_num_rows() {
             for col in 0..matrix.get_num_columns() {
                 let sample = uis.sample();
-                matrix.set_entry_unchecked(row, col, sample);
+                unsafe { matrix.set_entry_unchecked(row, col, sample) };
             }
         }
 

--- a/src/integer_mod_q/mat_zq/set.rs
+++ b/src/integer_mod_q/mat_zq/set.rs
@@ -84,6 +84,11 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZq {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::MatZq;
@@ -91,12 +96,14 @@ impl<Integer: Into<Z>> SetEntry<Integer> for MatZq {
     ///
     /// let mut matrix = MatZq::new(3, 3, 10);
     ///
-    /// matrix.set_entry_unchecked(0, 1, 5);
-    /// matrix.set_entry_unchecked(2, 2, 19);
+    /// unsafe {
+    ///     matrix.set_entry_unchecked(0, 1, 5);
+    ///     matrix.set_entry_unchecked(2, 2, 19);
+    /// }
     ///
     /// assert_eq!("[[0, 5, 0],[0, 0, 0],[0, 0, 19]] mod 10", matrix.to_string());
     /// ```
-    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: Integer) {
+    unsafe fn set_entry_unchecked(&mut self, row: i64, column: i64, value: Integer) {
         let value: Z = value.into();
 
         unsafe {
@@ -157,7 +164,7 @@ impl SetEntry<&Zq> for MatZq {
             )));
         }
 
-        self.set_entry_unchecked(row_i64, column_i64, value);
+        unsafe { self.set_entry_unchecked(row_i64, column_i64, value) };
 
         Ok(())
     }
@@ -171,6 +178,11 @@ impl SetEntry<&Zq> for MatZq {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::{MatZq, Zq};
@@ -179,12 +191,14 @@ impl SetEntry<&Zq> for MatZq {
     /// let mut matrix = MatZq::new(3, 3, 10);
     /// let value = Zq::from((5, 10));
     ///
-    /// matrix.set_entry_unchecked(0, 1, &value);
-    /// matrix.set_entry_unchecked(2, 2, Zq::from((19, 10)));
+    /// unsafe {
+    ///     matrix.set_entry_unchecked(0, 1, &value);
+    ///     matrix.set_entry_unchecked(2, 2, Zq::from((19, 10)));
+    /// }
     ///
     /// assert_eq!("[[0, 5, 0],[0, 0, 0],[0, 0, 9]] mod 10", matrix.to_string());
     /// ```
-    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &Zq) {
+    unsafe fn set_entry_unchecked(&mut self, row: i64, column: i64, value: &Zq) {
         unsafe {
             // get entry and replace the pointed at value with the specified value
             fmpz_mod_mat_set_entry(&mut self.matrix, row, column, &value.value.value)

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -101,7 +101,7 @@ impl MatZq {
         let mut out = MatZq::new(self.get_num_columns(), 1, matrix.get_mod());
         for (i, j) in indices.iter() {
             let entry: Z = unsafe { matrix.get_entry_unchecked(*i, matrix.get_num_columns() - 1) };
-            out.set_entry_unchecked(*j, 0, entry);
+            unsafe { out.set_entry_unchecked(*j, 0, entry) };
         }
 
         Some(out)
@@ -361,7 +361,7 @@ impl MatZq {
         let mut out = MatZq::new(self.get_num_columns(), 1, self.get_mod());
         for (current_row_x, (_row_nr, column_nr)) in indices.into_iter().enumerate() {
             let entry: Z = unsafe { x.get_entry_unchecked(current_row_x as i64, 0) };
-            out.set_entry_unchecked(column_nr, 0, entry);
+            unsafe { out.set_entry_unchecked(column_nr, 0, entry) };
         }
 
         Some(out)

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/coefficient_embedding.rs
@@ -57,7 +57,7 @@ impl IntoCoefficientEmbedding<MatZq> for &ModulusPolynomialRingZq {
         for j in 0..size {
             let coeff: Result<Z, _> = self.get_coeff(j);
             match coeff {
-                Ok(value) => out.set_entry_unchecked(j, 0, value),
+                Ok(value) => unsafe { out.set_entry_unchecked(j, 0, value) },
                 Err(_) => break,
             }
         }

--- a/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
@@ -59,7 +59,7 @@ impl IntoCoefficientEmbedding<MatZq> for &PolyOverZq {
         let mut out = MatZq::new(size, 1, &self.modulus);
         for j in 0..size {
             let coeff: Z = self.get_coeff(j).unwrap();
-            out.set_entry_unchecked(j, 0, coeff);
+            unsafe { out.set_entry_unchecked(j, 0, coeff) };
         }
 
         out

--- a/src/integer_mod_q/polynomial_ring_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/coefficient_embedding.rs
@@ -62,7 +62,7 @@ impl IntoCoefficientEmbedding<(MatZq, ModulusPolynomialRingZq)> for &PolynomialR
         let mut out = MatZq::new(size, 1, self.modulus.get_q());
         for j in 0..size {
             let coeff: Z = self.get_coeff(j).unwrap();
-            out.set_entry_unchecked(j, 0, coeff);
+            unsafe { out.set_entry_unchecked(j, 0, coeff) };
         }
 
         (out, self.modulus.clone())

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -202,7 +202,7 @@ macro_rules! implement_for_owned {
                 }
 
                 #[doc = "Documentation can be found at [`" $type "::set_entry`] for &[`" $source_type "`]."]
-                fn set_entry_unchecked(
+                unsafe fn set_entry_unchecked(
                     &mut self,
                     row: i64,
                     column: i64,

--- a/src/rational/mat_q/cholesky_decomp.rs
+++ b/src/rational/mat_q/cholesky_decomp.rs
@@ -141,7 +141,7 @@ impl MatQ {
         let mut res = MatQ::new(mat_dimension, mat_dimension);
         for (i, row) in out.iter().enumerate().take(mat_dimension) {
             for (j, entry) in row.iter().enumerate().take(mat_dimension) {
-                res.set_entry_unchecked(i as i64, j as i64, *entry);
+                unsafe { res.set_entry_unchecked(i as i64, j as i64, *entry) };
             }
         }
 

--- a/src/rational/mat_q/rounding.rs
+++ b/src/rational/mat_q/rounding.rs
@@ -37,7 +37,7 @@ impl MatQ {
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
                 let entry = unsafe { self.get_entry_unchecked(i, j) }.floor();
-                out.set_entry_unchecked(i, j, entry);
+                unsafe { out.set_entry_unchecked(i, j, entry) };
             }
         }
         out
@@ -63,7 +63,7 @@ impl MatQ {
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
                 let entry = unsafe { self.get_entry_unchecked(i, j) }.ceil();
-                out.set_entry_unchecked(i, j, entry);
+                unsafe { out.set_entry_unchecked(i, j, entry) };
             }
         }
         out
@@ -89,7 +89,7 @@ impl MatQ {
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
                 let entry = unsafe { self.get_entry_unchecked(i, j) }.round();
-                out.set_entry_unchecked(i, j, entry);
+                unsafe { out.set_entry_unchecked(i, j, entry) };
             }
         }
         out
@@ -161,7 +161,7 @@ impl MatQ {
             for j in 0..self.get_num_columns() {
                 let entry = unsafe { self.get_entry_unchecked(i, j) };
                 let simplified_entry = entry.simplify(&precision);
-                out.set_entry_unchecked(i, j, simplified_entry);
+                unsafe { out.set_entry_unchecked(i, j, simplified_entry) };
             }
         }
 
@@ -205,7 +205,7 @@ impl MatQ {
             for j in 0..out.get_num_columns() {
                 let entry =
                     unsafe { self.get_entry_unchecked(i, j) }.randomized_rounding(&r, &n)?;
-                out.set_entry_unchecked(i, j, entry);
+                unsafe { out.set_entry_unchecked(i, j, entry) };
             }
         }
         Ok(out)

--- a/src/rational/mat_q/sample/gauss.rs
+++ b/src/rational/mat_q/sample/gauss.rs
@@ -46,7 +46,7 @@ impl MatQ {
             for j in 0..out.get_num_columns() {
                 let center_entry_ij = center.get_entry(i, j)?;
                 let sample = Q::sample_gauss(center_entry_ij, sigma)?;
-                out.set_entry_unchecked(i, j, sample);
+                unsafe { out.set_entry_unchecked(i, j, sample) };
             }
         }
 
@@ -94,7 +94,7 @@ impl MatQ {
         for i in 0..out.get_num_rows() {
             for j in 0..out.get_num_columns() {
                 let sample = Q::sample_gauss(&center, sigma)?;
-                out.set_entry_unchecked(i, j, sample);
+                unsafe { out.set_entry_unchecked(i, j, sample) };
             }
         }
 

--- a/src/rational/mat_q/set.rs
+++ b/src/rational/mat_q/set.rs
@@ -76,7 +76,7 @@ impl<Rational: Into<Q>> SetEntry<Rational> for MatQ {
         // are previously checked to be inside of the matrix, no errors
         // appear inside of `unsafe` and `fmpq_set` can successfully clone the
         // value inside the matrix. Therefore no memory leaks can appear.
-        self.set_entry_unchecked(row_i64, column_i64, value);
+        unsafe { self.set_entry_unchecked(row_i64, column_i64, value) };
 
         Ok(())
     }
@@ -89,6 +89,11 @@ impl<Rational: Into<Q>> SetEntry<Rational> for MatQ {
     /// - `column`: specifies the column in which the entry is located
     /// - `value`: specifies the value to which the entry is set
     ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    ///
     /// # Examples
     /// ```
     /// use qfall_math::rational::MatQ;
@@ -98,13 +103,15 @@ impl<Rational: Into<Q>> SetEntry<Rational> for MatQ {
     /// let mut matrix = MatQ::new(3, 3);
     /// let value = Q::from((5, 2));
     ///
-    /// matrix.set_entry_unchecked(0, 1, &value);
-    /// matrix.set_entry_unchecked(2, 2, 5);
-    /// matrix.set_entry_unchecked(0, 2, (2, 3));
+    /// unsafe {
+    ///     matrix.set_entry_unchecked(0, 1, &value);
+    ///     matrix.set_entry_unchecked(2, 2, 5);
+    ///     matrix.set_entry_unchecked(0, 2, (2, 3));
+    /// }
     ///
     /// assert_eq!("[[0, 5/2, 2/3],[0, 0, 0],[0, 0, 5]]", matrix.to_string());
     /// ```
-    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: Rational) {
+    unsafe fn set_entry_unchecked(&mut self, row: i64, column: i64, value: Rational) {
         let value: Q = value.into();
 
         unsafe {

--- a/src/rational/poly_over_q/coefficient_embedding.rs
+++ b/src/rational/poly_over_q/coefficient_embedding.rs
@@ -58,7 +58,7 @@ impl IntoCoefficientEmbedding<MatQ> for &PolyOverQ {
         let mut out = MatQ::new(size, 1);
         for j in 0..size {
             let coeff = self.get_coeff(j).unwrap();
-            out.set_entry_unchecked(j, 0, coeff);
+            unsafe { out.set_entry_unchecked(j, 0, coeff) };
         }
 
         out

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -118,7 +118,12 @@ pub trait SetEntry<T> {
     /// - `row`: specifies the row in which the entry is located.
     /// - `column`: specifies the column in which the entry is located.
     /// - `value`: specifies the value to which the entry is set.
-    fn set_entry_unchecked(&mut self, row: i64, column: i64, value: T);
+    ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected entry is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    unsafe fn set_entry_unchecked(&mut self, row: i64, column: i64, value: T);
 }
 
 /// Is implemented by matrices to compute the tensor product.


### PR DESCRIPTION
**Description**

This PR implements makes `set_entry_unchecked` unsafe for all matrix types.

This is due to different error types / undefined behaviour if the entry isn't part of the matrix.