### PR TITLE
`Add` & `Sub` between `MatZ` and `MatZq`

### DIFF
--- a/src/integer/mat_z/arithmetic/add.rs
+++ b/src/integer/mat_z/arithmetic/add.rs
@@ -10,11 +10,14 @@
 
 use super::super::MatZ;
 use crate::error::MathError;
+use crate::integer_mod_q::MatZq;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+    arithmetic_trait_reverse,
 };
 use crate::traits::MatrixDimensions;
 use flint_sys::fmpz_mat::fmpz_mat_add;
+use flint_sys::fmpz_mod_mat::_fmpz_mod_mat_reduce;
 use std::ops::Add;
 
 impl Add for &MatZ {
@@ -47,6 +50,61 @@ impl Add for &MatZ {
         self.add_safe(other).unwrap()
     }
 }
+
+impl Add<&MatZq> for &MatZ {
+    type Output = MatZq;
+
+    /// Implements the [`Add`] trait for a [`MatZ`] and a [`MatZq`] matrix.
+    /// [`Add`] is implemented for any combination of [`MatZ`] and [`MatZq`].
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both numbers as a [`MatZq`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer::MatZ, integer_mod_q::MatZq};
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
+    /// let b = MatZq::from_str("[[1, 9, 3],[1, 0, 5]] mod 7").unwrap();
+    ///
+    /// let c = &a + &b;
+    /// let d = a + b;
+    /// let e = &c + d;
+    /// let f = c + &e;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
+    fn add(self, other: &MatZq) -> Self::Output {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
+        unsafe {
+            fmpz_mat_add(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
+            _fmpz_mod_mat_reduce(&mut out.matrix);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Add, add, MatZ, MatZq, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZ, MatZq, MatZq);
+arithmetic_trait_reverse!(Add, add, MatZq, MatZ, MatZq);
+arithmetic_trait_borrowed_to_owned!(Add, add, MatZq, MatZ, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZq, MatZ, MatZq);
 
 impl MatZ {
     /// Implements addition for two [`MatZ`] matrices.
@@ -98,6 +156,7 @@ arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZ, MatZ, MatZ);
 #[cfg(test)]
 mod test_add {
     use super::MatZ;
+    use crate::integer_mod_q::MatZq;
     use std::str::FromStr;
 
     /// Testing addition for two [`MatZ`]
@@ -175,5 +234,25 @@ mod test_add {
         let c: MatZ = MatZ::from_str("[[1, 2, 3]]").unwrap();
         assert!(a.add_safe(&b).is_err());
         assert!(c.add_safe(&b).is_err());
+    }
+
+    /// Ensures that addition between [`MatZ`] and [`MatZq`] works properly incl. reduction mod q
+    /// and is available for any combination.
+    #[test]
+    fn add_matzq() {
+        let a = MatZ::from_str("[[1, 2],[3, 4]]").unwrap();
+        let b = MatZq::from_str("[[5, 6],[9, 10]] mod 11").unwrap();
+        let cmp = MatZq::from_str("[[6, 8],[1, 3]] mod 11").unwrap();
+
+        let _ = &b + &a;
+        let _ = &b + a.clone();
+        let _ = b.clone() + &a;
+        let _ = b.clone() + a.clone();
+        let _ = &a + &b;
+        let _ = &a + b.clone();
+        let _ = a.clone() + &b;
+        let res = a.clone() + b.clone();
+
+        assert_eq!(cmp, res);
     }
 }

--- a/src/integer/mat_z/arithmetic/add.rs
+++ b/src/integer/mat_z/arithmetic/add.rs
@@ -10,14 +10,11 @@
 
 use super::super::MatZ;
 use crate::error::MathError;
-use crate::integer_mod_q::MatZq;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
-    arithmetic_trait_reverse,
 };
 use crate::traits::MatrixDimensions;
 use flint_sys::fmpz_mat::fmpz_mat_add;
-use flint_sys::fmpz_mod_mat::_fmpz_mod_mat_reduce;
 use std::ops::Add;
 
 impl Add for &MatZ {
@@ -50,61 +47,6 @@ impl Add for &MatZ {
         self.add_safe(other).unwrap()
     }
 }
-
-impl Add<&MatZq> for &MatZ {
-    type Output = MatZq;
-
-    /// Implements the [`Add`] trait for a [`MatZ`] and a [`MatZq`] matrix.
-    /// [`Add`] is implemented for any combination of [`MatZ`] and [`MatZq`].
-    ///
-    /// Parameters:
-    /// - `other`: specifies the value to add to `self`
-    ///
-    /// Returns the sum of both numbers as a [`MatZq`].
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::{integer::MatZ, integer_mod_q::MatZq};
-    /// use std::str::FromStr;
-    ///
-    /// let a = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
-    /// let b = MatZq::from_str("[[1, 9, 3],[1, 0, 5]] mod 7").unwrap();
-    ///
-    /// let c = &a + &b;
-    /// let d = a + b;
-    /// let e = &c + d;
-    /// let f = c + &e;
-    /// ```
-    ///
-    /// # Panics ...
-    /// - if the dimensions of both matrices mismatch.
-    fn add(self, other: &MatZq) -> Self::Output {
-        if self.get_num_rows() != other.get_num_rows()
-            || self.get_num_columns() != other.get_num_columns()
-        {
-            panic!(
-                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
-                self.get_num_rows(),
-                self.get_num_columns(),
-                other.get_num_rows(),
-                other.get_num_columns()
-            );
-        }
-
-        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
-        unsafe {
-            fmpz_mat_add(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
-            _fmpz_mod_mat_reduce(&mut out.matrix);
-        }
-        out
-    }
-}
-
-arithmetic_trait_borrowed_to_owned!(Add, add, MatZ, MatZq, MatZq);
-arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZ, MatZq, MatZq);
-arithmetic_trait_reverse!(Add, add, MatZq, MatZ, MatZq);
-arithmetic_trait_borrowed_to_owned!(Add, add, MatZq, MatZ, MatZq);
-arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZq, MatZ, MatZq);
 
 impl MatZ {
     /// Implements addition for two [`MatZ`] matrices.
@@ -156,7 +98,6 @@ arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZ, MatZ, MatZ);
 #[cfg(test)]
 mod test_add {
     use super::MatZ;
-    use crate::integer_mod_q::MatZq;
     use std::str::FromStr;
 
     /// Testing addition for two [`MatZ`]
@@ -234,25 +175,5 @@ mod test_add {
         let c: MatZ = MatZ::from_str("[[1, 2, 3]]").unwrap();
         assert!(a.add_safe(&b).is_err());
         assert!(c.add_safe(&b).is_err());
-    }
-
-    /// Ensures that addition between [`MatZ`] and [`MatZq`] works properly incl. reduction mod q
-    /// and is available for any combination.
-    #[test]
-    fn add_matzq() {
-        let a = MatZ::from_str("[[1, 2],[3, 4]]").unwrap();
-        let b = MatZq::from_str("[[5, 6],[9, 10]] mod 11").unwrap();
-        let cmp = MatZq::from_str("[[6, 8],[1, 3]] mod 11").unwrap();
-
-        let _ = &b + &a;
-        let _ = &b + a.clone();
-        let _ = b.clone() + &a;
-        let _ = b.clone() + a.clone();
-        let _ = &a + &b;
-        let _ = &a + b.clone();
-        let _ = a.clone() + &b;
-        let res = a.clone() + b.clone();
-
-        assert_eq!(cmp, res);
     }
 }

--- a/src/integer/mat_z/arithmetic/sub.rs
+++ b/src/integer/mat_z/arithmetic/sub.rs
@@ -10,13 +10,11 @@
 
 use super::super::MatZ;
 use crate::error::MathError;
-use crate::integer_mod_q::MatZq;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
 };
 use crate::traits::MatrixDimensions;
 use flint_sys::fmpz_mat::fmpz_mat_sub;
-use flint_sys::fmpz_mod_mat::_fmpz_mod_mat_reduce;
 use std::ops::Sub;
 
 impl Sub for &MatZ {
@@ -49,58 +47,6 @@ impl Sub for &MatZ {
         self.sub_safe(other).unwrap()
     }
 }
-
-impl Sub<&MatZq> for &MatZ {
-    type Output = MatZq;
-
-    /// Implements the [`Sub`] trait for a [`MatZ`] and a [`MatZq`] matrix.
-    /// [`Sub`] is implemented for any combination of [`MatZ`] and [`MatZq`].
-    ///
-    /// Parameters:
-    /// - `other`: specifies the value to subtract from `self`.
-    ///
-    /// Returns the difference from `self` and `other` as a [`MatZq`].
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::{integer::MatZ, integer_mod_q::MatZq};
-    /// use std::str::FromStr;
-    ///
-    /// let a = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
-    /// let b = MatZq::from_str("[[1, 9, 3],[1, 0, 5]] mod 7").unwrap();
-    ///
-    /// let c = &a - &b;
-    /// let d = a - b;
-    /// let e = &c - d;
-    /// let f = c - &e;
-    /// ```
-    ///
-    /// # Panics ...
-    /// - if the dimensions of both matrices mismatch.
-    fn sub(self, other: &MatZq) -> Self::Output {
-        if self.get_num_rows() != other.get_num_rows()
-            || self.get_num_columns() != other.get_num_columns()
-        {
-            panic!(
-                "Tried to subtract a '{}x{}' matrix from a '{}x{}' matrix.",
-                self.get_num_rows(),
-                self.get_num_columns(),
-                other.get_num_rows(),
-                other.get_num_columns()
-            );
-        }
-
-        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
-        unsafe {
-            fmpz_mat_sub(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
-            _fmpz_mod_mat_reduce(&mut out.matrix);
-        }
-        out
-    }
-}
-
-arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZq, MatZq);
-arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZq, MatZq);
 
 impl MatZ {
     /// Implements subtraction for two [`MatZ`] matrices.
@@ -152,7 +98,6 @@ arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZ, MatZ);
 #[cfg(test)]
 mod test_sub {
     use super::MatZ;
-    use crate::integer_mod_q::MatZq;
     use std::str::FromStr;
 
     /// Testing subtraction for two [`MatZ`]
@@ -227,25 +172,5 @@ mod test_sub {
         let c: MatZ = MatZ::from_str("[[1, 2, 3]]").unwrap();
         assert!(a.sub_safe(&b).is_err());
         assert!(c.sub_safe(&b).is_err());
-    }
-
-    /// Ensures that subtraction between [`MatZ`] and [`MatZq`] works properly incl. reduction mod q
-    /// and is available for any combination.
-    #[test]
-    fn sub_matzq() {
-        let a = MatZ::from_str("[[1, 2],[3, 4]]").unwrap();
-        let b = MatZq::from_str("[[5, 6],[2, 10]] mod 11").unwrap();
-        let cmp = MatZq::from_str("[[7, 7],[1, 5]] mod 11").unwrap();
-
-        let _ = &b - &a;
-        let _ = &b - a.clone();
-        let _ = b.clone() - &a;
-        let _ = b.clone() - a.clone();
-        let _ = &a - &b;
-        let _ = &a - b.clone();
-        let _ = a.clone() - &b;
-        let res = a.clone() - b.clone();
-
-        assert_eq!(cmp, res);
     }
 }

--- a/src/integer/mat_z/arithmetic/sub.rs
+++ b/src/integer/mat_z/arithmetic/sub.rs
@@ -50,6 +50,61 @@ impl Sub for &MatZ {
     }
 }
 
+arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZ, MatZ);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZ, MatZ);
+
+impl Sub<&MatZq> for &MatZ {
+    type Output = MatZq;
+
+    /// Implements the [`Sub`] trait for a [`MatZ`] and a [`MatZq`] matrix.
+    /// [`Sub`] is implemented for any combination of owned and borrowed values.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the matrix to subtract from `self`.
+    ///
+    /// Returns the subtraction of `self` and `other` as a [`MatZq`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer::MatZ, integer_mod_q::MatZq};
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
+    /// let b = MatZq::from_str("[[1, 9, 3],[1, 0, 5]] mod 7").unwrap();
+    ///
+    /// let c = &a - &b;
+    /// let d = a.clone() - b.clone();
+    /// let e = &a - &b;
+    /// let f = a - b;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
+    fn sub(self, other: &MatZq) -> Self::Output {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to subtract a '{}x{}' matrix from a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
+        unsafe {
+            fmpz_mat_sub(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
+            _fmpz_mod_mat_reduce(&mut out.matrix);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZq, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZq, MatZq);
+
 impl MatZ {
     /// Implements subtraction for two [`MatZ`] matrices.
     ///
@@ -93,38 +148,6 @@ impl MatZ {
         Ok(out)
     }
 }
-
-arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZ, MatZ);
-arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZ, MatZ);
-
-impl Sub<&MatZq> for &MatZ {
-    type Output = MatZq;
-
-    /// Documentation at [`MatZq::sub`].
-    fn sub(self, other: &MatZq) -> Self::Output {
-        if self.get_num_rows() != other.get_num_rows()
-            || self.get_num_columns() != other.get_num_columns()
-        {
-            panic!(
-                "Tried to subtract a '{}x{}' matrix from a '{}x{}' matrix.",
-                self.get_num_rows(),
-                self.get_num_columns(),
-                other.get_num_rows(),
-                other.get_num_columns()
-            );
-        }
-
-        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
-        unsafe {
-            fmpz_mat_sub(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
-            _fmpz_mod_mat_reduce(&mut out.matrix);
-        }
-        out
-    }
-}
-
-arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZq, MatZq);
-arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZq, MatZq);
 
 #[cfg(test)]
 mod test_sub {

--- a/src/integer/mat_z/arithmetic/sub.rs
+++ b/src/integer/mat_z/arithmetic/sub.rs
@@ -10,11 +10,13 @@
 
 use super::super::MatZ;
 use crate::error::MathError;
+use crate::integer_mod_q::MatZq;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
 };
 use crate::traits::MatrixDimensions;
 use flint_sys::fmpz_mat::fmpz_mat_sub;
+use flint_sys::fmpz_mod_mat::_fmpz_mod_mat_reduce;
 use std::ops::Sub;
 
 impl Sub for &MatZ {
@@ -47,6 +49,58 @@ impl Sub for &MatZ {
         self.sub_safe(other).unwrap()
     }
 }
+
+impl Sub<&MatZq> for &MatZ {
+    type Output = MatZq;
+
+    /// Implements the [`Sub`] trait for a [`MatZ`] and a [`MatZq`] matrix.
+    /// [`Sub`] is implemented for any combination of [`MatZ`] and [`MatZq`].
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to subtract from `self`.
+    ///
+    /// Returns the difference from `self` and `other` as a [`MatZq`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer::MatZ, integer_mod_q::MatZq};
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
+    /// let b = MatZq::from_str("[[1, 9, 3],[1, 0, 5]] mod 7").unwrap();
+    ///
+    /// let c = &a - &b;
+    /// let d = a - b;
+    /// let e = &c - d;
+    /// let f = c - &e;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
+    fn sub(self, other: &MatZq) -> Self::Output {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to subtract a '{}x{}' matrix from a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
+        unsafe {
+            fmpz_mat_sub(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
+            _fmpz_mod_mat_reduce(&mut out.matrix);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZq, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZq, MatZq);
 
 impl MatZ {
     /// Implements subtraction for two [`MatZ`] matrices.
@@ -98,6 +152,7 @@ arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZ, MatZ);
 #[cfg(test)]
 mod test_sub {
     use super::MatZ;
+    use crate::integer_mod_q::MatZq;
     use std::str::FromStr;
 
     /// Testing subtraction for two [`MatZ`]
@@ -172,5 +227,25 @@ mod test_sub {
         let c: MatZ = MatZ::from_str("[[1, 2, 3]]").unwrap();
         assert!(a.sub_safe(&b).is_err());
         assert!(c.sub_safe(&b).is_err());
+    }
+
+    /// Ensures that subtraction between [`MatZ`] and [`MatZq`] works properly incl. reduction mod q
+    /// and is available for any combination.
+    #[test]
+    fn sub_matzq() {
+        let a = MatZ::from_str("[[1, 2],[3, 4]]").unwrap();
+        let b = MatZq::from_str("[[5, 6],[2, 10]] mod 11").unwrap();
+        let cmp = MatZq::from_str("[[7, 7],[1, 5]] mod 11").unwrap();
+
+        let _ = &b - &a;
+        let _ = &b - a.clone();
+        let _ = b.clone() - &a;
+        let _ = b.clone() - a.clone();
+        let _ = &a - &b;
+        let _ = &a - b.clone();
+        let _ = a.clone() - &b;
+        let res = a.clone() - b.clone();
+
+        assert_eq!(cmp, res);
     }
 }

--- a/src/integer/mat_z/arithmetic/sub.rs
+++ b/src/integer/mat_z/arithmetic/sub.rs
@@ -10,11 +10,13 @@
 
 use super::super::MatZ;
 use crate::error::MathError;
+use crate::integer_mod_q::MatZq;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
 };
 use crate::traits::MatrixDimensions;
 use flint_sys::fmpz_mat::fmpz_mat_sub;
+use flint_sys::fmpz_mod_mat::_fmpz_mod_mat_reduce;
 use std::ops::Sub;
 
 impl Sub for &MatZ {
@@ -95,6 +97,35 @@ impl MatZ {
 arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZ, MatZ);
 arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZ, MatZ);
 
+impl Sub<&MatZq> for &MatZ {
+    type Output = MatZq;
+
+    /// Documentation at [`MatZq::sub`].
+    fn sub(self, other: &MatZq) -> Self::Output {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to subtract a '{}x{}' matrix from a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
+        unsafe {
+            fmpz_mat_sub(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
+            _fmpz_mod_mat_reduce(&mut out.matrix);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZq, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZq, MatZq);
+
 #[cfg(test)]
 mod test_sub {
     use super::MatZ;
@@ -172,5 +203,85 @@ mod test_sub {
         let c: MatZ = MatZ::from_str("[[1, 2, 3]]").unwrap();
         assert!(a.sub_safe(&b).is_err());
         assert!(c.sub_safe(&b).is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_sub_matzq {
+    use super::MatZ;
+    use crate::integer_mod_q::MatZq;
+    use std::str::FromStr;
+
+    /// Ensures that subtraction between [`MatZ`] and [`MatZq`] works properly incl. reduction mod q.
+    #[test]
+    fn small_numbers() {
+        let a = MatZ::from_str("[[1, 2],[3, 4]]").unwrap();
+        let b = MatZq::from_str("[[5, 6],[2, 10]] mod 11").unwrap();
+        let cmp = MatZq::from_str("[[7, 7],[1, 5]] mod 11").unwrap();
+
+        let res_0 = &a - &b;
+        let res_1 = MatZq::from((a, 11)) - b.get_representative_least_nonnegative_residue();
+
+        assert_eq!(res_0, res_1);
+        assert_eq!(cmp, res_0);
+    }
+
+    /// Testing subtraction for large numbers
+    #[test]
+    fn large_numbers() {
+        let a: MatZ =
+            MatZ::from_str(&format!("[[1, 2, {}],[3, -4, {}]]", i64::MIN, u64::MAX)).unwrap();
+        let b: MatZq = MatZq::from_str(&format!(
+            "[[1, 1, {}],[3, 9, {}]] mod {}",
+            i64::MAX,
+            i64::MAX,
+            u64::MAX - 58
+        ))
+        .unwrap();
+
+        let c = a - &b;
+
+        assert_eq!(
+            c,
+            MatZq::from_str(&format!(
+                "[[0, 1, -{}],[0, -13, {}]] mod {}",
+                u64::MAX,
+                (u64::MAX - 1) / 2 + 1,
+                u64::MAX - 58
+            ))
+            .unwrap()
+        );
+    }
+
+    /// Ensures that subtraction between [`MatZ`] and [`MatZq`] is available for any combination.
+    #[test]
+    fn available() {
+        let a = MatZ::new(2, 2);
+        let b = MatZq::new(2, 2, 7);
+
+        let _ = &a - &b;
+        let _ = &a - b.clone();
+        let _ = a.clone() - &b;
+        let _ = a.clone() - b.clone();
+    }
+
+    /// Ensures that mismatching rows results in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_rows() {
+        let a = MatZ::new(3, 2);
+        let b = MatZq::new(2, 2, 7);
+
+        let _ = &a - &b;
+    }
+
+    /// Ensures that mismatching columns results in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_column() {
+        let a = MatZ::new(2, 3);
+        let b = MatZq::new(2, 2, 7);
+
+        let _ = &a - &b;
     }
 }

--- a/src/integer_mod_q/mat_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/add.rs
@@ -10,11 +10,14 @@
 
 use super::super::MatZq;
 use crate::error::MathError;
+use crate::integer::MatZ;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+    arithmetic_trait_reverse,
 };
 use crate::traits::MatrixDimensions;
-use flint_sys::fmpz_mod_mat::fmpz_mod_mat_add;
+use flint_sys::fmpz_mat::fmpz_mat_add;
+use flint_sys::fmpz_mod_mat::{_fmpz_mod_mat_reduce, fmpz_mod_mat_add};
 use std::ops::Add;
 
 impl Add for &MatZq {
@@ -48,6 +51,61 @@ impl Add for &MatZq {
         self.add_safe(other).unwrap()
     }
 }
+
+impl Add<&MatZq> for &MatZ {
+    type Output = MatZq;
+
+    /// Implements the [`Add`] trait for a [`MatZ`] and a [`MatZq`] matrix.
+    /// [`Add`] is implemented for any combination of [`MatZ`] and [`MatZq`] and vice versa.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// Returns the sum of both numbers as a [`MatZq`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer::MatZ, integer_mod_q::MatZq};
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
+    /// let b = MatZq::from_str("[[1, 9, 3],[1, 0, 5]] mod 7").unwrap();
+    ///
+    /// let c = &a + &b;
+    /// let d = a.clone() + b.clone();
+    /// let e = &b + &a;
+    /// let f = b + a;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
+    fn add(self, other: &MatZq) -> Self::Output {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
+        unsafe {
+            fmpz_mat_add(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
+            _fmpz_mod_mat_reduce(&mut out.matrix);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Add, add, MatZ, MatZq, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZ, MatZq, MatZq);
+arithmetic_trait_reverse!(Add, add, MatZq, MatZ, MatZq);
+arithmetic_trait_borrowed_to_owned!(Add, add, MatZq, MatZ, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZq, MatZ, MatZq);
 
 impl MatZq {
     /// Implements addition for two [`MatZq`] matrices.
@@ -197,5 +255,88 @@ mod test_add {
         assert!(a.add_safe(&b).is_err());
         assert!(c.add_safe(&b).is_err());
         assert!(a.add_safe(&d).is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_add_matz {
+    use super::MatZq;
+    use crate::integer::MatZ;
+    use std::str::FromStr;
+
+    /// Ensures that addition between [`MatZ`] and [`MatZq`] works properly incl. reduction mod q.
+    #[test]
+    fn small_numbers() {
+        let a = MatZ::from_str("[[1, 2],[3, 4]]").unwrap();
+        let b = MatZq::from_str("[[5, 6],[9, 10]] mod 11").unwrap();
+        let cmp = MatZq::from_str("[[6, 8],[1, 3]] mod 11").unwrap();
+
+        let res_0 = &a + &b;
+        let res_1 = &b + &a;
+
+        assert_eq!(res_0, res_1);
+        assert_eq!(cmp, res_0);
+    }
+
+    /// Testing addition for large numbers
+    #[test]
+    fn large_numbers() {
+        let a: MatZ =
+            MatZ::from_str(&format!("[[1, 2, {}],[3, -4, {}]]", i64::MIN, i128::MAX,)).unwrap();
+        let b: MatZq = MatZq::from_str(&format!(
+            "[[1, 2, {}],[3, 9, {}]] mod {}",
+            i64::MIN + 1,
+            i128::MAX,
+            u64::MAX - 58
+        ))
+        .unwrap();
+
+        let c = a + &b;
+
+        assert_eq!(
+            c,
+            MatZq::from_str(&format!(
+                "[[2, 4, -{}],[6, 5, {}]] mod {}",
+                u64::MAX,
+                u128::MAX - 1,
+                u64::MAX - 58
+            ))
+            .unwrap()
+        );
+    }
+
+    /// Ensures that addition between [`MatZ`] and [`MatZq`] is available for any combination.
+    #[test]
+    fn available() {
+        let a = MatZ::new(2, 2);
+        let b = MatZq::new(2, 2, 7);
+
+        let _ = &b + &a;
+        let _ = &b + a.clone();
+        let _ = b.clone() + &a;
+        let _ = b.clone() + a.clone();
+        let _ = &a + &b;
+        let _ = &a + b.clone();
+        let _ = a.clone() + &b;
+    }
+
+    /// Ensures that mismatching rows results in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_rows() {
+        let a = MatZ::new(3, 2);
+        let b = MatZq::new(2, 2, 7);
+
+        let _ = &b + &a;
+    }
+
+    /// Ensures that mismatching columns results in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_column() {
+        let a = MatZ::new(2, 3);
+        let b = MatZq::new(2, 2, 7);
+
+        let _ = &b + &a;
     }
 }

--- a/src/integer_mod_q/mat_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/add.rs
@@ -52,7 +52,7 @@ impl Add for &MatZq {
     }
 }
 
-impl Add<&MatZq> for &MatZ {
+impl Add<&MatZ> for &MatZq {
     type Output = MatZq;
 
     /// Implements the [`Add`] trait for a [`MatZ`] and a [`MatZq`] matrix.
@@ -79,7 +79,7 @@ impl Add<&MatZq> for &MatZ {
     ///
     /// # Panics ...
     /// - if the dimensions of both matrices mismatch.
-    fn add(self, other: &MatZq) -> Self::Output {
+    fn add(self, other: &MatZ) -> Self::Output {
         if self.get_num_rows() != other.get_num_rows()
             || self.get_num_columns() != other.get_num_columns()
         {
@@ -92,20 +92,20 @@ impl Add<&MatZq> for &MatZ {
             );
         }
 
-        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod());
         unsafe {
-            fmpz_mat_add(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
+            fmpz_mat_add(&mut out.matrix.mat[0], &self.matrix.mat[0], &other.matrix);
             _fmpz_mod_mat_reduce(&mut out.matrix);
         }
         out
     }
 }
 
-arithmetic_trait_borrowed_to_owned!(Add, add, MatZ, MatZq, MatZq);
-arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZ, MatZq, MatZq);
-arithmetic_trait_reverse!(Add, add, MatZq, MatZ, MatZq);
 arithmetic_trait_borrowed_to_owned!(Add, add, MatZq, MatZ, MatZq);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZq, MatZ, MatZq);
+arithmetic_trait_reverse!(Add, add, MatZ, MatZq, MatZq);
+arithmetic_trait_borrowed_to_owned!(Add, add, MatZ, MatZq, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZ, MatZq, MatZq);
 
 impl MatZq {
     /// Implements addition for two [`MatZq`] matrices.

--- a/src/integer_mod_q/mat_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/sub.rs
@@ -103,35 +103,6 @@ impl Sub<&MatZ> for &MatZq {
 arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZq, MatZ, MatZq);
 arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZq, MatZ, MatZq);
 
-impl Sub<&MatZq> for &MatZ {
-    type Output = MatZq;
-
-    /// Documentation at [`MatZq::sub`].
-    fn sub(self, other: &MatZq) -> Self::Output {
-        if self.get_num_rows() != other.get_num_rows()
-            || self.get_num_columns() != other.get_num_columns()
-        {
-            panic!(
-                "Tried to subtract a '{}x{}' matrix from a '{}x{}' matrix.",
-                self.get_num_rows(),
-                self.get_num_columns(),
-                other.get_num_rows(),
-                other.get_num_columns()
-            );
-        }
-
-        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
-        unsafe {
-            fmpz_mat_sub(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
-            _fmpz_mod_mat_reduce(&mut out.matrix);
-        }
-        out
-    }
-}
-
-arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZq, MatZq);
-arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZq, MatZq);
-
 impl MatZq {
     /// Implements subtraction for two [`MatZq`] matrices.
     ///
@@ -300,10 +271,10 @@ mod test_sub_matz {
     fn small_numbers() {
         let a = MatZ::from_str("[[1, 2],[3, 4]]").unwrap();
         let b = MatZq::from_str("[[5, 6],[2, 10]] mod 11").unwrap();
-        let cmp = MatZq::from_str("[[7, 7],[1, 5]] mod 11").unwrap();
+        let cmp = MatZq::from_str("[[4, 4],[-1, 6]] mod 11").unwrap();
 
-        let res_0 = &a - &b;
-        let res_1 = MatZq::from((a, 11)) - b.get_representative_least_nonnegative_residue();
+        let res_0 = &b - &a;
+        let res_1 = b - MatZq::from((a, 11));
 
         assert_eq!(res_0, res_1);
         assert_eq!(cmp, res_0);
@@ -313,16 +284,16 @@ mod test_sub_matz {
     #[test]
     fn large_numbers() {
         let a: MatZ =
-            MatZ::from_str(&format!("[[1, 2, {}],[3, -4, {}]]", i64::MIN, u64::MAX)).unwrap();
+            MatZ::from_str(&format!("[[1, 1, {}],[3, 9, {}]]", i64::MAX, i64::MAX)).unwrap();
         let b: MatZq = MatZq::from_str(&format!(
-            "[[1, 1, {}],[3, 9, {}]] mod {}",
-            i64::MAX,
-            i64::MAX,
+            "[[1, 2, {}],[3, -4, {}]] mod {}",
+            i64::MIN,
+            u64::MAX,
             u64::MAX - 58
         ))
         .unwrap();
 
-        let c = a - &b;
+        let c = &b - a;
 
         assert_eq!(
             c,
@@ -346,9 +317,6 @@ mod test_sub_matz {
         let _ = &b - a.clone();
         let _ = b.clone() - &a;
         let _ = b.clone() - a.clone();
-        let _ = &a - &b;
-        let _ = &a - b.clone();
-        let _ = a.clone() - &b;
     }
 
     /// Ensures that mismatching rows results in a panic.

--- a/src/integer_mod_q/mat_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/sub.rs
@@ -10,11 +10,13 @@
 
 use super::super::MatZq;
 use crate::error::MathError;
+use crate::integer::MatZ;
 use crate::macros::arithmetics::{
     arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
 };
 use crate::traits::MatrixDimensions;
-use flint_sys::fmpz_mod_mat::fmpz_mod_mat_sub;
+use flint_sys::fmpz_mat::fmpz_mat_sub;
+use flint_sys::fmpz_mod_mat::{_fmpz_mod_mat_reduce, fmpz_mod_mat_sub};
 use std::ops::Sub;
 
 impl Sub for &MatZq {
@@ -48,6 +50,58 @@ impl Sub for &MatZq {
         self.sub_safe(other).unwrap()
     }
 }
+
+impl Sub<&MatZ> for &MatZq {
+    type Output = MatZq;
+
+    /// Implements the [`Sub`] trait for a [`MatZ`] and a [`MatZq`] matrix.
+    /// [`Sub`] is implemented for any combination of [`MatZ`] and [`MatZq`].
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to subtract from `self`.
+    ///
+    /// Returns the difference from `self` and `other` as a [`MatZq`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer::MatZ, integer_mod_q::MatZq};
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
+    /// let b = MatZq::from_str("[[1, 9, 3],[1, 0, 5]] mod 7").unwrap();
+    ///
+    /// let c = &a - &b;
+    /// let d = a - b;
+    /// let e = &c - d;
+    /// let f = c - &e;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the dimensions of both matrices mismatch.
+    fn sub(self, other: &MatZ) -> Self::Output {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to subtract a '{}x{}' matrix from a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), self.get_mod());
+        unsafe {
+            fmpz_mat_sub(&mut out.matrix.mat[0], &self.matrix.mat[0], &other.matrix);
+            _fmpz_mod_mat_reduce(&mut out.matrix);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZq, MatZ, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZq, MatZ, MatZq);
 
 impl MatZq {
     /// Implements subtraction for two [`MatZq`] matrices.

--- a/src/integer_mod_q/mat_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/sub.rs
@@ -51,11 +51,14 @@ impl Sub for &MatZq {
     }
 }
 
+arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZq, MatZq, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZq, MatZq, MatZq);
+
 impl Sub<&MatZ> for &MatZq {
     type Output = MatZq;
 
-    /// Implements the [`Sub`] trait for a [`MatZ`] and a [`MatZq`] matrix.
-    /// [`Sub`] is implemented for any combination of [`MatZ`] and [`MatZq`] and vice versa.
+    /// Implements the [`Sub`] trait for a [`MatZq`] and a [`MatZ`] matrix.
+    /// [`Sub`] is implemented for any combination of owned and borrowed values.
     ///
     /// Parameters:
     /// - `other`: specifies the matrix to subtract from `self`.
@@ -70,8 +73,8 @@ impl Sub<&MatZ> for &MatZq {
     /// let a = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
     /// let b = MatZq::from_str("[[1, 9, 3],[1, 0, 5]] mod 7").unwrap();
     ///
-    /// let c = &a - &b;
-    /// let d = a.clone() - b.clone();
+    /// let c = &b - &a;
+    /// let d = b.clone() - a.clone();
     /// let e = &b - &a;
     /// let f = b - a;
     /// ```
@@ -154,9 +157,6 @@ impl MatZq {
         Ok(out)
     }
 }
-
-arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZq, MatZq, MatZq);
-arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZq, MatZq, MatZq);
 
 #[cfg(test)]
 mod test_sub {

--- a/src/integer_mod_q/mat_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/sub.rs
@@ -55,12 +55,12 @@ impl Sub<&MatZ> for &MatZq {
     type Output = MatZq;
 
     /// Implements the [`Sub`] trait for a [`MatZ`] and a [`MatZq`] matrix.
-    /// [`Sub`] is implemented for any combination of [`MatZ`] and [`MatZq`].
+    /// [`Sub`] is implemented for any combination of [`MatZ`] and [`MatZq`] and vice versa.
     ///
     /// Parameters:
-    /// - `other`: specifies the value to subtract from `self`.
+    /// - `other`: specifies the matrix to subtract from `self`.
     ///
-    /// Returns the difference from `self` and `other` as a [`MatZq`].
+    /// Returns the subtraction of `self` and `other` as a [`MatZq`].
     ///
     /// # Examples
     /// ```
@@ -71,9 +71,9 @@ impl Sub<&MatZ> for &MatZq {
     /// let b = MatZq::from_str("[[1, 9, 3],[1, 0, 5]] mod 7").unwrap();
     ///
     /// let c = &a - &b;
-    /// let d = a - b;
-    /// let e = &c - d;
-    /// let f = c - &e;
+    /// let d = a.clone() - b.clone();
+    /// let e = &b - &a;
+    /// let f = b - a;
     /// ```
     ///
     /// # Panics ...
@@ -102,6 +102,35 @@ impl Sub<&MatZ> for &MatZq {
 
 arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZq, MatZ, MatZq);
 arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZq, MatZ, MatZq);
+
+impl Sub<&MatZq> for &MatZ {
+    type Output = MatZq;
+
+    /// Documentation at [`MatZq::sub`].
+    fn sub(self, other: &MatZq) -> Self::Output {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to subtract a '{}x{}' matrix from a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        let mut out = MatZq::new(self.get_num_rows(), self.get_num_columns(), other.get_mod());
+        unsafe {
+            fmpz_mat_sub(&mut out.matrix.mat[0], &self.matrix, &other.matrix.mat[0]);
+            _fmpz_mod_mat_reduce(&mut out.matrix);
+        }
+        out
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Sub, sub, MatZ, MatZq, MatZq);
+arithmetic_trait_mixed_borrowed_owned!(Sub, sub, MatZ, MatZq, MatZq);
 
 impl MatZq {
     /// Implements subtraction for two [`MatZq`] matrices.
@@ -257,5 +286,88 @@ mod test_sub {
         assert!(a.sub_safe(&b).is_err());
         assert!(c.sub_safe(&b).is_err());
         assert!(a.add_safe(&d).is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_sub_matz {
+    use super::MatZ;
+    use crate::integer_mod_q::MatZq;
+    use std::str::FromStr;
+
+    /// Ensures that subtraction between [`MatZ`] and [`MatZq`] works properly incl. reduction mod q.
+    #[test]
+    fn small_numbers() {
+        let a = MatZ::from_str("[[1, 2],[3, 4]]").unwrap();
+        let b = MatZq::from_str("[[5, 6],[2, 10]] mod 11").unwrap();
+        let cmp = MatZq::from_str("[[7, 7],[1, 5]] mod 11").unwrap();
+
+        let res_0 = &a - &b;
+        let res_1 = MatZq::from((a, 11)) - b.get_representative_least_nonnegative_residue();
+
+        assert_eq!(res_0, res_1);
+        assert_eq!(cmp, res_0);
+    }
+
+    /// Testing subtraction for large numbers
+    #[test]
+    fn large_numbers() {
+        let a: MatZ =
+            MatZ::from_str(&format!("[[1, 2, {}],[3, -4, {}]]", i64::MIN, u64::MAX)).unwrap();
+        let b: MatZq = MatZq::from_str(&format!(
+            "[[1, 1, {}],[3, 9, {}]] mod {}",
+            i64::MAX,
+            i64::MAX,
+            u64::MAX - 58
+        ))
+        .unwrap();
+
+        let c = a - &b;
+
+        assert_eq!(
+            c,
+            MatZq::from_str(&format!(
+                "[[0, 1, -{}],[0, -13, {}]] mod {}",
+                u64::MAX,
+                (u64::MAX - 1) / 2 + 1,
+                u64::MAX - 58
+            ))
+            .unwrap()
+        );
+    }
+
+    /// Ensures that subtraction between [`MatZ`] and [`MatZq`] is available for any combination.
+    #[test]
+    fn available() {
+        let a = MatZ::new(2, 2);
+        let b = MatZq::new(2, 2, 7);
+
+        let _ = &b - &a;
+        let _ = &b - a.clone();
+        let _ = b.clone() - &a;
+        let _ = b.clone() - a.clone();
+        let _ = &a - &b;
+        let _ = &a - b.clone();
+        let _ = a.clone() - &b;
+    }
+
+    /// Ensures that mismatching rows results in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_rows() {
+        let a = MatZ::new(3, 2);
+        let b = MatZq::new(2, 2, 7);
+
+        let _ = &b - &a;
+    }
+
+    /// Ensures that mismatching columns results in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_column() {
+        let a = MatZ::new(2, 3);
+        let b = MatZq::new(2, 2, 7);
+
+        let _ = &b - &a;
     }
 }


### PR DESCRIPTION
**Description**

This PR implements...
- [x] add
- [x] sub

between MatZ and MatZq.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide