### PR TITLE
`AddAssign` for Matrices

### DIFF
--- a/src/integer/mat_poly_over_z/arithmetic/add.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/add.rs
@@ -34,6 +34,9 @@ impl AddAssign<&MatPolyOverZ> for MatPolyOverZ {
     /// a += &b;
     /// a += b;
     /// ```
+    ///
+    /// # Panics ...
+    /// - if the matrix dimensions mismatch.
     fn add_assign(&mut self, other: &Self) {
         if self.get_num_rows() != other.get_num_rows()
             || self.get_num_columns() != other.get_num_columns()
@@ -104,7 +107,8 @@ impl MatPolyOverZ {
     ///
     /// let c: MatPolyOverZ = a.add_safe(&b).unwrap();
     /// ```
-    /// # Errors
+    ///
+    /// # Errors and Failures
     /// - Returns a [`MathError`] of type
     ///     [`MathError::MismatchingMatrixDimension`] if the matrix dimensions
     ///     mismatch.

--- a/src/integer/mat_poly_over_z/arithmetic/add.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/add.rs
@@ -11,11 +11,47 @@
 use super::super::MatPolyOverZ;
 use crate::error::MathError;
 use crate::macros::arithmetics::{
-    arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+    arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
+    arithmetic_trait_mixed_borrowed_owned,
 };
 use crate::traits::MatrixDimensions;
 use flint_sys::fmpz_poly_mat::fmpz_poly_mat_add;
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&MatPolyOverZ> for MatPolyOverZ {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// let mut a = MatPolyOverZ::identity(2, 2);
+    /// let b = MatPolyOverZ::new(2, 2);
+    ///
+    /// a += &b;
+    /// a += b;
+    /// ```
+    fn add_assign(&mut self, other: &Self) {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        unsafe { fmpz_poly_mat_add(&mut self.matrix, &self.matrix, &other.matrix) };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, MatPolyOverZ, MatPolyOverZ);
 
 impl Add for &MatPolyOverZ {
     type Output = MatPolyOverZ;
@@ -94,6 +130,68 @@ impl MatPolyOverZ {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, MatPolyOverZ, MatPolyOverZ, MatPolyOverZ);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, MatPolyOverZ, MatPolyOverZ, MatPolyOverZ);
+
+#[cfg(test)]
+mod test_add_assign {
+    use crate::integer::MatPolyOverZ;
+    use std::str::FromStr;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = MatPolyOverZ::identity(2, 2);
+        let b = MatPolyOverZ::from_str("[[1  4, 2  1 5],[1  -6, 1  -1]]").unwrap();
+        let cmp = MatPolyOverZ::from_str("[[1  5, 2  1 5],[1  -6, 0]]").unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a =
+            MatPolyOverZ::from_str(&format!("[[1  {}, 2  0 2],[1  {}, 0]]", i64::MAX, i64::MIN))
+                .unwrap();
+        let b = MatPolyOverZ::from_str(&format!("[[1  {}, 1  1],[1  6, 1  3]]", i64::MAX)).unwrap();
+        let cmp = MatPolyOverZ::from_str(&format!(
+            "[[1  {}, 2  1 2],[1  {}, 1  3]]",
+            2 * (i64::MAX as u64),
+            i64::MIN + 6
+        ))
+        .unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for different matrix dimensions.
+    #[test]
+    fn matrix_dimensions() {
+        let dimensions = [(3, 3), (5, 1), (1, 4)];
+
+        for (nr_rows, nr_cols) in dimensions {
+            let mut a = MatPolyOverZ::new(nr_rows, nr_cols);
+            let b = MatPolyOverZ::identity(nr_rows, nr_cols);
+
+            a += b;
+
+            assert_eq!(MatPolyOverZ::identity(nr_rows, nr_cols), a);
+        }
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = MatPolyOverZ::new(2, 2);
+        let b = MatPolyOverZ::new(2, 2);
+
+        a += &b;
+        a += b;
+    }
+}
 
 #[cfg(test)]
 mod test_add {

--- a/src/integer/mat_z/arithmetic/add.rs
+++ b/src/integer/mat_z/arithmetic/add.rs
@@ -34,6 +34,9 @@ impl AddAssign<&MatZ> for MatZ {
     /// a += &b;
     /// a += b;
     /// ```
+    ///
+    /// # Panics ...
+    /// - if the matrix dimensions mismatch.
     fn add_assign(&mut self, other: &Self) {
         if self.get_num_rows() != other.get_num_rows()
             || self.get_num_columns() != other.get_num_columns()

--- a/src/integer/mat_z/arithmetic/add.rs
+++ b/src/integer/mat_z/arithmetic/add.rs
@@ -11,11 +11,47 @@
 use super::super::MatZ;
 use crate::error::MathError;
 use crate::macros::arithmetics::{
-    arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+    arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
+    arithmetic_trait_mixed_borrowed_owned,
 };
 use crate::traits::MatrixDimensions;
 use flint_sys::fmpz_mat::fmpz_mat_add;
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&MatZ> for MatZ {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatZ;
+    /// let mut a = MatZ::identity(2, 2);
+    /// let b = MatZ::new(2, 2);
+    ///
+    /// a += &b;
+    /// a += b;
+    /// ```
+    fn add_assign(&mut self, other: &Self) {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        unsafe { fmpz_mat_add(&mut self.matrix, &self.matrix, &other.matrix) };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, MatZ, MatZ);
 
 impl Add for &MatZ {
     type Output = MatZ;
@@ -94,6 +130,66 @@ impl MatZ {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, MatZ, MatZ, MatZ);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZ, MatZ, MatZ);
+
+#[cfg(test)]
+mod test_add_assign {
+    use crate::integer::MatZ;
+    use std::str::FromStr;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = MatZ::identity(2, 2);
+        let b = MatZ::from_str("[[4, 5],[-6, -1]]").unwrap();
+        let cmp = MatZ::from_str("[[5, 5],[-6, 0]]").unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a = MatZ::from_str(&format!("[[{}, 5],[{}, -1]]", i64::MAX, i64::MIN)).unwrap();
+        let b = MatZ::from_str(&format!("[[{}, -6],[6, -1]]", i64::MAX)).unwrap();
+        let cmp = MatZ::from_str(&format!(
+            "[[{}, -1],[{}, -2]]",
+            2 * (i64::MAX as u64),
+            i64::MIN + 6
+        ))
+        .unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for different matrix dimensions.
+    #[test]
+    fn matrix_dimensions() {
+        let dimensions = [(3, 3), (5, 1), (1, 4)];
+
+        for (nr_rows, nr_cols) in dimensions {
+            let mut a = MatZ::new(nr_rows, nr_cols);
+            let b = MatZ::identity(nr_rows, nr_cols);
+
+            a += b;
+
+            assert_eq!(MatZ::identity(nr_rows, nr_cols), a);
+        }
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = MatZ::new(2, 2);
+        let b = MatZ::new(2, 2);
+
+        a += &b;
+        a += b;
+    }
+}
 
 #[cfg(test)]
 mod test_add {

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
@@ -15,9 +15,7 @@ use crate::{
         arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
         arithmetic_trait_mixed_borrowed_owned,
     },
-    traits::MatrixDimensions,
 };
-use flint_sys::fmpz_poly_mat::fmpz_poly_mat_add;
 use std::ops::{Add, AddAssign};
 
 impl AddAssign<&MatPolynomialRingZq> for MatPolynomialRingZq {
@@ -46,17 +44,6 @@ impl AddAssign<&MatPolynomialRingZq> for MatPolynomialRingZq {
     /// - if the matrix dimensions mismatch.
     /// - if the moduli of the matrices mismatch.
     fn add_assign(&mut self, other: &Self) {
-        if self.get_num_rows() != other.get_num_rows()
-            || self.get_num_columns() != other.get_num_columns()
-        {
-            panic!(
-                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
-                self.get_num_rows(),
-                self.get_num_columns(),
-                other.get_num_rows(),
-                other.get_num_columns()
-            );
-        }
         if self.modulus != other.modulus {
             panic!(
                 "Tried to add polynomial with modulus '{}' and polynomial with modulus '{}'.",
@@ -64,13 +51,8 @@ impl AddAssign<&MatPolynomialRingZq> for MatPolynomialRingZq {
             );
         }
 
-        unsafe {
-            fmpz_poly_mat_add(
-                &mut self.matrix.matrix,
-                &self.matrix.matrix,
-                &other.matrix.matrix,
-            )
-        };
+        self.matrix += &other.matrix;
+
         self.reduce();
     }
 }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
@@ -12,10 +12,75 @@ use super::super::MatPolynomialRingZq;
 use crate::{
     error::MathError,
     macros::arithmetics::{
-        arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+        arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
     },
+    traits::MatrixDimensions,
 };
-use std::ops::Add;
+use flint_sys::fmpz_poly_mat::fmpz_poly_mat_add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&MatPolynomialRingZq> for MatPolynomialRingZq {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::MatPolynomialRingZq;
+    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("3  1 0 1 mod 7").unwrap();
+    /// let mut a = MatPolynomialRingZq::identity(2, 2, &modulus);
+    /// let b = MatPolynomialRingZq::new(2, 2, &modulus);
+    ///
+    /// a += &b;
+    /// a += b;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the matrix dimensions mismatch.
+    /// - if the moduli of the matrices mismatch.
+    fn add_assign(&mut self, other: &Self) {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+        if self.modulus != other.modulus {
+            panic!(
+                "Tried to add polynomial with modulus '{}' and polynomial with modulus '{}'.",
+                self.modulus, other.modulus
+            );
+        }
+
+        unsafe {
+            fmpz_poly_mat_add(
+                &mut self.matrix.matrix,
+                &self.matrix.matrix,
+                &other.matrix.matrix,
+            )
+        };
+        self.reduce();
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(
+    AddAssign,
+    add_assign,
+    MatPolynomialRingZq,
+    MatPolynomialRingZq
+);
 
 impl Add for &MatPolynomialRingZq {
     type Output = MatPolynomialRingZq;
@@ -78,6 +143,7 @@ impl MatPolynomialRingZq {
     ///
     /// let poly_ring_mat_3: MatPolynomialRingZq = poly_ring_mat_1.add_safe(&poly_ring_mat_2).unwrap();
     /// ```
+    ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`MathError::MismatchingModulus`] if the moduli of
     ///     both [`MatPolynomialRingZq`] mismatch.
@@ -110,6 +176,93 @@ arithmetic_trait_mixed_borrowed_owned!(
     MatPolynomialRingZq,
     MatPolynomialRingZq
 );
+
+#[cfg(test)]
+mod test_add_assign {
+    use crate::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    use std::str::FromStr;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = MatPolynomialRingZq::from_str("[[1  1, 0],[0, 1  1]] / 2  0 1 mod 7").unwrap();
+        let b =
+            MatPolynomialRingZq::from_str("[[1  4, 1  5],[1  -6, 2  6 1]] / 2  0 1 mod 7").unwrap();
+        let cmp = MatPolynomialRingZq::from_str("[[1  5, 1  5],[1  1, 0]] / 2  0 1 mod 7").unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a = MatPolynomialRingZq::from_str(&format!(
+            "[[1  {}, 1  5],[1  {}, 1  -1]] / 2  0 1 mod {}",
+            i64::MAX,
+            i64::MIN,
+            u64::MAX
+        ))
+        .unwrap();
+        let b = MatPolynomialRingZq::from_str(&format!(
+            "[[1  {}, 1  -6],[1  6, 1  -1]] / 2  0 1 mod {}",
+            i64::MAX,
+            u64::MAX
+        ))
+        .unwrap();
+        let cmp = MatPolynomialRingZq::from_str(&format!(
+            "[[1  {}, 1  -1],[1  {}, 1  -2]] / 2  0 1 mod {}",
+            2 * (i64::MAX as u64),
+            i64::MIN + 6,
+            u64::MAX
+        ))
+        .unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for different matrix dimensions.
+    #[test]
+    fn matrix_dimensions() {
+        let modulus = ModulusPolynomialRingZq::from_str("3  1 0 1 mod 7").unwrap();
+        let dimensions = [(3, 3), (5, 1), (1, 4)];
+
+        for (nr_rows, nr_cols) in dimensions {
+            let mut a = MatPolynomialRingZq::new(nr_rows, nr_cols, &modulus);
+            let b = MatPolynomialRingZq::identity(nr_rows, nr_cols, &modulus);
+
+            a += b;
+
+            assert_eq!(MatPolynomialRingZq::identity(nr_rows, nr_cols, &modulus), a);
+        }
+    }
+
+    /// Ensures that mismatching moduli will result in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_moduli() {
+        let modulus_0 = ModulusPolynomialRingZq::from_str("3  1 0 1 mod 7").unwrap();
+        let modulus_1 = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 7").unwrap();
+        let mut a = MatPolynomialRingZq::new(1, 1, &modulus_0);
+        let b = MatPolynomialRingZq::new(1, 1, &modulus_1);
+
+        a += b;
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let modulus = ModulusPolynomialRingZq::from_str("3  1 0 1 mod 7").unwrap();
+        let mut a = MatPolynomialRingZq::new(2, 2, &modulus);
+        let b = MatPolynomialRingZq::new(2, 2, &modulus);
+
+        a += &b;
+        a += b;
+    }
+}
 
 #[cfg(test)]
 mod test_add {

--- a/src/integer_mod_q/mat_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/add.rs
@@ -39,6 +39,10 @@ impl AddAssign<&MatZq> for MatZq {
     /// a += &c;
     /// a += c;
     /// ```
+    ///
+    /// # Panics ...
+    /// - if the matrix dimensions mismatch.
+    /// - if the moduli of the matrices mismatch.
     fn add_assign(&mut self, other: &Self) {
         if self.get_num_rows() != other.get_num_rows()
             || self.get_num_columns() != other.get_num_columns()

--- a/src/integer_mod_q/mat_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/add.rs
@@ -12,13 +12,80 @@ use super::super::MatZq;
 use crate::error::MathError;
 use crate::integer::MatZ;
 use crate::macros::arithmetics::{
-    arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
-    arithmetic_trait_reverse,
+    arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
+    arithmetic_trait_mixed_borrowed_owned, arithmetic_trait_reverse,
 };
 use crate::traits::MatrixDimensions;
 use flint_sys::fmpz_mat::fmpz_mat_add;
 use flint_sys::fmpz_mod_mat::{_fmpz_mod_mat_reduce, fmpz_mod_mat_add};
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&MatZq> for MatZq {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer_mod_q::MatZq, integer::MatZ};
+    /// let mut a = MatZq::identity(2, 2, 7);
+    /// let b = MatZq::new(2, 2, 7);
+    /// let c = MatZ::new(2, 2);
+    ///
+    /// a += &b;
+    /// a += b;
+    /// a += &c;
+    /// a += c;
+    /// ```
+    fn add_assign(&mut self, other: &Self) {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+        if self.modulus != other.modulus {
+            panic!(
+                "Tried to add matrices with moduli '{}' and '{}'.",
+                self.get_mod(),
+                other.get_mod()
+            )
+        }
+
+        unsafe { fmpz_mod_mat_add(&mut self.matrix, &self.matrix, &other.matrix) };
+    }
+}
+impl AddAssign<&MatZ> for MatZq {
+    /// Documentation at [`MatZq::add_assign`].
+    fn add_assign(&mut self, other: &MatZ) {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        unsafe {
+            fmpz_mat_add(&mut self.matrix.mat[0], &self.matrix.mat[0], &other.matrix);
+            _fmpz_mod_mat_reduce(&mut self.matrix);
+        };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, MatZq, MatZq);
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, MatZq, MatZ);
 
 impl Add for &MatZq {
     type Output = MatZq;
@@ -161,6 +228,90 @@ impl MatZq {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, MatZq, MatZq, MatZq);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, MatZq, MatZq, MatZq);
+
+#[cfg(test)]
+mod test_add_assign {
+    use crate::{integer::MatZ, integer_mod_q::MatZq};
+    use std::str::FromStr;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = MatZq::identity(2, 2, 7);
+        let b = MatZq::from_str("[[4, 5],[-6, 6]] mod 7").unwrap();
+        let mut c = a.clone();
+        let d = b.get_representative_least_nonnegative_residue();
+        let cmp = MatZq::from_str("[[5, 5],[1, 0]] mod 7").unwrap();
+
+        a += b;
+        c += d;
+
+        assert_eq!(cmp, a);
+        assert_eq!(cmp, c);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a = MatZq::from_str(&format!(
+            "[[{}, 5],[{}, -1]] mod {}",
+            i64::MAX,
+            i64::MIN,
+            u64::MAX
+        ))
+        .unwrap();
+        let b = MatZq::from_str(&format!("[[{}, -6],[6, -1]] mod {}", i64::MAX, u64::MAX)).unwrap();
+        let cmp = MatZq::from_str(&format!(
+            "[[{}, -1],[{}, -2]] mod {}",
+            2 * (i64::MAX as u64),
+            i64::MIN + 6,
+            u64::MAX
+        ))
+        .unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for different matrix dimensions.
+    #[test]
+    fn matrix_dimensions() {
+        let dimensions = [(3, 3), (5, 1), (1, 4)];
+
+        for (nr_rows, nr_cols) in dimensions {
+            let mut a = MatZq::new(nr_rows, nr_cols, 7);
+            let b = MatZq::identity(nr_rows, nr_cols, 7);
+
+            a += b;
+
+            assert_eq!(MatZq::identity(nr_rows, nr_cols, 7), a);
+        }
+    }
+
+    /// Ensures that mismatching moduli will result in a panic.
+    #[test]
+    #[should_panic]
+    fn mismatching_moduli() {
+        let mut a = MatZq::new(1, 1, 5);
+        let b = MatZq::new(1, 1, 6);
+
+        a += b;
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = MatZq::new(2, 2, 7);
+        let b = MatZq::new(2, 2, 7);
+        let c = MatZ::new(2, 2);
+
+        a += &b;
+        a += b;
+        a += &c;
+        a += c;
+    }
+}
 
 #[cfg(test)]
 mod test_add {

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -350,7 +350,7 @@ impl MatZq {
                 &self.get_mod(),
             ));
             x_i = &matrix_base_inv * &b_i;
-            x = x + &x_i * &base.pow(i).unwrap();
+            x += &x_i * &base.pow(i).unwrap();
         }
 
         let mut out = MatZq::new(self.get_num_columns(), 1, self.get_mod());

--- a/src/rational/mat_q/arithmetic/add.rs
+++ b/src/rational/mat_q/arithmetic/add.rs
@@ -10,13 +10,16 @@
 
 use super::super::MatQ;
 use crate::error::MathError;
-use crate::integer::MatZ;
+use crate::integer::{MatZ, Z};
 use crate::macros::arithmetics::{
     arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
     arithmetic_trait_mixed_borrowed_owned,
 };
 use crate::traits::MatrixDimensions;
-use flint_sys::fmpq_mat::fmpq_mat_add;
+use flint_sys::fmpq_mat::{
+    fmpq_mat_add, fmpq_mat_get_fmpz_mat_matwise, fmpq_mat_set_fmpz_mat_div_fmpz,
+};
+use flint_sys::fmpz_mat::fmpz_mat_add;
 use std::ops::{Add, AddAssign};
 
 impl AddAssign<&MatQ> for MatQ {
@@ -72,9 +75,13 @@ impl AddAssign<&MatZ> for MatQ {
             );
         }
 
-        // there should be a better way than this, but I haven't found it
-        let other = MatQ::from(other);
-        unsafe { fmpq_mat_add(&mut self.matrix, &self.matrix, &other.matrix) };
+        let mut num = MatZ::new(self.get_num_rows(), self.get_num_columns());
+        let mut den = Z::default();
+        unsafe {
+            fmpq_mat_get_fmpz_mat_matwise(&mut num.matrix, &mut den.value, &self.matrix);
+            fmpz_mat_add(&mut num.matrix, &num.matrix, &other.matrix);
+            fmpq_mat_set_fmpz_mat_div_fmpz(&mut self.matrix, &num.matrix, &den.value);
+        }
     }
 }
 

--- a/src/rational/mat_q/arithmetic/add.rs
+++ b/src/rational/mat_q/arithmetic/add.rs
@@ -10,12 +10,76 @@
 
 use super::super::MatQ;
 use crate::error::MathError;
+use crate::integer::MatZ;
 use crate::macros::arithmetics::{
-    arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned,
+    arithmetic_assign_trait_borrowed_to_owned, arithmetic_trait_borrowed_to_owned,
+    arithmetic_trait_mixed_borrowed_owned,
 };
 use crate::traits::MatrixDimensions;
 use flint_sys::fmpq_mat::fmpq_mat_add;
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
+
+impl AddAssign<&MatQ> for MatQ {
+    /// Computes the addition of `self` and `other` reusing
+    /// the memory of `self`.
+    ///
+    /// Parameters:
+    /// - `other`: specifies the value to add to `self`
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{rational::MatQ, integer::MatZ};
+    /// let mut a = MatQ::identity(2, 2);
+    /// let b = MatQ::new(2, 2);
+    /// let c = MatZ::new(2, 2);
+    ///
+    /// a += &b;
+    /// a += b;
+    /// a += &c;
+    /// a += c;
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if the matrix dimensions mismatch.
+    fn add_assign(&mut self, other: &Self) {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        unsafe { fmpq_mat_add(&mut self.matrix, &self.matrix, &other.matrix) };
+    }
+}
+impl AddAssign<&MatZ> for MatQ {
+    /// Documentation at [`MatQ::add_assign`].
+    fn add_assign(&mut self, other: &MatZ) {
+        if self.get_num_rows() != other.get_num_rows()
+            || self.get_num_columns() != other.get_num_columns()
+        {
+            panic!(
+                "Tried to add a '{}x{}' matrix and a '{}x{}' matrix.",
+                self.get_num_rows(),
+                self.get_num_columns(),
+                other.get_num_rows(),
+                other.get_num_columns()
+            );
+        }
+
+        // there should be a better way than this, but I haven't found it
+        let other = MatQ::from(other);
+        unsafe { fmpq_mat_add(&mut self.matrix, &self.matrix, &other.matrix) };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, MatQ, MatQ);
+arithmetic_assign_trait_borrowed_to_owned!(AddAssign, add_assign, MatQ, MatZ);
 
 impl Add for &MatQ {
     type Output = MatQ;
@@ -94,6 +158,74 @@ impl MatQ {
 
 arithmetic_trait_borrowed_to_owned!(Add, add, MatQ, MatQ, MatQ);
 arithmetic_trait_mixed_borrowed_owned!(Add, add, MatQ, MatQ, MatQ);
+
+#[cfg(test)]
+mod test_add_assign {
+    use crate::{integer::MatZ, rational::MatQ};
+    use std::str::FromStr;
+
+    /// Ensure that `add_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = MatQ::identity(2, 2);
+        let b = MatQ::from_str("[[4/5, 5],[-6, -1]]").unwrap();
+        let mut c = a.clone();
+        let d = MatZ::from_str("[[4, 5],[-6, -1]]").unwrap();
+        let cmp_0 = MatQ::from_str("[[9/5, 5],[-6, 0]]").unwrap();
+        let cmp_1 = MatQ::from_str("[[5, 5],[-6, 0]]").unwrap();
+
+        a += b;
+        c += d;
+
+        assert_eq!(cmp_0, a);
+        assert_eq!(cmp_1, c);
+    }
+
+    /// Ensure that `add_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a = MatQ::from_str(&format!("[[{}/1, 5/2],[{}, -1]]", i64::MAX, i64::MIN)).unwrap();
+        let b = MatQ::from_str(&format!("[[{}, -6/2],[6, -1]]", i64::MAX)).unwrap();
+        let cmp = MatQ::from_str(&format!(
+            "[[{}, -1/2],[{}, -2]]",
+            2 * (i64::MAX as u64),
+            i64::MIN + 6
+        ))
+        .unwrap();
+
+        a += b;
+
+        assert_eq!(cmp, a);
+    }
+
+    /// Ensure that `add_assign` works for different matrix dimensions.
+    #[test]
+    fn matrix_dimensions() {
+        let dimensions = [(3, 3), (5, 1), (1, 4)];
+
+        for (nr_rows, nr_cols) in dimensions {
+            let mut a = MatQ::new(nr_rows, nr_cols);
+            let b = MatQ::identity(nr_rows, nr_cols);
+
+            a += b;
+
+            assert_eq!(MatQ::identity(nr_rows, nr_cols), a);
+        }
+    }
+
+    /// Ensure that `add_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = MatQ::new(2, 2);
+        let b = MatQ::new(2, 2);
+        let c = MatZ::new(2, 2);
+
+        a += &b;
+        a += b;
+        a += &c;
+        a += c;
+    }
+}
 
 #[cfg(test)]
 mod test_add {


### PR DESCRIPTION
**Description**
This PR implements `AddAssign` for ...
- [x] MatZ
- [x] MatZq
- [x] MatQ
- [x] MatPolyOverZ
- [x] MatPolynomialRingZq

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide