### PR TITLE
Revise decimal representation of `Q`, `MatQ` and `PolyOverQ`

### DIFF
--- a/src/rational/mat_q/to_string.rs
+++ b/src/rational/mat_q/to_string.rs
@@ -151,8 +151,7 @@ impl MatQ {
         column: i64,
         nr_decimal_digits: usize,
     ) {
-        // exchange with `get_entry_unchecked` once changes are on dev
-        let entry = self.get_entry(row, column).unwrap();
+        let entry = unsafe { self.get_entry_unchecked(row, column) };
         let entry_string = entry.to_string_decimal(nr_decimal_digits);
         matrix_string.push_str(&entry_string);
     }
@@ -178,11 +177,11 @@ mod test_to_string_decimal {
         let c_0 = c.to_string_decimal(0);
         let c_1 = c.to_string_decimal(1);
 
-        assert_eq!("[[1, 0],\n[-1, -2]]", a_0);
+        assert_eq!("[[2, 0],\n[-1, -2]]", a_0);
         assert_eq!("[[1.5, 0.5],\n[-1.0, -2.3]]", a_1);
-        assert_eq!("[[1],\n[-2]]", b_0);
+        assert_eq!("[[2],\n[-2]]", b_0);
         assert_eq!("[[1.50],\n[-2.33]]", b_2);
-        assert_eq!("[[1, 0, -2]]", c_0);
+        assert_eq!("[[2, 0, -2]]", c_0);
         assert_eq!("[[1.5, 0.5, -2.3]]", c_1);
     }
 }

--- a/src/rational/poly_over_q/to_string.rs
+++ b/src/rational/poly_over_q/to_string.rs
@@ -141,8 +141,8 @@ mod test_to_string_decimal {
         assert_eq!("0", a_1);
         assert_eq!("1  0", b_0);
         assert_eq!("1  0.33", b_2);
-        assert_eq!("3  0 0 -1", c_0);
-        assert_eq!("3  0.3 0.0 -1.6", c_1);
+        assert_eq!("3  0 0 -2", c_0);
+        assert_eq!("3  0.3 0.0 -1.7", c_1);
     }
 }
 

--- a/src/rational/q/to_string.rs
+++ b/src/rational/q/to_string.rs
@@ -87,7 +87,11 @@ impl Q {
     /// Outputs the decimal representation of a [`Q`] with
     /// the specified number of decimal digits.
     /// If `self` can't be represented exactly, it provides the
-    /// closest value representable with `nr_decimal_digits` rounded towards zero.
+    /// closest value representable with `nr_decimal_digits` rounded
+    /// towards the next representable number.
+    ///
+    /// Notice that, e.g., `0.5` is represented as `0.499...` as [`f64`].
+    /// Therefore, rounding with `nr_decimal_digits = 0` will output `0`.
     ///
     /// **WARNING:** This function converts the [`Q`] value into an [`f64`] before
     /// outputting the decimal representation. Thus, values that can't be represented exactly
@@ -113,26 +117,7 @@ impl Q {
     /// - if `self` can't be represented as an [`f64`].
     pub fn to_string_decimal(&self, nr_decimal_digits: usize) -> String {
         let value = f64::from(self);
-        let mut string = value.to_string();
-        let index_of_dot = string.find(".");
-
-        match (index_of_dot, nr_decimal_digits) {
-            (Some(index), 0) => string.truncate(index + nr_decimal_digits),
-            (Some(index), _) => {
-                if index + nr_decimal_digits + 1 > string.len() {
-                    string.push_str(&str::repeat(
-                        "0",
-                        index + nr_decimal_digits + 1 - string.len(),
-                    ));
-                } else {
-                    string.truncate(index + nr_decimal_digits + 1);
-                }
-            }
-            (None, 0) => (),
-            (None, _) => string.push_str(&format!(".{}", str::repeat("0", nr_decimal_digits))),
-        }
-
-        string
+        format!("{:.1$}", value, nr_decimal_digits)
     }
 }
 
@@ -185,9 +170,9 @@ mod test_to_string_decimal {
         let c_1 = c.to_string_decimal(1);
         let c_2 = c.to_string_decimal(2);
 
-        assert_eq!("0", a_0);
-        assert_eq!("0.6", a_1);
-        assert_eq!("0.66", a_2);
+        assert_eq!("1", a_0);
+        assert_eq!("0.7", a_1);
+        assert_eq!("0.67", a_2);
         assert_eq!("10", b_0);
         assert_eq!("10.5", b_1);
         assert_eq!("10.50", b_2);
@@ -204,8 +189,8 @@ mod test_to_string_decimal {
         let a_0 = a.to_string_decimal(0);
         let a_1 = a.to_string_decimal(1);
 
-        assert_eq!("9223372036854775000", a_0); // deviation of 807 from original value
-        assert_eq!("9223372036854775000.0", a_1);
+        assert_eq!("9223372036854774784", a_0); // deviation of 1023 from original value
+        assert_eq!("9223372036854774784.0", a_1);
     }
 }
 


### PR DESCRIPTION
**Description**

This PR...
- [x] updates decimal representation of Q, MatQ and PolyOverQ using the built-in function for f64::to_string and the new unsafe function to get an entry for MatQ

Downside of this: Rounding is less clear. It requires knowledge of how a number is represented in floating point arithmetic to understand the output (mostly relevant for the case if `nr_decimal_digits = 0`).