### PR TITLE
Rework Getters for Matrices by accessing via Submatrices

### DIFF
--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -13,7 +13,7 @@ use crate::{
     error::MathError,
     integer::PolyOverZ,
     traits::{MatrixDimensions, MatrixGetEntry, MatrixGetSubmatrix},
-    utils::index::{evaluate_index_for_vector, evaluate_indices_for_matrix},
+    utils::index::evaluate_indices_for_matrix,
 };
 use flint_sys::{
     fmpz_poly::{fmpz_poly_set, fmpz_poly_struct},
@@ -133,39 +133,6 @@ impl MatrixGetEntry<PolyOverZ> for MatPolyOverZ {
 }
 
 impl MatrixGetSubmatrix for MatPolyOverZ {
-    /// Outputs a column vector of the specified column.
-    ///
-    /// Input parameters:
-    /// - `column`: specifies the column of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a column vector of the matrix at the position of the given
-    /// `column` or an error if the number of columns is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{integer::MatPolyOverZ, traits::MatrixGetSubmatrix};
-    /// use std::str::FromStr;
-    ///
-    /// let matrix = MatPolyOverZ::from_str("[[1  1, 0],[1  3, 1  4],[0, 1  6]]").unwrap();
-    ///
-    /// let col_0 = matrix.get_column(0).unwrap(); // first column
-    /// let col_1 = matrix.get_column(1).unwrap(); // second column
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the column is greater than the matrix.
-    fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_cols = self.get_num_columns();
-        let column_i64 = evaluate_index_for_vector(column, num_cols)?;
-
-        self.get_submatrix(0, self.get_num_rows() - 1, column_i64, column_i64)
-    }
-
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
     /// a new matrix.

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -133,11 +133,9 @@ impl MatrixGetEntry<PolyOverZ> for MatPolyOverZ {
 }
 
 impl MatrixGetSubmatrix for MatPolyOverZ {
-    /// Returns a deep copy of the submatrix defined by the given parameters.
-    /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
-    /// a new matrix.
-    /// Note that `row_1 >= row_2` and `col_1 >= col_2` must hold after converting negative indices.
-    /// Otherwise the function will panic.
+    /// Returns a deep copy of the submatrix defined by the given parameters
+    /// and does not check the provided dimensions.
+    /// There is also a safe version of this function that checks the input.
     ///
     /// Parameters:
     /// `row_1`: the starting row of the submatrix
@@ -145,11 +143,7 @@ impl MatrixGetSubmatrix for MatPolyOverZ {
     /// `col_1`: the starting column of the submatrix
     /// `col_2`: the ending column of the submatrix
     ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(inclusively)
-    /// or an error if any provided row or column is greater than the matrix.
+    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(exclusively).
     ///
     /// # Examples
     /// ```
@@ -166,34 +160,16 @@ impl MatrixGetSubmatrix for MatPolyOverZ {
     /// assert_eq!(e_2, sub_mat_2);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    ///   if any provided row or column is greater than the matrix.
-    ///
-    /// # Panics ...
-    /// - if `col_1 > col_2` or `row_1 > row_2`.
-    fn get_submatrix(
+    /// # Safety
+    /// The user has to ensure that all entries are within the matrix dimensions.
+    /// Otherwise, memory leaks can occur and no guarantees are given.
+    unsafe fn get_submatrix_unchecked(
         &self,
-        row_1: impl TryInto<i64> + Display,
-        row_2: impl TryInto<i64> + Display,
-        col_1: impl TryInto<i64> + Display,
-        col_2: impl TryInto<i64> + Display,
+        row_1: i64,
+        row_2: i64,
+        col_1: i64,
+        col_2: i64,
     ) -> Result<Self, MathError> {
-        let (row_1, col_1) = evaluate_indices_for_matrix(self, row_1, col_1)?;
-        let (row_2, col_2) = evaluate_indices_for_matrix(self, row_2, col_2)?;
-        assert!(
-            row_2 >= row_1,
-            "The number of rows must be positive, i.e. row_2 ({row_2}) must be greater or equal row_1 ({row_1})"
-        );
-
-        assert!(
-            col_2 >= col_1,
-            "The number of columns must be positive, i.e. col_2 ({col_2}) must be greater or equal col_1 ({col_1})"
-        );
-
-        // increase both values to have an inclusive capturing of the matrix entries
-        let (row_2, col_2) = (row_2 + 1, col_2 + 1);
-
         let mut window = MaybeUninit::uninit();
         // The memory for the elements of window is shared with self.
         unsafe {

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -154,22 +154,25 @@ impl MatrixGetSubmatrix for MatPolyOverZ {
     ///
     /// let sub_mat_1 = mat.get_submatrix(0, 2, 1, 1).unwrap();
     /// let sub_mat_2 = mat.get_submatrix(0, -1, 1, -2).unwrap();
+    /// let sub_mat_3 = unsafe{mat.get_submatrix_unchecked(0, 3, 1, 2)};
     ///
     /// let e_2 = MatPolyOverZ::from_str("[[0],[1  1],[0]]").unwrap();
     /// assert_eq!(e_2, sub_mat_1);
     /// assert_eq!(e_2, sub_mat_2);
+    /// assert_eq!(e_2, sub_mat_3);
     /// ```
     ///
     /// # Safety
-    /// The user has to ensure that all entries are within the matrix dimensions.
-    /// Otherwise, memory leaks can occur and no guarantees are given.
+    /// To use this function safely, make sure that the selected submatrix is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
     unsafe fn get_submatrix_unchecked(
         &self,
         row_1: i64,
         row_2: i64,
         col_1: i64,
         col_2: i64,
-    ) -> Result<Self, MathError> {
+    ) -> Self {
         let mut window = MaybeUninit::uninit();
         // The memory for the elements of window is shared with self.
         unsafe {
@@ -190,9 +193,9 @@ impl MatrixGetSubmatrix for MatPolyOverZ {
             // the memory to the underlying matrix that window points to is not freed
             fmpz_poly_mat_window_clear(window.as_mut_ptr());
         }
-        Ok(MatPolyOverZ {
+        MatPolyOverZ {
             matrix: unsafe { window_copy.assume_init() },
-        })
+        }
     }
 }
 

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -133,40 +133,6 @@ impl MatrixGetEntry<PolyOverZ> for MatPolyOverZ {
 }
 
 impl MatrixGetSubmatrix for MatPolyOverZ {
-    /// Outputs the row vector of the specified row.
-    ///
-    /// Parameters:
-    /// - `row`: specifies the row of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a row vector of the matrix at the position of the given
-    /// `row` or an error if the number of rows is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{integer::MatPolyOverZ, traits::MatrixGetSubmatrix};
-    /// use std::str::FromStr;
-    ///
-    /// let matrix = MatPolyOverZ::from_str("[[1  1, 0],[1  3, 1  4],[0, 1  6]]").unwrap();
-    ///
-    /// let row_0 = matrix.get_row(0).unwrap(); // first row
-    /// let row_1 = matrix.get_row(1).unwrap(); // second row
-    /// let row_2 = matrix.get_row(2).unwrap(); // third row
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the row is greater than the matrix.
-    fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_rows = self.get_num_rows();
-        let row_i64 = evaluate_index_for_vector(row, num_rows)?;
-
-        self.get_submatrix(row_i64, row_i64, 0, self.get_num_columns() - 1)
-    }
-
     /// Outputs a column vector of the specified column.
     ///
     /// Input parameters:

--- a/src/integer/mat_poly_over_z/sort.rs
+++ b/src/integer/mat_poly_over_z/sort.rs
@@ -68,7 +68,7 @@ impl MatPolyOverZ {
     ) -> Result<Self, MathError> {
         let mut condition_values = vec![];
         for col in 0..self.get_num_columns() {
-            condition_values.push(cond_func(&self.get_column(col).unwrap())?);
+            condition_values.push(cond_func(&unsafe { self.get_column_unchecked(col) })?);
         }
 
         let mut id_vec: Vec<usize> = (0..self.get_num_columns() as usize).collect();
@@ -135,7 +135,7 @@ impl MatPolyOverZ {
     ) -> Result<Self, MathError> {
         let mut condition_values = vec![];
         for row in 0..self.get_num_rows() {
-            condition_values.push(cond_func(&self.get_row(row).unwrap())?);
+            condition_values.push(cond_func(&unsafe { self.get_row_unchecked(row) })?);
         }
         let mut id_vec: Vec<usize> = (0..self.get_num_rows() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -13,7 +13,7 @@ use crate::{
     error::MathError,
     integer::Z,
     traits::{MatrixDimensions, MatrixGetEntry, MatrixGetSubmatrix},
-    utils::index::{evaluate_index_for_vector, evaluate_indices_for_matrix},
+    utils::index::evaluate_indices_for_matrix,
 };
 use flint_sys::{
     fmpz::{fmpz, fmpz_init_set},
@@ -132,40 +132,6 @@ impl MatrixGetEntry<Z> for MatZ {
 }
 
 impl MatrixGetSubmatrix for MatZ {
-    /// Outputs a column vector of the specified column.
-    ///
-    /// Input parameters:
-    /// - `column`: specifies the column of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a column vector of the matrix at the position of the given
-    /// `column` or an error if the number of columns is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{integer::MatZ, traits::MatrixGetSubmatrix};
-    /// use std::str::FromStr;
-    ///
-    /// let matrix = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
-    ///
-    /// let col_0 = matrix.get_column(0).unwrap(); // first column
-    /// let col_1 = matrix.get_column(1).unwrap(); // second column
-    /// let col_2 = matrix.get_column(2).unwrap(); // third column
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the column is greater than the matrix.
-    fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_cols = self.get_num_columns();
-        let column_i64 = evaluate_index_for_vector(column, num_cols)?;
-
-        self.get_submatrix(0, self.get_num_rows() - 1, column_i64, column_i64)
-    }
-
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
     /// a new matrix.

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -132,39 +132,6 @@ impl MatrixGetEntry<Z> for MatZ {
 }
 
 impl MatrixGetSubmatrix for MatZ {
-    /// Outputs the row vector of the specified row.
-    ///
-    /// Parameters:
-    /// - `row`: specifies the row of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a row vector of the matrix at the position of the given
-    /// `row` or an error if the number of rows is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{integer::MatZ, traits::MatrixGetSubmatrix};
-    /// use std::str::FromStr;
-    ///
-    /// let matrix = MatZ::from_str("[[1, 2, 3],[3, 4, 5]]").unwrap();
-    ///
-    /// let row_0 = matrix.get_row(0).unwrap(); // first row
-    /// let row_1 = matrix.get_row(1).unwrap(); // second row
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the row is greater than the matrix.
-    fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_rows = self.get_num_rows();
-        let row_i64 = evaluate_index_for_vector(row, num_rows)?;
-
-        self.get_submatrix(row_i64, row_i64, 0, self.get_num_columns() - 1)
-    }
-
     /// Outputs a column vector of the specified column.
     ///
     /// Input parameters:

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -132,11 +132,9 @@ impl MatrixGetEntry<Z> for MatZ {
 }
 
 impl MatrixGetSubmatrix for MatZ {
-    /// Returns a deep copy of the submatrix defined by the given parameters.
-    /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
-    /// a new matrix.
-    /// Note that `row_1 >= row_2` and `col_1 >= col_2` must hold after converting negative indices.
-    /// Otherwise the function will panic.
+    /// Returns a deep copy of the submatrix defined by the given parameters
+    /// and does not check the provided dimensions.
+    /// There is also a safe version of this function that checks the input.
     ///
     /// Parameters:
     /// `row_1`: the starting row of the submatrix
@@ -144,11 +142,7 @@ impl MatrixGetSubmatrix for MatZ {
     /// `col_1`: the starting column of the submatrix
     /// `col_2`: the ending column of the submatrix
     ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(inclusively)
-    /// or an error if any provided row or column is greater than the matrix.
+    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(exclusively).
     ///
     /// # Examples
     /// ```
@@ -165,34 +159,16 @@ impl MatrixGetSubmatrix for MatZ {
     /// assert_eq!(e_2, sub_mat_2);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    ///   if any provided row or column is greater than the matrix.
-    ///
-    /// # Panics ...
-    /// - if `col_1 > col_2` or `row_1 > row_2`.
-    fn get_submatrix(
+    /// # Safety
+    /// The user has to ensure that all entries are within the matrix dimensions.
+    /// Otherwise, memory leaks can occur and no guarantees are given.
+    unsafe fn get_submatrix_unchecked(
         &self,
-        row_1: impl TryInto<i64> + Display,
-        row_2: impl TryInto<i64> + Display,
-        col_1: impl TryInto<i64> + Display,
-        col_2: impl TryInto<i64> + Display,
+        row_1: i64,
+        row_2: i64,
+        col_1: i64,
+        col_2: i64,
     ) -> Result<Self, MathError> {
-        let (row_1, col_1) = evaluate_indices_for_matrix(self, row_1, col_1)?;
-        let (row_2, col_2) = evaluate_indices_for_matrix(self, row_2, col_2)?;
-        assert!(
-            row_2 >= row_1,
-            "The number of rows must be positive, i.e. row_2 ({row_2}) must be greater or equal row_1 ({row_1})"
-        );
-
-        assert!(
-            col_2 >= col_1,
-            "The number of columns must be positive, i.e. col_2 ({col_2}) must be greater or equal col_1 ({col_1})"
-        );
-
-        // increase both values to have an inclusive capturing of the matrix entries
-        let (row_2, col_2) = (row_2 + 1, col_2 + 1);
-
         let mut window = MaybeUninit::uninit();
         // The memory for the elements of window is shared with self.
         unsafe {

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -153,22 +153,25 @@ impl MatrixGetSubmatrix for MatZ {
     ///
     /// let sub_mat_1 = mat.get_submatrix(0, 2, 1, 1).unwrap();
     /// let sub_mat_2 = mat.get_submatrix(0, -1, 1, -2).unwrap();
+    /// let sub_mat_3 = unsafe{mat.get_submatrix_unchecked(0, 3, 1, 2)};
     ///
     /// let e_2 = MatZ::from_str("[[0],[1],[0]]").unwrap();
     /// assert_eq!(e_2, sub_mat_1);
     /// assert_eq!(e_2, sub_mat_2);
+    /// assert_eq!(e_2, sub_mat_3);
     /// ```
     ///
     /// # Safety
-    /// The user has to ensure that all entries are within the matrix dimensions.
-    /// Otherwise, memory leaks can occur and no guarantees are given.
+    /// To use this function safely, make sure that the selected submatrix is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
     unsafe fn get_submatrix_unchecked(
         &self,
         row_1: i64,
         row_2: i64,
         col_1: i64,
         col_2: i64,
-    ) -> Result<Self, MathError> {
+    ) -> Self {
         let mut window = MaybeUninit::uninit();
         // The memory for the elements of window is shared with self.
         unsafe {
@@ -189,9 +192,9 @@ impl MatrixGetSubmatrix for MatZ {
             // the memory to the underlying matrix that window points to is not freed
             fmpz_mat_window_clear(window.as_mut_ptr());
         }
-        Ok(MatZ {
+        MatZ {
             matrix: unsafe { window_copy.assume_init() },
-        })
+        }
     }
 }
 

--- a/src/integer/mat_z/sort.rs
+++ b/src/integer/mat_z/sort.rs
@@ -67,7 +67,7 @@ impl MatZ {
     ) -> Result<Self, MathError> {
         let mut condition_values = vec![];
         for col in 0..self.get_num_columns() {
-            condition_values.push(cond_func(&self.get_column(col).unwrap())?);
+            condition_values.push(cond_func(&unsafe { self.get_column_unchecked(col) })?);
         }
 
         let mut id_vec: Vec<usize> = (0..self.get_num_columns() as usize).collect();
@@ -133,7 +133,7 @@ impl MatZ {
     ) -> Result<Self, MathError> {
         let mut condition_values = vec![];
         for row in 0..self.get_num_rows() {
-            condition_values.push(cond_func(&self.get_row(row).unwrap())?);
+            condition_values.push(cond_func(&unsafe { self.get_row_unchecked(row) })?);
         }
         let mut id_vec: Vec<usize> = (0..self.get_num_rows() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -14,7 +14,6 @@ use crate::{
     integer::{MatPolyOverZ, PolyOverZ},
     integer_mod_q::{ModulusPolynomialRingZq, PolynomialRingZq},
     traits::{MatrixDimensions, MatrixGetEntry, MatrixGetSubmatrix},
-    utils::index::evaluate_index_for_vector,
 };
 use flint_sys::{fmpz_poly::fmpz_poly_struct, fmpz_poly_mat::fmpz_poly_mat_entry};
 use std::fmt::Display;
@@ -277,43 +276,6 @@ impl MatrixGetEntry<PolynomialRingZq> for MatPolynomialRingZq {
 }
 
 impl MatrixGetSubmatrix for MatPolynomialRingZq {
-    /// Outputs a column vector of the specified column.
-    ///
-    /// Input parameters:
-    /// - `column`: specifies the column of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a column vector of the matrix at the position of the given
-    /// `column` or an error if the number of columns is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{integer::MatPolyOverZ, traits::MatrixGetSubmatrix};
-    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
-    /// use std::str::FromStr;
-    ///
-    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();();
-    /// let mat_poly = MatPolyOverZ::identity(3, 3);
-    /// let matrix = MatPolynomialRingZq::from((&mat_poly, &modulus));
-    ///
-    /// let col_0 = matrix.get_column(0).unwrap(); // first column
-    /// let col_1 = matrix.get_column(1).unwrap(); // second column
-    /// let col_1 = matrix.get_column(2).unwrap(); // third column
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the column is greater than the matrix.
-    fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_cols = self.get_num_columns();
-        let column_i64 = evaluate_index_for_vector(column, num_cols)?;
-
-        self.get_submatrix(0, self.get_num_rows() - 1, column_i64, column_i64)
-    }
-
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
     /// a new matrix.

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -116,8 +116,7 @@ impl MatrixGetEntry<PolyOverZ> for MatPolynomialRingZq {
     /// the last element.
     ///
     /// Returns the [`PolyOverZ`] value of the matrix at the position of the given
-    /// row and column or an error if the number of rows or columns is
-    /// greater than the matrix or negative.
+    /// row and column or an error if the position is not in the matrix.
     ///
     /// # Examples
     /// ```
@@ -198,8 +197,7 @@ impl MatrixGetEntry<PolynomialRingZq> for MatPolynomialRingZq {
     /// the last element.
     ///
     /// Returns the [`PolynomialRingZq`] value of the matrix at the position of the given
-    /// row and column or an error if the number of rows or columns is
-    /// greater than the matrix or negative.
+    /// row and column or an error if the position is not in the matrix.
     ///
     /// # Examples
     /// ```

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -276,11 +276,9 @@ impl MatrixGetEntry<PolynomialRingZq> for MatPolynomialRingZq {
 }
 
 impl MatrixGetSubmatrix for MatPolynomialRingZq {
-    /// Returns a deep copy of the submatrix defined by the given parameters.
-    /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
-    /// a new matrix.
-    /// Note that `row_1 >= row_2` and `col_1 >= col_2` must hold after converting negative indices.
-    /// Otherwise the function will panic.
+    /// Returns a deep copy of the submatrix defined by the given parameters
+    /// and does not check the provided dimensions.
+    /// There is also a safe version of this function that checks the input.
     ///
     /// Parameters:
     /// `row_1`: the starting row of the submatrix
@@ -288,11 +286,7 @@ impl MatrixGetSubmatrix for MatPolynomialRingZq {
     /// `col_1`: the starting column of the submatrix
     /// `col_2`: the ending column of the submatrix
     ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(inclusively)
-    /// or an error if any provided row or column is greater than the matrix.
+    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(exclusively).
     ///
     /// # Examples
     /// ```
@@ -313,21 +307,20 @@ impl MatrixGetSubmatrix for MatPolynomialRingZq {
     /// assert_eq!(e_2, sub_mat_2);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    ///   if any provided row or column is greater than the matrix.
-    ///
-    /// # Panics ...
-    /// - if `col_1 > col_2` or `row_1 > row_2`.
-    fn get_submatrix(
+    /// # Safety
+    /// The user has to ensure that all entries are within the matrix dimensions.
+    /// Otherwise, memory leaks can occur and no guarantees are given.
+    unsafe fn get_submatrix_unchecked(
         &self,
-        row_1: impl TryInto<i64> + Display,
-        row_2: impl TryInto<i64> + Display,
-        col_1: impl TryInto<i64> + Display,
-        col_2: impl TryInto<i64> + Display,
+        row_1: i64,
+        row_2: i64,
+        col_1: i64,
+        col_2: i64,
     ) -> Result<Self, MathError> {
         Ok(MatPolynomialRingZq {
-            matrix: self.matrix.get_submatrix(row_1, row_2, col_1, col_2)?,
+            matrix: self
+                .matrix
+                .get_submatrix_unchecked(row_1, row_2, col_1, col_2)?,
             modulus: self.get_mod(),
         })
     }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -277,43 +277,6 @@ impl MatrixGetEntry<PolynomialRingZq> for MatPolynomialRingZq {
 }
 
 impl MatrixGetSubmatrix for MatPolynomialRingZq {
-    /// Outputs the row vector of the specified row.
-    ///
-    /// Parameters:
-    /// - `row`: specifies the row of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a row vector of the matrix at the position of the given
-    /// `row` or an error if the number of rows is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{integer::MatPolyOverZ, traits::MatrixGetSubmatrix};
-    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
-    /// use std::str::FromStr;
-    ///
-    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 17").unwrap();();
-    /// let mat_poly = MatPolyOverZ::identity(3, 3);
-    /// let matrix = MatPolynomialRingZq::from((&mat_poly, &modulus));
-    ///
-    /// let row_0 = matrix.get_row(0).unwrap(); // first row
-    /// let row_1 = matrix.get_row(1).unwrap(); // second row
-    /// let row_2 = matrix.get_row(2).unwrap(); // third row
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the row is greater than the matrix.
-    fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_rows = self.get_num_rows();
-        let row_i64 = evaluate_index_for_vector(row, num_rows)?;
-
-        self.get_submatrix(row_i64, row_i64, 0, self.get_num_columns() - 1)
-    }
-
     /// Outputs a column vector of the specified column.
     ///
     /// Input parameters:

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -300,29 +300,32 @@ impl MatrixGetSubmatrix for MatPolynomialRingZq {
     ///
     /// let sub_mat_1 = poly_ring_mat.get_submatrix(0, 2, 1, 1).unwrap();
     /// let sub_mat_2 = poly_ring_mat.get_submatrix(0, -1, 1, -2).unwrap();
+    /// let sub_mat_3 = unsafe{poly_ring_mat.get_submatrix_unchecked(0, 3, 1, 2)};
     ///
     /// let e_2 = MatPolyOverZ::from_str("[[0],[1  1],[0]]").unwrap();
     /// let e_2 = MatPolynomialRingZq::from((&e_2, &modulus));
     /// assert_eq!(e_2, sub_mat_1);
     /// assert_eq!(e_2, sub_mat_2);
+    /// assert_eq!(e_2, sub_mat_3);
     /// ```
     ///
     /// # Safety
-    /// The user has to ensure that all entries are within the matrix dimensions.
-    /// Otherwise, memory leaks can occur and no guarantees are given.
+    /// To use this function safely, make sure that the selected submatrix is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
     unsafe fn get_submatrix_unchecked(
         &self,
         row_1: i64,
         row_2: i64,
         col_1: i64,
         col_2: i64,
-    ) -> Result<Self, MathError> {
-        Ok(MatPolynomialRingZq {
+    ) -> Self {
+        MatPolynomialRingZq {
             matrix: self
                 .matrix
-                .get_submatrix_unchecked(row_1, row_2, col_1, col_2)?,
+                .get_submatrix_unchecked(row_1, row_2, col_1, col_2),
             modulus: self.get_mod(),
-        })
+        }
     }
 }
 

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -371,7 +371,7 @@ impl MatrixSwaps for MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if one of the given columns is greater than the matrix or negative.
+    ///   if one of the given columns is not in the matrix.
     fn swap_columns(
         &mut self,
         col_0: impl TryInto<i64> + Display,
@@ -403,7 +403,7 @@ impl MatrixSwaps for MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if one of the given rows is greater than the matrix or negative.
+    ///   if one of the given rows is not in the matrix.
     fn swap_rows(
         &mut self,
         row_0: impl TryInto<i64> + Display,

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sort.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sort.rs
@@ -68,7 +68,7 @@ impl MatPolynomialRingZq {
     ) -> Result<Self, MathError> {
         let mut condition_values = vec![];
         for col in 0..self.get_num_columns() {
-            condition_values.push(cond_func(&self.get_column(col).unwrap())?);
+            condition_values.push(cond_func(&unsafe { self.get_column_unchecked(col) })?);
         }
 
         let mut id_vec: Vec<usize> = (0..self.get_num_columns() as usize).collect();

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -117,39 +117,6 @@ impl MatZq {
 }
 
 impl MatrixGetSubmatrix for MatZq {
-    /// Outputs the row vector of the specified row.
-    ///
-    /// Parameters:
-    /// - `row`: specifies the row of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a row vector of the matrix at the position of the given
-    /// `row` or an error if the number of rows is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{integer_mod_q::MatZq, traits::MatrixGetSubmatrix};
-    /// use std::str::FromStr;
-    ///
-    /// let matrix = MatZq::from_str("[[1, 2, 3],[3, 4, 5]] mod 4").unwrap();
-    ///
-    /// let row_0 = matrix.get_row(0).unwrap(); // first row
-    /// let row_1 = matrix.get_row(1).unwrap(); // second row
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the row is greater than the matrix.
-    fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_rows = self.get_num_rows();
-        let row_i64 = evaluate_index_for_vector(row, num_rows)?;
-
-        self.get_submatrix(row_i64, row_i64, 0, self.get_num_columns() - 1)
-    }
-
     /// Outputs a column vector of the specified column.
     ///
     /// Input parameters:

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -14,7 +14,7 @@ use crate::{
     integer::{MatZ, Z},
     integer_mod_q::{fmpz_mod_helpers::length, Modulus, Zq},
     traits::{MatrixDimensions, MatrixGetEntry, MatrixGetSubmatrix, MatrixSetEntry},
-    utils::index::{evaluate_index_for_vector, evaluate_indices_for_matrix},
+    utils::index::evaluate_indices_for_matrix,
 };
 use flint_sys::{
     fmpz::{fmpz, fmpz_init_set},
@@ -117,40 +117,6 @@ impl MatZq {
 }
 
 impl MatrixGetSubmatrix for MatZq {
-    /// Outputs a column vector of the specified column.
-    ///
-    /// Input parameters:
-    /// - `column`: specifies the column of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a column vector of the matrix at the position of the given
-    /// `column` or an error if the number of columns is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{integer_mod_q::MatZq, traits::MatrixGetSubmatrix};
-    /// use std::str::FromStr;
-    ///
-    /// let matrix = MatZq::from_str("[[1, 2, 3],[3, 4, 5]] mod 4").unwrap();
-    ///
-    /// let col_0 = matrix.get_column(0).unwrap(); // first column
-    /// let col_1 = matrix.get_column(1).unwrap(); // second column
-    /// let col_2 = matrix.get_column(2).unwrap(); // third column
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the column is greater than the matrix.
-    fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_cols = self.get_num_columns();
-        let column_i64 = evaluate_index_for_vector(column, num_cols)?;
-
-        self.get_submatrix(0, self.get_num_rows() - 1, column_i64, column_i64)
-    }
-
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
     /// a new matrix.

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -138,22 +138,25 @@ impl MatrixGetSubmatrix for MatZq {
     ///
     /// let sub_mat_1 = mat.get_submatrix(0, 2, 1, 1).unwrap();
     /// let sub_mat_2 = mat.get_submatrix(0, -1, 1, -2).unwrap();
+    /// let sub_mat_3 = unsafe{mat.get_submatrix_unchecked(0, 3, 1, 2)};
     ///
     /// let e_2 = MatZq::from_str("[[0],[1],[0]] mod 17").unwrap();
     /// assert_eq!(e_2, sub_mat_1);
     /// assert_eq!(e_2, sub_mat_2);
+    /// assert_eq!(e_2, sub_mat_3);
     /// ```
     ///
     /// # Safety
-    /// The user has to ensure that all entries are within the matrix dimensions.
-    /// Otherwise, memory leaks can occur and no guarantees are given.
+    /// To use this function safely, make sure that the selected submatrix is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
     unsafe fn get_submatrix_unchecked(
         &self,
         row_1: i64,
         row_2: i64,
         col_1: i64,
         col_2: i64,
-    ) -> Result<Self, MathError> {
+    ) -> Self {
         let mut window = MaybeUninit::uninit();
         // The memory for the elements of window is shared with self.
         unsafe {
@@ -174,10 +177,10 @@ impl MatrixGetSubmatrix for MatZq {
             // the memory to the underlying matrix that window points to is not freed
             fmpz_mod_mat_window_clear(window.as_mut_ptr());
         }
-        Ok(MatZq {
+        MatZq {
             matrix: unsafe { window_copy.assume_init() },
             modulus: self.get_mod(),
-        })
+        }
     }
 }
 

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -117,11 +117,9 @@ impl MatZq {
 }
 
 impl MatrixGetSubmatrix for MatZq {
-    /// Returns a deep copy of the submatrix defined by the given parameters.
-    /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
-    /// a new matrix.
-    /// Note that `row_1 >= row_2` and `col_1 >= col_2` must hold after converting negative indices.
-    /// Otherwise the function will panic.
+    /// Returns a deep copy of the submatrix defined by the given parameters
+    /// and does not check the provided dimensions.
+    /// There is also a safe version of this function that checks the input.
     ///
     /// Parameters:
     /// `row_1`: the starting row of the submatrix
@@ -129,11 +127,7 @@ impl MatrixGetSubmatrix for MatZq {
     /// `col_1`: the starting column of the submatrix
     /// `col_2`: the ending column of the submatrix
     ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(inclusively)
-    /// or an error if the number of rows or columns is greater than the matrix.
+    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(exclusively).
     ///
     /// # Examples
     /// ```
@@ -150,34 +144,16 @@ impl MatrixGetSubmatrix for MatZq {
     /// assert_eq!(e_2, sub_mat_2);
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    ///   if any provided row or column is greater than the matrix.
-    ///
-    /// # Panics ...
-    /// - if `col_1 > col_2` or `row_1 > row_2`.
-    fn get_submatrix(
+    /// # Safety
+    /// The user has to ensure that all entries are within the matrix dimensions.
+    /// Otherwise, memory leaks can occur and no guarantees are given.
+    unsafe fn get_submatrix_unchecked(
         &self,
-        row_1: impl TryInto<i64> + Display,
-        row_2: impl TryInto<i64> + Display,
-        col_1: impl TryInto<i64> + Display,
-        col_2: impl TryInto<i64> + Display,
+        row_1: i64,
+        row_2: i64,
+        col_1: i64,
+        col_2: i64,
     ) -> Result<Self, MathError> {
-        let (row_1, col_1) = evaluate_indices_for_matrix(self, row_1, col_1)?;
-        let (row_2, col_2) = evaluate_indices_for_matrix(self, row_2, col_2)?;
-        assert!(
-                row_2 >= row_1,
-                "The number of rows must be positive, i.e. row_2 ({row_2}) must be greater or equal row_1 ({row_1})"
-            );
-
-        assert!(
-                col_2 >= col_1,
-                "The number of columns must be positive, i.e. col_2 ({col_2}) must be greater or equal col_1 ({col_1})"
-            );
-
-        // increase both values to have an inclusive capturing of the matrix entries
-        let (row_2, col_2) = (row_2 + 1, col_2 + 1);
-
         let mut window = MaybeUninit::uninit();
         // The memory for the elements of window is shared with self.
         unsafe {

--- a/src/integer_mod_q/mat_zq/norm.rs
+++ b/src/integer_mod_q/mat_zq/norm.rs
@@ -35,7 +35,7 @@ impl MatZq {
     pub fn norm_l_2_infty_sqrd(&self) -> Z {
         let mut max_sqrd_norm = Z::ZERO;
         for i in 0..self.get_num_columns() {
-            let column = self.get_column(i).unwrap();
+            let column = unsafe { self.get_column_unchecked(i) };
             let sqrd_norm = column.norm_eucl_sqrd().unwrap();
             if sqrd_norm > max_sqrd_norm {
                 max_sqrd_norm = sqrd_norm;
@@ -81,7 +81,7 @@ impl MatZq {
     pub fn norm_l_infty_infty(&self) -> Z {
         let mut max_norm = Z::ZERO;
         for i in 0..self.get_num_columns() {
-            let column = self.get_column(i).unwrap();
+            let column = unsafe { self.get_column_unchecked(i) };
             let norm = column.norm_infty().unwrap();
             if norm > max_norm {
                 max_norm = norm;

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -117,7 +117,7 @@ impl MatZq {
 
         // Set all other entries in that column to `0` (gaussian elimination).
         for row_nr in (0..self.get_num_rows()).filter(|x| *x != row_nr) {
-            let old_row = self.get_row(row_nr).unwrap();
+            let old_row = unsafe { self.get_row_unchecked(row_nr) };
             let entry: Z = unsafe { old_row.get_entry_unchecked(0, column_nr) };
             if !entry.is_zero() {
                 let new_row = &old_row - entry * &row;

--- a/src/integer_mod_q/mat_zq/sort.rs
+++ b/src/integer_mod_q/mat_zq/sort.rs
@@ -67,7 +67,7 @@ impl MatZq {
     ) -> Result<Self, MathError> {
         let mut condition_values = vec![];
         for col in 0..self.get_num_columns() {
-            condition_values.push(cond_func(&self.get_column(col).unwrap())?);
+            condition_values.push(cond_func(&unsafe { self.get_column_unchecked(col) })?);
         }
 
         let mut id_vec: Vec<usize> = (0..self.get_num_columns() as usize).collect();
@@ -133,7 +133,7 @@ impl MatZq {
     ) -> Result<Self, MathError> {
         let mut condition_values = vec![];
         for row in 0..self.get_num_rows() {
-            condition_values.push(cond_func(&self.get_row(row).unwrap())?);
+            condition_values.push(cond_func(&unsafe { self.get_row_unchecked(row) })?);
         }
         let mut id_vec: Vec<usize> = (0..self.get_num_rows() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);

--- a/src/rational/mat_q/cholesky_decomp.rs
+++ b/src/rational/mat_q/cholesky_decomp.rs
@@ -54,11 +54,9 @@ impl MatQ {
             let a_ii = unsafe { a.get_entry_unchecked(0, 0) };
             assert!(a_ii > Q::ZERO, "The matrix is not positive-definite.");
             let column_a_i = match i {
-                0 => a.get_column(0).unwrap(),
-                _ => MatQ::new(i, 1)
-                    .get_column(0)
-                    .unwrap()
-                    .concat_vertical(&a.get_column(0).unwrap())
+                0 => unsafe { a.get_column_unchecked(0) },
+                _ => unsafe { MatQ::new(i, 1).get_column_unchecked(0) }
+                    .concat_vertical(&unsafe { a.get_column_unchecked(0) })
                     .unwrap(),
             } * (1 / (a_ii.sqrt()));
             // in the previous line: sqrt panics if `a_ii` is negative, i.e. if an

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -10,7 +10,7 @@
 
 use super::MatQ;
 use crate::traits::{MatrixDimensions, MatrixGetEntry, MatrixGetSubmatrix};
-use crate::utils::index::{evaluate_index_for_vector, evaluate_indices_for_matrix};
+use crate::utils::index::evaluate_indices_for_matrix;
 use crate::{error::MathError, rational::Q};
 use flint_sys::fmpq_mat::{fmpq_mat_init_set, fmpq_mat_window_clear, fmpq_mat_window_init};
 use flint_sys::{
@@ -131,40 +131,6 @@ impl MatrixGetEntry<Q> for MatQ {
 }
 
 impl MatrixGetSubmatrix for MatQ {
-    /// Outputs a column vector of the specified column.
-    ///
-    /// Input parameters:
-    /// - `column`: specifies the column of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a column vector of the matrix at the position of the given
-    /// `column` or an error if the number of columns is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{rational::MatQ, traits::MatrixGetSubmatrix};
-    /// use std::str::FromStr;
-    ///
-    /// let matrix = MatQ::from_str("[[1, 2/3, 3],[3, 4, 5/2]]").unwrap();
-    ///
-    /// let col_0 = matrix.get_column(0).unwrap(); // first column
-    /// let col_1 = matrix.get_column(1).unwrap(); // second column
-    /// let col_2 = matrix.get_column(2).unwrap(); // third column
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the column is greater than the matrix.
-    fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_cols = self.get_num_columns();
-        let column_i64 = evaluate_index_for_vector(column, num_cols)?;
-
-        self.get_submatrix(0, self.get_num_rows() - 1, column_i64, column_i64)
-    }
-
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
     /// a new matrix.

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -131,11 +131,9 @@ impl MatrixGetEntry<Q> for MatQ {
 }
 
 impl MatrixGetSubmatrix for MatQ {
-    /// Returns a deep copy of the submatrix defined by the given parameters.
-    /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in
-    /// a new matrix.
-    /// Note that `row_1 >= row_2` and `col_1 >= col_2` must hold after converting negative indices.
-    /// Otherwise the function will panic.
+    /// Returns a deep copy of the submatrix defined by the given parameters
+    /// and does not check the provided dimensions.
+    /// There is also a safe version of this function that checks the input.
     ///
     /// Parameters:
     /// `row_1`: the starting row of the submatrix
@@ -143,11 +141,7 @@ impl MatrixGetSubmatrix for MatQ {
     /// `col_1`: the starting column of the submatrix
     /// `col_2`: the ending column of the submatrix
     ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(inclusively)
-    /// or an error if the number of rows or columns is greater than the matrix.
+    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(exclusively).
     ///
     /// # Examples
     /// ```
@@ -163,35 +157,13 @@ impl MatrixGetSubmatrix for MatQ {
     /// assert_eq!(e_2, sub_mat_1);
     /// assert_eq!(e_2, sub_mat_2);
     /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`MathError::OutOfBounds`]
-    ///   if any provided row or column is greater than the matrix.
-    ///
-    /// # Panics ...
-    /// - if `col_1 > col_2` or `row_1 > row_2`.
-    fn get_submatrix(
+    unsafe fn get_submatrix_unchecked(
         &self,
-        row_1: impl TryInto<i64> + Display,
-        row_2: impl TryInto<i64> + Display,
-        col_1: impl TryInto<i64> + Display,
-        col_2: impl TryInto<i64> + Display,
+        row_1: i64,
+        row_2: i64,
+        col_1: i64,
+        col_2: i64,
     ) -> Result<Self, MathError> {
-        let (row_1, col_1) = evaluate_indices_for_matrix(self, row_1, col_1)?;
-        let (row_2, col_2) = evaluate_indices_for_matrix(self, row_2, col_2)?;
-        assert!(
-            row_2 >= row_1,
-            "The number of rows must be positive, i.e. row_2 ({row_2}) must be greater or equal row_1 ({row_1})"
-        );
-
-        assert!(
-            col_2 >= col_1,
-            "The number of columns must be positive, i.e. col_2 ({col_2}) must be greater or equal col_1 ({col_1})"
-        );
-
-        // increase both values to have an inclusive capturing of the matrix entries
-        let (row_2, col_2) = (row_2 + 1, col_2 + 1);
-
         let mut window = MaybeUninit::uninit();
         // The memory for the elements of window is shared with self.
         unsafe {
@@ -234,6 +206,10 @@ impl MatQ {
     ///
     /// let fmpq_entries = mat.collect_entries();
     /// ```
+    ///
+    /// # Safety
+    /// The user has to ensure that all entries are within the matrix dimensions.
+    /// Otherwise, memory leaks can occur and no guarantees are given.
     pub(crate) fn collect_entries(&self) -> Vec<fmpq> {
         let mut entries: Vec<fmpq> = vec![];
 

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -131,39 +131,6 @@ impl MatrixGetEntry<Q> for MatQ {
 }
 
 impl MatrixGetSubmatrix for MatQ {
-    /// Outputs the row vector of the specified row.
-    ///
-    /// Parameters:
-    /// - `row`: specifies the row of the matrix
-    ///
-    /// Negative indices can be used to index from the back, e.g., `-1` for
-    /// the last element.
-    ///
-    /// Returns a row vector of the matrix at the position of the given
-    /// `row` or an error if the number of rows is
-    /// greater than the matrix or negative.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use qfall_math::{rational::MatQ, traits::MatrixGetSubmatrix};
-    /// use std::str::FromStr;
-    ///
-    /// let matrix = MatQ::from_str("[[1, 2/3, 3],[3, 4, 5/2]]").unwrap();
-    ///
-    /// let row_0 = matrix.get_row(0).unwrap(); // first row
-    /// let row_1 = matrix.get_row(1).unwrap(); // second row
-    /// ```
-    ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if the number of the row is greater than the matrix.
-    fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError> {
-        let num_rows = self.get_num_rows();
-        let row_i64 = evaluate_index_for_vector(row, num_rows)?;
-
-        self.get_submatrix(row_i64, row_i64, 0, self.get_num_columns() - 1)
-    }
-
     /// Outputs a column vector of the specified column.
     ///
     /// Input parameters:

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -152,18 +152,25 @@ impl MatrixGetSubmatrix for MatQ {
     ///
     /// let sub_mat_1 = mat.get_submatrix(0, 2, 1, 1).unwrap();
     /// let sub_mat_2 = mat.get_submatrix(0, -1, 1, -2).unwrap();
+    /// let sub_mat_3 = unsafe{mat.get_submatrix_unchecked(0, 3, 1, 2)};
     ///
     /// let e_2 = MatQ::from_str("[[0],[1],[0]]").unwrap();
     /// assert_eq!(e_2, sub_mat_1);
     /// assert_eq!(e_2, sub_mat_2);
+    /// assert_eq!(e_2, sub_mat_3);
     /// ```
+    ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected submatrix is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
     unsafe fn get_submatrix_unchecked(
         &self,
         row_1: i64,
         row_2: i64,
         col_1: i64,
         col_2: i64,
-    ) -> Result<Self, MathError> {
+    ) -> Self {
         let mut window = MaybeUninit::uninit();
         // The memory for the elements of window is shared with self.
         unsafe {
@@ -184,9 +191,9 @@ impl MatrixGetSubmatrix for MatQ {
             // the memory to the underlying matrix that window points to is not freed
             fmpq_mat_window_clear(window.as_mut_ptr());
         }
-        Ok(MatQ {
+        MatQ {
             matrix: unsafe { window_copy.assume_init() },
-        })
+        }
     }
 }
 

--- a/src/rational/mat_q/norm.rs
+++ b/src/rational/mat_q/norm.rs
@@ -34,7 +34,7 @@ impl MatQ {
     pub fn norm_l_2_infty_sqrd(&self) -> Q {
         let mut max_sqrd_norm = Q::ZERO;
         for i in 0..self.get_num_columns() {
-            let column = self.get_column(i).unwrap();
+            let column = unsafe { self.get_column_unchecked(i) };
             let sqrd_norm = column.norm_eucl_sqrd().unwrap();
             if sqrd_norm > max_sqrd_norm {
                 max_sqrd_norm = sqrd_norm;
@@ -80,7 +80,7 @@ impl MatQ {
     pub fn norm_l_infty_infty(&self) -> Q {
         let mut max_norm = Q::ZERO;
         for i in 0..self.get_num_columns() {
-            let column = self.get_column(i).unwrap();
+            let column = unsafe { self.get_column_unchecked(i) };
             let norm = column.norm_infty().unwrap();
             if norm > max_norm {
                 max_norm = norm;

--- a/src/rational/mat_q/sort.rs
+++ b/src/rational/mat_q/sort.rs
@@ -67,7 +67,7 @@ impl MatQ {
     ) -> Result<Self, MathError> {
         let mut condition_values = vec![];
         for col in 0..self.get_num_columns() {
-            condition_values.push(cond_func(&self.get_column(col).unwrap())?);
+            condition_values.push(cond_func(&unsafe { self.get_column_unchecked(col) })?);
         }
 
         let mut id_vec: Vec<usize> = (0..self.get_num_columns() as usize).collect();
@@ -133,7 +133,7 @@ impl MatQ {
     ) -> Result<Self, MathError> {
         let mut condition_values = vec![];
         for row in 0..self.get_num_rows() {
-            condition_values.push(cond_func(&self.get_row(row).unwrap())?);
+            condition_values.push(cond_func(&unsafe { self.get_row_unchecked(row) })?);
         }
         let mut id_vec: Vec<usize> = (0..self.get_num_rows() as usize).collect();
         id_vec.sort_by_key(|x| &condition_values[*x]);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -95,8 +95,6 @@ where
     /// occur.
     unsafe fn get_entry_unchecked(&self, row: i64, column: i64) -> T;
 
-    // *** Automatically implemented functions
-
     /// Outputs a [`Vec<Vec<T>>`] containing all entries of the matrix s.t.
     /// any entry in row `i` and column `j` can be accessed via `entries[i][j]`
     /// if `entries = matrix.get_entries`.
@@ -196,8 +194,7 @@ where
     /// the last element.
     ///
     /// Returns a row vector of the matrix at the position of the given
-    /// `row` or an error if the number of rows is
-    /// greater than the matrix or negative.
+    /// `row` or an error if specified row is not part of the matrix.
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
@@ -232,8 +229,7 @@ where
     /// the last element.
     ///
     /// Returns a column vector of the matrix at the position of the given
-    /// `column` or an error if the number of columns is
-    /// greater than the matrix or negative.
+    /// `column` or an error if specified column is not part of the matrix.
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
@@ -331,8 +327,6 @@ where
         col_1: i64,
         col_2: i64,
     ) -> Self;
-
-    // *** Automatically implemented functions
 
     /// Outputs a [`Vec`] containing all rows of the matrix in order.
     /// Use this function for simple iteration over the rows of the matrix.
@@ -526,7 +520,7 @@ pub trait MatrixSwaps {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if one of the given rows is greater than the matrix or negative.
+    ///   if one of the given rows is not in the matrix.
     fn swap_rows(
         &mut self,
         row_0: impl TryInto<i64> + Display,
@@ -544,7 +538,7 @@ pub trait MatrixSwaps {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if one of the given columns is greater than the matrix or negative.
+    ///   if one of the given columns is not in the matrix.
     fn swap_columns(
         &mut self,
         col_0: impl TryInto<i64> + Display,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -189,13 +189,19 @@ where
     /// Parameters:
     /// - `row`: specifies the row of the matrix to return
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns a row vector of the matrix at the position of the given
-    /// `row` or an error if specified row is not part of the matrix.
+    /// `row` or an error if the number of rows is
+    /// greater than the matrix or negative.
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if specified row is not part of the matrix.
-    fn get_row(&self, row: impl TryInto<i64> + Display) -> Result<Self, MathError>;
+    ///     if specified row is not part of the matrix.
+    fn get_row(&self, row: impl TryInto<i64> + Display + Clone) -> Result<Self, MathError> {
+        self.get_submatrix(row.clone(), row, 0, -1)
+    }
 
     /// Outputs the column vector of the specified column.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -201,7 +201,7 @@ where
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///     if specified row is not part of the matrix.
+    ///   if specified row is not part of the matrix.
     fn get_row(&self, row: impl TryInto<i64> + Display + Clone) -> Result<Self, MathError> {
         let row = evaluate_index_for_vector(row, self.get_num_rows())?;
         Ok(unsafe { self.get_row_unchecked(row) })
@@ -237,7 +237,7 @@ where
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///     if specified column is not part of the matrix.
+    ///   if specified column is not part of the matrix.
     fn get_column(&self, column: impl TryInto<i64> + Display + Clone) -> Result<Self, MathError> {
         let column = evaluate_index_for_vector(column, self.get_num_columns())?;
         Ok(unsafe { self.get_column_unchecked(column) })

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -208,13 +208,19 @@ where
     /// Parameters:
     /// - `column`: specifies the column of the matrix to return
     ///
+    /// Negative indices can be used to index from the back, e.g., `-1` for
+    /// the last element.
+    ///
     /// Returns a column vector of the matrix at the position of the given
-    /// `column` or an error if specified column is not part of the matrix.
+    /// `column` or an error if the number of columns is
+    /// greater than the matrix or negative.
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-    ///   if specified column is not part of the matrix.
-    fn get_column(&self, column: impl TryInto<i64> + Display) -> Result<Self, MathError>;
+    ///     if specified column is not part of the matrix.
+    fn get_column(&self, column: impl TryInto<i64> + Display + Clone) -> Result<Self, MathError> {
+        self.get_submatrix(0, -1, column.clone(), column)
+    }
 
     /// Returns a deep copy of the submatrix defined by the given parameters.
     /// All entries starting from `(row_1, col_1)` to `(row_2, col_2)`(inclusively) are collected in

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,7 +9,7 @@
 //! This module contains basic traits for this library. These include
 //! specific traits for matrices and polynomials.
 
-use crate::error::MathError;
+use crate::{error::MathError, utils::index::evaluate_indices_for_matrix};
 use flint_sys::fmpz::fmpz;
 use std::fmt::Display;
 
@@ -252,6 +252,46 @@ where
         row_2: impl TryInto<i64> + Display,
         col_1: impl TryInto<i64> + Display,
         col_2: impl TryInto<i64> + Display,
+    ) -> Result<Self, MathError> {
+        let (row_1, col_1) = evaluate_indices_for_matrix(self, row_1, col_1)?;
+        let (row_2, col_2) = evaluate_indices_for_matrix(self, row_2, col_2)?;
+
+        assert!(
+            row_2 >= row_1,
+            "The number of rows must be positive, i.e. row_2 ({row_2}) must be greater or equal row_1 ({row_1})"
+        );
+
+        assert!(
+            col_2 >= col_1,
+            "The number of columns must be positive, i.e. col_2 ({col_2}) must be greater or equal col_1 ({col_1})"
+        );
+
+        // increase both values to have an inclusive capturing of the matrix entries
+        let (row_2, col_2) = (row_2 + 1, col_2 + 1);
+        unsafe { self.get_submatrix_unchecked(row_1, row_2, col_1, col_2) }
+    }
+
+    /// Returns a deep copy of the submatrix defined by the given parameters
+    /// and does not check the provided dimensions.
+    /// There is also a safe version of this function that checks the input.
+    ///
+    /// Parameters:
+    /// `row_1`: the starting row of the submatrix
+    /// `row_2`: the ending row of the submatrix
+    /// `col_1`: the starting column of the submatrix
+    /// `col_2`: the ending column of the submatrix
+    ///
+    /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(exclusively).
+    ///
+    /// # Safety
+    /// The user has to ensure that all entries are within the matrix dimensions.
+    /// Otherwise, memory leaks can occur and no guarantees are given.
+    unsafe fn get_submatrix_unchecked(
+        &self,
+        row_1: i64,
+        row_2: i64,
+        col_1: i64,
+        col_2: i64,
     ) -> Result<Self, MathError>;
 
     // *** Automatically implemented functions

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,7 +9,10 @@
 //! This module contains basic traits for this library. These include
 //! specific traits for matrices and polynomials.
 
-use crate::{error::MathError, utils::index::evaluate_indices_for_matrix};
+use crate::{
+    error::MathError,
+    utils::index::{evaluate_index_for_vector, evaluate_indices_for_matrix},
+};
 use flint_sys::fmpz::fmpz;
 use std::fmt::Display;
 
@@ -200,7 +203,24 @@ where
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
     ///     if specified row is not part of the matrix.
     fn get_row(&self, row: impl TryInto<i64> + Display + Clone) -> Result<Self, MathError> {
-        self.get_submatrix(row.clone(), row, 0, -1)
+        let row = evaluate_index_for_vector(row, self.get_num_rows())?;
+        Ok(unsafe { self.get_row_uncheckd(row) })
+    }
+
+    /// Outputs the row vector of the specified row.
+    ///
+    /// Parameters:
+    /// - `row`: specifies the row of the matrix to return
+    ///
+    /// Returns a row vector of the matrix at the position of the given
+    /// `row`.
+    ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected row is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    unsafe fn get_row_uncheckd(&self, row: i64) -> Self {
+        self.get_submatrix_unchecked(row, row + 1, 0, self.get_num_columns())
     }
 
     /// Outputs the column vector of the specified column.
@@ -219,7 +239,24 @@ where
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
     ///     if specified column is not part of the matrix.
     fn get_column(&self, column: impl TryInto<i64> + Display + Clone) -> Result<Self, MathError> {
-        self.get_submatrix(0, -1, column.clone(), column)
+        let column = evaluate_index_for_vector(column, self.get_num_columns())?;
+        Ok(unsafe { self.get_column_unchecked(column) })
+    }
+
+    /// Outputs the column vector of the specified column.
+    ///
+    /// Parameters:
+    /// - `column`: specifies the row of the matrix to return
+    ///
+    /// Returns a column vector of the matrix at the position of the given
+    /// `column`.
+    ///
+    /// # Safety
+    /// To use this function safely, make sure that the selected column is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
+    unsafe fn get_column_unchecked(&self, column: i64) -> Self {
+        self.get_submatrix_unchecked(0, self.get_num_rows(), column, column + 1)
     }
 
     /// Returns a deep copy of the submatrix defined by the given parameters.
@@ -268,7 +305,7 @@ where
 
         // increase both values to have an inclusive capturing of the matrix entries
         let (row_2, col_2) = (row_2 + 1, col_2 + 1);
-        unsafe { self.get_submatrix_unchecked(row_1, row_2, col_1, col_2) }
+        Ok(unsafe { self.get_submatrix_unchecked(row_1, row_2, col_1, col_2) })
     }
 
     /// Returns a deep copy of the submatrix defined by the given parameters
@@ -284,15 +321,16 @@ where
     /// Returns the submatrix from `(row_1, col_1)` to `(row_2, col_2)`(exclusively).
     ///
     /// # Safety
-    /// The user has to ensure that all entries are within the matrix dimensions.
-    /// Otherwise, memory leaks can occur and no guarantees are given.
+    /// To use this function safely, make sure that the selected submatrix is part
+    /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
+    /// occur.
     unsafe fn get_submatrix_unchecked(
         &self,
         row_1: i64,
         row_2: i64,
         col_1: i64,
         col_2: i64,
-    ) -> Result<Self, MathError>;
+    ) -> Self;
 
     // *** Automatically implemented functions
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -204,7 +204,7 @@ where
     ///     if specified row is not part of the matrix.
     fn get_row(&self, row: impl TryInto<i64> + Display + Clone) -> Result<Self, MathError> {
         let row = evaluate_index_for_vector(row, self.get_num_rows())?;
-        Ok(unsafe { self.get_row_uncheckd(row) })
+        Ok(unsafe { self.get_row_unchecked(row) })
     }
 
     /// Outputs the row vector of the specified row.
@@ -219,7 +219,7 @@ where
     /// To use this function safely, make sure that the selected row is part
     /// of the matrix. If it is not, memory leaks, unexpected panics, etc. might
     /// occur.
-    unsafe fn get_row_uncheckd(&self, row: i64) -> Self {
+    unsafe fn get_row_unchecked(&self, row: i64) -> Self {
         self.get_submatrix_unchecked(row, row + 1, 0, self.get_num_columns())
     }
 
@@ -363,8 +363,7 @@ where
         let mut rows = vec![];
 
         for i in 0..self.get_num_rows() {
-            // replace with self.get_row_unchecked once available
-            let entry = self.get_row(i).unwrap();
+            let entry = unsafe { self.get_row_unchecked(i) };
             rows.push(entry);
         }
 
@@ -400,8 +399,7 @@ where
         let mut columns = vec![];
 
         for i in 0..self.get_num_columns() {
-            // replace with self.get_column_unchecked once available
-            let entry = self.get_column(i).unwrap();
+            let entry = unsafe { self.get_column_unchecked(i) };
             columns.push(entry);
         }
 

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -337,7 +337,7 @@ pub(crate) fn sample_d_precomputed_gso(
 
     for i in (0..basis_gso.get_num_columns()).rev() {
         // basisvector_i = b_tilde[i]
-        let basisvector_orth_i = basis_gso.get_column(i).unwrap();
+        let basisvector_orth_i = unsafe { basis_gso.get_column_unchecked(i) };
 
         // define the center for sample_z as c_2 = <c, b_tilde[i]> / <b_tilde[i], b_tilde[i]>;
         let c_2 = center.dot_product(&basisvector_orth_i).unwrap()
@@ -351,7 +351,7 @@ pub(crate) fn sample_d_precomputed_gso(
         let z = dgis.sample_z();
 
         // update the center c = c - z * b[i]
-        let basisvector_i = basis.get_column(i).unwrap();
+        let basisvector_i = unsafe { basis.get_column_unchecked(i) };
         center = center - MatQ::from(&(&z * &basisvector_i));
 
         // out = out + z * b[i]


### PR DESCRIPTION
**Description**

This PR reworks how we have implemented getters for rows and columns for matrices.
The new implementation is easier to maintain and has less code redundancy.
Additionally I...
- [x] added unchecked getters for: rows, columns and submatrices
- [x] went through our current codebase and changed the implementations to use the more efficient unchecked getters where it makes sense.

<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

I did not add additional dedicated tests for the unchecked matrices, as I think they are sufficiently tested through the checked methods that call them

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfils best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
