### PR TITLE
PartialEq between PolyOverZq and ModPoly

### DIFF
--- a/src/integer/mat_z/forms.rs
+++ b/src/integer/mat_z/forms.rs
@@ -136,7 +136,7 @@ mod test_hermite_nf {
         ))
         .unwrap();
         let h_cmp = MatZ::from_str(&format!("[[{}, 0],[0, {}]]", i64::MAX, u64::MAX)).unwrap();
-        let u_cmp = MatZ::from_str(&format!("[[1, 0],[-2, 1]]")).unwrap();
+        let u_cmp = MatZ::from_str("[[1, 0],[-2, 1]]").unwrap();
 
         let (h, u) = matrix.hermite_nf();
 

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
@@ -10,6 +10,10 @@
 //! This uses the traits from [`std::cmp`].
 
 use super::ModulusPolynomialRingZq;
+use crate::{
+    integer::Z, integer_mod_q::PolyOverZq, macros::for_others::implement_trait_reverse,
+    traits::GetCoefficient,
+};
 use flint_sys::{fmpz::fmpz_equal, fmpz_mod_poly::fmpz_mod_poly_equal};
 
 impl PartialEq for ModulusPolynomialRingZq {
@@ -61,6 +65,61 @@ impl PartialEq for ModulusPolynomialRingZq {
 // With the [`Eq`] trait, `a == a` is always true.
 // This is not guaranteed by the [`PartialEq`] trait.
 impl Eq for ModulusPolynomialRingZq {}
+
+impl PartialEq<PolyOverZq> for ModulusPolynomialRingZq {
+    /// Checks if an integer matrix and a rational matrix are equal. Used by the `==` and `!=` operators.
+    /// [`PartialEq`] is also implemented for [`PolyOverZq`] using [`ModulusPolynomialRingZq`].
+    ///
+    /// Parameters:
+    /// - `other`: the other value that is used to compare the elements
+    ///
+    /// Returns `true` if the elements are equal, otherwise `false`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{PolyOverZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
+    /// let a: ModulusPolynomialRingZq = ModulusPolynomialRingZq::from_str("3  1 2 3 mod 17").unwrap();
+    /// let b: PolyOverZq = PolyOverZq::from_str("3  1 2 3 mod 17").unwrap();
+    ///
+    /// // These are all equivalent and return true.
+    /// let compared: bool = (a == b);
+    /// # assert!(compared);
+    /// let compared: bool = (b == a);
+    /// # assert!(compared);
+    /// let compared: bool = (&a == &b);
+    /// # assert!(compared);
+    /// let compared: bool = (&b == &a);
+    /// # assert!(compared);
+    /// let compared: bool = (a.eq(&b));
+    /// # assert!(compared);
+    /// let compared: bool = (b.eq(&a));
+    /// # assert!(compared);
+    /// let compared: bool = (ModulusPolynomialRingZq::eq(&a, &b));
+    /// # assert!(compared);
+    /// let compared: bool = (PolyOverZq::eq(&b, &a));
+    /// # assert!(compared);
+    /// ```
+    fn eq(&self, other: &PolyOverZq) -> bool {
+        let degree = self.get_degree();
+
+        if degree != other.get_degree() {
+            return false;
+        }
+
+        for i in 0..degree + 1 {
+            if GetCoefficient::<Z>::get_coeff(self, i).unwrap()
+                != GetCoefficient::<Z>::get_coeff(other, i).unwrap()
+            {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+implement_trait_reverse!(PartialEq, eq, PolyOverZq, ModulusPolynomialRingZq, bool);
 
 /// Test that the [`PartialEq`] trait is correctly implemented.
 /// Consider that negative is turned positive due to the modulus being applied.
@@ -232,5 +291,35 @@ mod test_partial_eq {
         let second = ModulusPolynomialRingZq::from_str(second_str).unwrap();
 
         assert_ne!(first, second);
+    }
+}
+
+/// Test that the [`PartialEq`] trait is correctly implemented.
+#[cfg(test)]
+mod test_partial_eq_q_other {
+    use crate::integer_mod_q::{ModulusPolynomialRingZq, PolyOverZq};
+    use std::str::FromStr;
+
+    // Ensure that the function can be called with several types
+    #[test]
+    #[allow(clippy::op_ref)]
+    fn availability() {
+        let q = ModulusPolynomialRingZq::from_str("4  1 2 3 4 mod 17").unwrap();
+        let z = PolyOverZq::from_str("4  1 2 3 4 mod 17").unwrap();
+
+        assert!(q == z);
+        assert!(z == q);
+        assert!(&q == &z);
+        assert!(&z == &q);
+    }
+
+    // Ensure that large values are compared correctly
+    #[test]
+    fn equal_large() {
+        let q = ModulusPolynomialRingZq::from_str(&format!("3  1 2 {} mod {}", i64::MAX, u64::MAX))
+            .unwrap();
+        let z = PolyOverZq::from_str(&format!("3  1 2 {} mod {}", i64::MAX, u64::MAX)).unwrap();
+
+        assert!(q == z);
     }
 }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
@@ -101,8 +101,11 @@ impl PartialEq<PolyOverZq> for ModulusPolynomialRingZq {
     /// # assert!(compared);
     /// ```
     fn eq(&self, other: &PolyOverZq) -> bool {
-        let degree = self.get_degree();
+        if self.get_q() != other.modulus {
+            return false;
+        }
 
+        let degree = self.get_degree();
         if degree != other.get_degree() {
             return false;
         }
@@ -300,7 +303,7 @@ mod test_partial_eq_q_other {
     use crate::integer_mod_q::{ModulusPolynomialRingZq, PolyOverZq};
     use std::str::FromStr;
 
-    // Ensure that the function can be called with several types
+    /// Ensure that the function can be called with several types.
     #[test]
     #[allow(clippy::op_ref)]
     fn availability() {
@@ -313,13 +316,30 @@ mod test_partial_eq_q_other {
         assert!(&z == &q);
     }
 
-    // Ensure that large values are compared correctly
+    /// Ensure that equal values are compared correctly.
     #[test]
-    fn equal_large() {
+    fn equal() {
         let q = ModulusPolynomialRingZq::from_str(&format!("3  1 2 {} mod {}", i64::MAX, u64::MAX))
             .unwrap();
-        let z = PolyOverZq::from_str(&format!("3  1 2 {} mod {}", i64::MAX, u64::MAX)).unwrap();
+        let z_1 = PolyOverZq::from_str(&format!("3  1 2 {} mod {}", i64::MAX, u64::MAX)).unwrap();
+        let z_2 = PolyOverZq::from_str(&format!("4  1 2 {} 0 mod {}", i64::MAX, u64::MAX)).unwrap();
 
-        assert!(q == z);
+        assert!(q == z_1);
+        assert!(q == z_2);
+    }
+
+    /// Ensure that unequal values are compared correctly.
+    #[test]
+    fn unequal() {
+        let q = ModulusPolynomialRingZq::from_str(&format!("3  1 2 {} mod {}", i64::MAX, u64::MAX))
+            .unwrap();
+        let z_1 = PolyOverZq::from_str(&format!("3  1 3 {} mod {}", i64::MAX, u64::MAX)).unwrap();
+        let z_2 = PolyOverZq::from_str(&format!("4  1 2 {} 1 mod {}", i64::MAX, u64::MAX)).unwrap();
+        let z_3 =
+            PolyOverZq::from_str(&format!("3  1 2 {} mod {}", i64::MAX, u64::MAX - 1)).unwrap();
+
+        assert!(q != z_1);
+        assert!(q != z_2);
+        assert!(q != z_3);
     }
 }

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/serialize.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/serialize.rs
@@ -85,8 +85,11 @@ mod test_deserialize {
         let poly_str = "2  17 42 mod 331";
         let cmp_str = format!("{{\"poly\":\"{poly_str}\"}}");
 
-        let poly_z = ModulusPolynomialRingZq::from_str(poly_str).unwrap();
-        assert_eq!(poly_z, serde_json::from_str(&cmp_str).unwrap());
+        let poly_mod = ModulusPolynomialRingZq::from_str(poly_str).unwrap();
+        assert_eq!(
+            poly_mod,
+            serde_json::from_str::<ModulusPolynomialRingZq>(&cmp_str).unwrap()
+        );
     }
 
     /// Tests whether the deserialization of a negative [`ModulusPolynomialRingZq`] works.
@@ -95,8 +98,11 @@ mod test_deserialize {
         let poly_str = "3  -17 -42 1 mod 331";
         let cmp_str = format!("{{\"poly\":\"{poly_str}\"}}");
 
-        let poly_z = ModulusPolynomialRingZq::from_str(poly_str).unwrap();
-        assert_eq!(poly_z, serde_json::from_str(&cmp_str).unwrap());
+        let poly_mod = ModulusPolynomialRingZq::from_str(poly_str).unwrap();
+        assert_eq!(
+            poly_mod,
+            serde_json::from_str::<ModulusPolynomialRingZq>(&cmp_str).unwrap()
+        );
     }
 
     /// Tests whether the deserialization of a positive large [`ModulusPolynomialRingZq`] works.
@@ -105,8 +111,11 @@ mod test_deserialize {
         let poly_str = format!("3  -17 {} 1 mod {}", u64::MAX, u64::MAX - 58);
         let cmp_str = format!("{{\"poly\":\"{poly_str}\"}}");
 
-        let poly_z = ModulusPolynomialRingZq::from_str(&poly_str).unwrap();
-        assert_eq!(poly_z, serde_json::from_str(&cmp_str).unwrap());
+        let poly_mod = ModulusPolynomialRingZq::from_str(&poly_str).unwrap();
+        assert_eq!(
+            poly_mod,
+            serde_json::from_str::<ModulusPolynomialRingZq>(&cmp_str).unwrap()
+        );
     }
 
     /// Tests whether the deserialization of a negative large [`ModulusPolynomialRingZq`] works.
@@ -115,8 +124,11 @@ mod test_deserialize {
         let poly_str = format!("3  -17 -{} 1 mod {}", u64::MAX, u64::MAX - 58);
         let cmp_str = format!("{{\"poly\":\"{poly_str}\"}}");
 
-        let poly_z = ModulusPolynomialRingZq::from_str(&poly_str).unwrap();
-        assert_eq!(poly_z, serde_json::from_str(&cmp_str).unwrap());
+        let poly_mod = ModulusPolynomialRingZq::from_str(&poly_str).unwrap();
+        assert_eq!(
+            poly_mod,
+            serde_json::from_str::<ModulusPolynomialRingZq>(&cmp_str).unwrap()
+        );
     }
 
     /// Tests whether deserialization of a non-prime large `q` [`ModulusPolynomialRingZq`] fails.

--- a/src/integer_mod_q/poly_over_zq/serialize.rs
+++ b/src/integer_mod_q/poly_over_zq/serialize.rs
@@ -85,8 +85,11 @@ mod test_deserialize {
         let poly_str = "2  17 42 mod 81";
         let cmp_str = format!("{{\"poly\":\"{poly_str}\"}}");
 
-        let poly_z = PolyOverZq::from_str(poly_str).unwrap();
-        assert_eq!(poly_z, serde_json::from_str(&cmp_str).unwrap());
+        let poly_zq = PolyOverZq::from_str(poly_str).unwrap();
+        assert_eq!(
+            poly_zq,
+            serde_json::from_str::<PolyOverZq>(&cmp_str).unwrap()
+        );
     }
 
     /// Tests whether the deserialization of a negative [`PolyOverZq`] works.
@@ -95,8 +98,11 @@ mod test_deserialize {
         let poly_str = "3  -17 -42 1 mod 81";
         let cmp_str = format!("{{\"poly\":\"{poly_str}\"}}");
 
-        let poly_z = PolyOverZq::from_str(poly_str).unwrap();
-        assert_eq!(poly_z, serde_json::from_str(&cmp_str).unwrap());
+        let poly_zq = PolyOverZq::from_str(poly_str).unwrap();
+        assert_eq!(
+            poly_zq,
+            serde_json::from_str::<PolyOverZq>(&cmp_str).unwrap()
+        );
     }
 
     /// Tests whether the deserialization of a positive large [`PolyOverZq`] works.
@@ -105,8 +111,11 @@ mod test_deserialize {
         let poly_str = format!("3  -17 {} 1 mod {}", u64::MAX, u64::MAX - 58);
         let cmp_str = format!("{{\"poly\":\"{poly_str}\"}}");
 
-        let poly_z = PolyOverZq::from_str(&poly_str).unwrap();
-        assert_eq!(poly_z, serde_json::from_str(&cmp_str).unwrap());
+        let poly_zq = PolyOverZq::from_str(&poly_str).unwrap();
+        assert_eq!(
+            poly_zq,
+            serde_json::from_str::<PolyOverZq>(&cmp_str).unwrap()
+        );
     }
 
     /// Tests whether the deserialization of a negative large [`PolyOverZq`] works.
@@ -115,8 +124,11 @@ mod test_deserialize {
         let poly_str = format!("3  -17 -{} 1 mod {}", u64::MAX, u64::MAX - 58);
         let cmp_str = format!("{{\"poly\":\"{poly_str}\"}}");
 
-        let poly_z = PolyOverZq::from_str(&poly_str).unwrap();
-        assert_eq!(poly_z, serde_json::from_str(&cmp_str).unwrap());
+        let poly_zq = PolyOverZq::from_str(&poly_str).unwrap();
+        assert_eq!(
+            poly_zq,
+            serde_json::from_str::<PolyOverZq>(&cmp_str).unwrap()
+        );
     }
 
     /// Tests whether no fields 'poly' provided yield an error


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements PartialEq between PolyOverZq and ModPoly.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
