### PR TITLE
Extend remainder trait

### DIFF
--- a/src/integer/mat_poly_over_z/arithmetic/modulo.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/modulo.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/arithmetic/modulo.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/modulo.rs
@@ -11,6 +11,7 @@
 use super::super::MatPolyOverZ;
 use crate::{
     integer::Z,
+    integer_mod_q::{MatPolynomialRingZq, Modulus, ModulusPolynomialRingZq},
     macros::{
         arithmetics::{arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned},
         for_others::implement_for_others,
@@ -62,15 +63,111 @@ impl Rem<&Z> for &MatPolyOverZ {
     }
 }
 
+impl Rem<&Modulus> for &MatPolyOverZ {
+    type Output = MatPolyOverZ;
+    /// Computes `self` mod `modulus` as long as `modulus` is greater than 1.
+    /// For negative entries in `self`, the smallest positive representative is returned.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the positive remainders are computed
+    ///
+    /// Returns `self` mod `modulus` as a [`MatPolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use qfall_math::integer_mod_q::Modulus;
+    /// use std::str::FromStr;
+    ///
+    /// let a: MatPolyOverZ = MatPolyOverZ::from_str("[[2  1 -2],[1  42]]").unwrap();
+    /// let b = Modulus::from(24);
+    ///
+    /// let c: MatPolyOverZ = &a % &b;
+    /// ```
+    fn rem(self, modulus: &Modulus) -> Self::Output {
+        let mut out = MatPolyOverZ::new(self.get_num_rows(), self.get_num_rows());
+
+        for i in 0..self.get_num_rows() {
+            for j in 0..self.get_num_columns() {
+                let mut entry = unsafe { self.get_entry_unchecked(i, j) };
+                entry = entry % modulus;
+                unsafe { out.set_entry_unchecked(i, j, entry) };
+            }
+        }
+
+        out
+    }
+}
+
+impl<Mod: Into<ModulusPolynomialRingZq>> Rem<Mod> for &MatPolyOverZ {
+    type Output = MatPolyOverZ;
+    /// Computes `self` mod `modulus` as long as `modulus` is greater than 1.
+    /// For negative entries in `self`, the smallest positive representative is returned.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the positive remainders are computed
+    ///
+    /// Returns `self` mod `modulus` as a [`MatPolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
+    /// use std::str::FromStr;
+    ///
+    /// let a: MatPolyOverZ = MatPolyOverZ::from_str("[[2  1 -2],[1  42]]").unwrap();
+    /// let b = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+    ///
+    /// let c: MatPolyOverZ = &a % &b;
+    /// ```
+    fn rem(self, modulus: Mod) -> Self::Output {
+        MatPolynomialRingZq::from((self, modulus)).matrix
+    }
+}
+
+impl<Mod: Into<ModulusPolynomialRingZq>> Rem<Mod> for MatPolyOverZ {
+    type Output = MatPolyOverZ;
+    /// Computes `self` mod `modulus` as long as `modulus` is greater than 1.
+    /// For negative entries in `self`, the smallest positive representative is returned.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the positive remainders are computed
+    ///
+    /// Returns `self` mod `modulus` as a [`MatPolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
+    /// use std::str::FromStr;
+    ///
+    /// let a: MatPolyOverZ = MatPolyOverZ::from_str("[[2  1 -2],[1  42]]").unwrap();
+    /// let b = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+    ///
+    /// let c: MatPolyOverZ = &a % &b;
+    /// ```
+    fn rem(self, modulus: Mod) -> Self::Output {
+        MatPolynomialRingZq::from((self, modulus)).matrix
+    }
+}
+
 arithmetic_trait_borrowed_to_owned!(Rem, rem, MatPolyOverZ, Z, MatPolyOverZ);
 arithmetic_trait_mixed_borrowed_owned!(Rem, rem, MatPolyOverZ, Z, MatPolyOverZ);
+arithmetic_trait_borrowed_to_owned!(Rem, rem, MatPolyOverZ, Modulus, MatPolyOverZ);
+arithmetic_trait_mixed_borrowed_owned!(Rem, rem, MatPolyOverZ, Modulus, MatPolyOverZ);
 
 implement_for_others!(Z, MatPolyOverZ, Rem for i8 i16 i32 i64 u8 u16 u32 u64);
 
 #[cfg(test)]
 mod test_rem {
     use super::Z;
-    use crate::integer::MatPolyOverZ;
+    use crate::{
+        integer::MatPolyOverZ,
+        integer_mod_q::{Modulus, ModulusPolynomialRingZq, PolyOverZq},
+    };
     use std::str::FromStr;
 
     /// Testing modulo for two owned
@@ -78,11 +175,15 @@ mod test_rem {
     fn rem() {
         let a = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap();
         let b = Z::from(24);
-        let c = a % b;
-        assert_eq!(
-            c,
-            MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 18, 0]]").unwrap()
-        );
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = a.clone() % b;
+        let c2 = a.clone() % modulus;
+        let c3 = a % poly_mod;
+        let cmp = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 18, 0]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for two borrowed
@@ -90,11 +191,15 @@ mod test_rem {
     fn rem_borrow() {
         let a = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap();
         let b = Z::from(24);
-        let c = &a % &b;
-        assert_eq!(
-            c,
-            MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 18, 0]]").unwrap()
-        );
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = &a % &b;
+        let c2 = &a % &modulus;
+        let c3 = &a % &poly_mod;
+        let cmp = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 18, 0]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for borrowed and owned
@@ -102,11 +207,15 @@ mod test_rem {
     fn rem_first_borrowed() {
         let a = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap();
         let b = Z::from(24);
-        let c = &a % b;
-        assert_eq!(
-            c,
-            MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 18, 0]]").unwrap()
-        );
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = &a % b;
+        let c2 = &a % modulus;
+        let c3 = &a % poly_mod;
+        let cmp = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 18, 0]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for owned and borrowed
@@ -114,11 +223,15 @@ mod test_rem {
     fn rem_second_borrowed() {
         let a = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap();
         let b = Z::from(24);
-        let c = a % &b;
-        assert_eq!(
-            c,
-            MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 18, 0]]").unwrap()
-        );
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = a.clone() % &b;
+        let c2 = a.clone() % &modulus;
+        let c3 = a % &poly_mod;
+        let cmp = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 18, 0]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for negative values
@@ -126,11 +239,15 @@ mod test_rem {
     fn rem_negative_representation() {
         let a = MatPolyOverZ::from_str("[[1  -2, 1  3],[2  3 42, 1  24]]").unwrap();
         let b = Z::from(24);
-        let c = &a % &b;
-        assert_eq!(
-            c,
-            MatPolyOverZ::from_str("[[1  22, 1  3],[2  3 18, 0]]").unwrap()
-        );
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = &a % &b;
+        let c2 = &a % &modulus;
+        let c3 = a % &poly_mod;
+        let cmp = MatPolyOverZ::from_str("[[1  22, 1  3],[2  3 18, 0]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for large numbers
@@ -139,11 +256,26 @@ mod test_rem {
         let a =
             MatPolyOverZ::from_str(&format!("[[1  2, 1  {}],[2  3 42, 1  24]]", u64::MAX)).unwrap();
         let b = Z::from(u64::MAX - 2);
-        let c = &a % &b;
-        assert_eq!(
-            c,
-            MatPolyOverZ::from_str("[[1  2, 1  2],[2  3 42, 1  24]]").unwrap()
-        );
+        let modulus = Modulus::from(u64::MAX - 2);
+        let poly_mod =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX - 2)).unwrap();
+        let c1 = a.clone() % &b;
+        let c2 = a.clone() % &modulus;
+        let c3 = a % &poly_mod;
+        let cmp = MatPolyOverZ::from_str("[[1  2, 1  2],[2  3 42, 1  24]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
+    }
+
+    /// Ensure that the reduction with a polynomial modulus also reduces the polynomial degree.
+    #[test]
+    fn polynomial_reduction() {
+        let a = MatPolyOverZ::from_str("[[1  -2, 4  1 1 0 1],[2  3 42, 1  24]]").unwrap();
+        let b = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c = a % b;
+        let cmp = MatPolyOverZ::from_str("[[1  22, 2  0 1],[2  3 18, 0]]").unwrap();
+        assert_eq!(c, cmp);
     }
 
     /// Ensures that computing modulo a negative number results in a panic
@@ -174,9 +306,15 @@ mod test_rem {
         let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap() % 2i32;
         let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap() % 2i64;
         let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap() % Z::from(2);
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap()
+            % ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
 
         let _ = &MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap() % 2u8;
         let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap() % &Z::from(2);
         let _ = &MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap() % &Z::from(2);
+        let _ = &MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap()
+            % PolyOverZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let _ = &MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap()
+            % &PolyOverZq::from_str("4  1 0 0 1 mod 24").unwrap();
     }
 }

--- a/src/integer/mat_z/arithmetic/modulo.rs
+++ b/src/integer/mat_z/arithmetic/modulo.rs
@@ -79,7 +79,7 @@ impl Rem<&Modulus> for &MatZ {
     /// use std::str::FromStr;
     ///
     /// let a: MatZ = MatZ::from_str("[[-2],[42]]").unwrap();
-    /// let b: Z = Modulus::from(24);
+    /// let b = Modulus::from(24);
     ///
     /// let c: MatZ = &a % &b;
     /// ```

--- a/src/integer/mat_z/arithmetic/modulo.rs
+++ b/src/integer/mat_z/arithmetic/modulo.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //
@@ -11,13 +11,14 @@
 use super::super::MatZ;
 use crate::{
     integer::Z,
+    integer_mod_q::Modulus,
     macros::{
         arithmetics::{arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned},
         for_others::implement_for_others,
     },
-    traits::{MatrixDimensions, MatrixGetEntry, MatrixSetEntry},
+    traits::MatrixDimensions,
 };
-use flint_sys::fmpz_mat::fmpz_mat_scalar_smod;
+use flint_sys::{fmpz::fmpz_mod, fmpz_mat::fmpz_mat_entry, fmpz_mod::fmpz_mod_set_fmpz};
 use std::ops::Rem;
 
 impl Rem<&Z> for &MatZ {
@@ -46,18 +47,49 @@ impl Rem<&Z> for &MatZ {
     /// - if `modulus` is smaller than `2`.
     fn rem(self, modulus: &Z) -> Self::Output {
         assert!(modulus > &1, "Modulus can not be smaller than 2.");
-        let num_cols = self.get_num_columns();
-        let num_rows = self.get_num_rows();
 
-        let mut out = MatZ::new(num_rows, num_cols);
-        unsafe { fmpz_mat_scalar_smod(&mut out.matrix, &self.matrix, &modulus.value) };
+        let out = self.clone();
 
-        for i in 0..num_rows {
-            for j in 0..num_cols {
-                let entry = unsafe { out.get_entry_unchecked(i, j) };
-                if entry < 0 {
-                    unsafe { out.set_entry_unchecked(i, j, entry + modulus) };
-                }
+        for i in 0..out.get_num_rows() {
+            for j in 0..out.get_num_columns() {
+                let entry = unsafe { fmpz_mat_entry(&out.matrix, i, j) };
+                unsafe { fmpz_mod(entry, entry, &modulus.value) }
+            }
+        }
+
+        out
+    }
+}
+
+impl Rem<&Modulus> for &MatZ {
+    type Output = MatZ;
+    /// Computes `self` mod `modulus`.
+    /// For negative entries in `self`, the smallest positive representative is returned.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the positive remainders are computed
+    ///
+    /// Returns `self` mod `modulus` as a [`MatZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatZ;
+    /// use qfall_math::integer_mod_q::Modulus;
+    /// use std::str::FromStr;
+    ///
+    /// let a: MatZ = MatZ::from_str("[[-2],[42]]").unwrap();
+    /// let b: Z = Modulus::from(24);
+    ///
+    /// let c: MatZ = &a % &b;
+    /// ```
+    fn rem(self, modulus: &Modulus) -> Self::Output {
+        let out = self.clone();
+
+        for i in 0..out.get_num_rows() {
+            for j in 0..out.get_num_columns() {
+                let entry = unsafe { fmpz_mat_entry(&out.matrix, i, j) };
+                unsafe { fmpz_mod_set_fmpz(entry, entry, modulus.get_fmpz_mod_ctx_struct()) }
             }
         }
 
@@ -67,13 +99,15 @@ impl Rem<&Z> for &MatZ {
 
 arithmetic_trait_borrowed_to_owned!(Rem, rem, MatZ, Z, MatZ);
 arithmetic_trait_mixed_borrowed_owned!(Rem, rem, MatZ, Z, MatZ);
+arithmetic_trait_borrowed_to_owned!(Rem, rem, MatZ, Modulus, MatZ);
+arithmetic_trait_mixed_borrowed_owned!(Rem, rem, MatZ, Modulus, MatZ);
 
 implement_for_others!(Z, MatZ, Rem for i8 i16 i32 i64 u8 u16 u32 u64);
 
 #[cfg(test)]
 mod test_rem {
     use super::Z;
-    use crate::integer::MatZ;
+    use crate::{integer::MatZ, integer_mod_q::Modulus};
     use std::str::FromStr;
 
     /// Testing modulo for two owned
@@ -81,8 +115,10 @@ mod test_rem {
     fn rem() {
         let a = MatZ::from_str("[[2, 3],[42, 24]]").unwrap();
         let b = Z::from(24);
-        let c = a % b;
-        assert_eq!(c, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
+        let c1 = a.clone() % b;
+        let c2 = a % Modulus::from(24);
+        assert_eq!(c1, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
     }
 
     /// Testing modulo for two borrowed
@@ -90,8 +126,10 @@ mod test_rem {
     fn rem_borrow() {
         let a = MatZ::from_str("[[2, 3],[42, 24]]").unwrap();
         let b = Z::from(24);
-        let c = &a % &b;
-        assert_eq!(c, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
+        let c1 = &a % &b;
+        let c2 = &a % &Modulus::from(24);
+        assert_eq!(c1, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
     }
 
     /// Testing modulo for borrowed and owned
@@ -99,8 +137,10 @@ mod test_rem {
     fn rem_first_borrowed() {
         let a = MatZ::from_str("[[2, 3],[42, 24]]").unwrap();
         let b = Z::from(24);
-        let c = &a % b;
-        assert_eq!(c, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
+        let c1 = &a % b;
+        let c2 = &a % Modulus::from(24);
+        assert_eq!(c1, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
     }
 
     /// Testing modulo for owned and borrowed
@@ -108,8 +148,10 @@ mod test_rem {
     fn rem_second_borrowed() {
         let a = MatZ::from_str("[[2, 3],[42, 24]]").unwrap();
         let b = Z::from(24);
-        let c = a % &b;
-        assert_eq!(c, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
+        let c1 = a.clone() % &b;
+        let c2 = a % &Modulus::from(24);
+        assert_eq!(c1, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[2, 3],[18, 0]]").unwrap());
     }
 
     /// Testing modulo for negative values
@@ -117,8 +159,10 @@ mod test_rem {
     fn rem_negative_representation() {
         let a = MatZ::from_str("[[-2, 3],[42, 24]]").unwrap();
         let b = Z::from(24);
-        let c = &a % &b;
-        assert_eq!(c, MatZ::from_str("[[22, 3],[18, 0]]").unwrap());
+        let c1 = &a % &b;
+        let c2 = &a % &Modulus::from(24);
+        assert_eq!(c1, MatZ::from_str("[[22, 3],[18, 0]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[22, 3],[18, 0]]").unwrap());
     }
 
     /// Testing modulo for large numbers
@@ -126,8 +170,10 @@ mod test_rem {
     fn rem_large_numbers() {
         let a = MatZ::from_str(&format!("[[2, 3],[{}, 24]]", u64::MAX)).unwrap();
         let b = Z::from(u64::MAX - 2);
-        let c = &a % &b;
-        assert_eq!(c, MatZ::from_str("[[2, 3],[2, 24]]").unwrap());
+        let c1 = &a % &b;
+        let c2 = &a % &Modulus::from(u64::MAX - 2);
+        assert_eq!(c1, MatZ::from_str("[[2, 3],[2, 24]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[2, 3],[2, 24]]").unwrap());
     }
 
     /// Ensures that computing modulo a negative number results in a panic
@@ -146,7 +192,7 @@ mod test_rem {
         _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % 0;
     }
 
-    /// Ensures that `modulo` is available for several types implementing [`Into<Z>`].
+    /// Ensures that `modulo` is available for several types.
     #[test]
     fn availability() {
         let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % 2u8;
@@ -158,6 +204,7 @@ mod test_rem {
         let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % 2i32;
         let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % 2i64;
         let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % Z::from(2);
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % Modulus::from(2);
 
         let _ = &MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % 2u8;
         let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % &Z::from(2);

--- a/src/integer/poly_over_z/arithmetic/modulo.rs
+++ b/src/integer/poly_over_z/arithmetic/modulo.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/arithmetic/modulo.rs
+++ b/src/integer/poly_over_z/arithmetic/modulo.rs
@@ -11,6 +11,7 @@
 use super::super::PolyOverZ;
 use crate::{
     integer::Z,
+    integer_mod_q::{Modulus, ModulusPolynomialRingZq, PolyOverZq, PolynomialRingZq},
     macros::{
         arithmetics::{arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned},
         for_others::implement_for_others,
@@ -51,6 +52,91 @@ impl Rem<&Z> for &PolyOverZ {
     }
 }
 
+impl Rem<&Modulus> for &PolyOverZ {
+    type Output = PolyOverZ;
+    /// Computes `self` mod `modulus` as long as `modulus` is greater than 1.
+    /// For negative values of `self`, the smallest positive representative is returned.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the positive remainder is computed
+    ///
+    /// Returns `self` mod `modulus` as a [`PolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::Modulus;
+    /// use qfall_math::integer::{PolyOverZ, Z};
+    /// use std::str::FromStr;
+    ///
+    /// let a: PolyOverZ = PolyOverZ::from_str("2  -2 42").unwrap();
+    /// let b = Modulus::from(24);
+    ///
+    /// let c: PolyOverZ = a % b;
+    /// ```
+    fn rem(self, modulus: &Modulus) -> Self::Output {
+        let out = PolyOverZq::from((self, modulus));
+        out.get_representative_least_nonnegative_residue()
+    }
+}
+
+impl<Mod: Into<ModulusPolynomialRingZq>> Rem<Mod> for &PolyOverZ {
+    type Output = PolyOverZ;
+    /// Computes `self` mod `modulus` as long as `modulus` is greater than 1.
+    /// For negative values of `self`, the smallest positive representative is returned.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the positive remainder is computed
+    ///
+    /// Returns `self` mod `modulus` as a [`PolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
+    /// use qfall_math::integer::{PolyOverZ, Z};
+    /// use std::str::FromStr;
+    ///
+    /// let a: PolyOverZ = PolyOverZ::from_str("2  -2 42").unwrap();
+    /// let b = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+    ///
+    /// let c: PolyOverZ = &a % b;
+    /// ```
+    fn rem(self, modulus: Mod) -> Self::Output {
+        let out = PolynomialRingZq::from((self, modulus));
+        out.get_representative_least_nonnegative_residue()
+    }
+}
+
+impl<Mod: Into<ModulusPolynomialRingZq>> Rem<Mod> for PolyOverZ {
+    type Output = PolyOverZ;
+    /// Computes `self` mod `modulus` as long as `modulus` is greater than 1.
+    /// For negative values of `self`, the smallest positive representative is returned.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the positive remainder is computed
+    ///
+    /// Returns `self` mod `modulus` as a [`PolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::ModulusPolynomialRingZq;
+    /// use qfall_math::integer::{PolyOverZ, Z};
+    /// use std::str::FromStr;
+    ///
+    /// let a: PolyOverZ = PolyOverZ::from_str("2  -2 42").unwrap();
+    /// let b = ModulusPolynomialRingZq::from(24);
+    ///
+    /// let c: PolyOverZ = a % b;
+    /// ```
+    fn rem(self, modulus: Mod) -> Self::Output {
+        PolynomialRingZq::from((self, modulus)).poly
+    }
+}
+
+arithmetic_trait_borrowed_to_owned!(Rem, rem, PolyOverZ, Modulus, PolyOverZ);
+arithmetic_trait_mixed_borrowed_owned!(Rem, rem, PolyOverZ, Modulus, PolyOverZ);
 arithmetic_trait_borrowed_to_owned!(Rem, rem, PolyOverZ, Z, PolyOverZ);
 arithmetic_trait_mixed_borrowed_owned!(Rem, rem, PolyOverZ, Z, PolyOverZ);
 
@@ -59,7 +145,10 @@ implement_for_others!(Z, PolyOverZ, Rem for i8 i16 i32 i64 u8 u16 u32 u64);
 #[cfg(test)]
 mod test_rem {
     use super::Z;
-    use crate::integer::PolyOverZ;
+    use crate::{
+        integer::PolyOverZ,
+        integer_mod_q::{Modulus, ModulusPolynomialRingZq, PolyOverZq},
+    };
     use std::str::FromStr;
 
     /// Testing modulo for two owned
@@ -67,8 +156,15 @@ mod test_rem {
     fn rem() {
         let a = PolyOverZ::from_str("2  2 42").unwrap();
         let b = Z::from(24);
-        let c = a % b;
-        assert_eq!(c, PolyOverZ::from_str("2  2 18").unwrap());
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = a.clone() % b;
+        let c2 = a.clone() % modulus;
+        let c3 = a % poly_mod;
+        let cmp = PolyOverZ::from_str("2  2 18").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for two borrowed
@@ -76,8 +172,15 @@ mod test_rem {
     fn rem_borrow() {
         let a = PolyOverZ::from_str("2  2 42").unwrap();
         let b = Z::from(24);
-        let c = &a % &b;
-        assert_eq!(c, PolyOverZ::from_str("2  2 18").unwrap());
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = &a % &b;
+        let c2 = &a % &modulus;
+        let c3 = &a % &poly_mod;
+        let cmp = PolyOverZ::from_str("2  2 18").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for borrowed and owned
@@ -85,8 +188,15 @@ mod test_rem {
     fn rem_first_borrowed() {
         let a = PolyOverZ::from_str("2  2 42").unwrap();
         let b = Z::from(24);
-        let c = &a % b;
-        assert_eq!(c, PolyOverZ::from_str("2  2 18").unwrap());
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = &a % b;
+        let c2 = &a % modulus;
+        let c3 = &a % poly_mod;
+        let cmp = PolyOverZ::from_str("2  2 18").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for owned and borrowed
@@ -94,8 +204,15 @@ mod test_rem {
     fn rem_second_borrowed() {
         let a = PolyOverZ::from_str("2  2 42").unwrap();
         let b = Z::from(24);
-        let c = a % &b;
-        assert_eq!(c, PolyOverZ::from_str("2  2 18").unwrap());
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = a.clone() % &b;
+        let c2 = a.clone() % &modulus;
+        let c3 = a % &poly_mod;
+        let cmp = PolyOverZ::from_str("2  2 18").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for negative values
@@ -103,8 +220,15 @@ mod test_rem {
     fn rem_negative_representation() {
         let a = PolyOverZ::from_str("2  -2 42").unwrap();
         let b = Z::from(24);
-        let c = &a % &b;
-        assert_eq!(c, PolyOverZ::from_str("2  22 18").unwrap());
+        let modulus = Modulus::from(24);
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c1 = &a % &b;
+        let c2 = &a % &modulus;
+        let c3 = a % &poly_mod;
+        let cmp = PolyOverZ::from_str("2  22 18").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
     }
 
     /// Testing modulo for large numbers
@@ -112,8 +236,26 @@ mod test_rem {
     fn rem_large_numbers() {
         let a = PolyOverZ::from_str(&format!("2  2 {}", u64::MAX)).unwrap();
         let b = Z::from(u64::MAX - 2);
-        let c = &a % &b;
-        assert_eq!(c, PolyOverZ::from_str("2  2 2").unwrap());
+        let modulus = Modulus::from(u64::MAX - 2);
+        let poly_mod =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX - 2)).unwrap();
+        let c1 = a.clone() % &b;
+        let c2 = a.clone() % &modulus;
+        let c3 = a % &poly_mod;
+        let cmp = PolyOverZ::from_str("2  2 2").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+        assert_eq!(c3, cmp);
+    }
+
+    /// Ensure that the reduction with a polynomial modulus also reduces the polynomial degree.
+    #[test]
+    fn polynomial_reduction() {
+        let a = PolyOverZ::from_str("4  2 42 0 1").unwrap();
+        let b = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let c = a % b;
+        let cmp = PolyOverZ::from_str("2  1 18").unwrap();
+        assert_eq!(c, cmp);
     }
 
     /// Ensures that computing modulo a negative number results in a panic
@@ -132,7 +274,7 @@ mod test_rem {
         _ = PolyOverZ::from_str("2  2 42").unwrap() % 0;
     }
 
-    /// Ensures that `modulo` is available for several types implementing [`Into<Z>`].
+    /// Ensures that `modulo` is available for several types
     #[test]
     fn availability() {
         let _ = PolyOverZ::from_str("2  2 42").unwrap() % 2u8;
@@ -144,9 +286,16 @@ mod test_rem {
         let _ = PolyOverZ::from_str("2  2 42").unwrap() % 2i32;
         let _ = PolyOverZ::from_str("2  2 42").unwrap() % 2i64;
         let _ = PolyOverZ::from_str("2  2 42").unwrap() % Z::from(2);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap() % Modulus::from(2);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap()
+            % ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
 
         let _ = &PolyOverZ::from_str("2  2 42").unwrap() % 2u8;
         let _ = PolyOverZ::from_str("2  2 42").unwrap() % &Z::from(2);
         let _ = &PolyOverZ::from_str("2  2 42").unwrap() % &Z::from(2);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap()
+            % PolyOverZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let _ = PolyOverZ::from_str("2  2 42").unwrap()
+            % &PolyOverZq::from_str("4  1 0 0 1 mod 24").unwrap();
     }
 }

--- a/src/integer/poly_over_z/arithmetic/modulo.rs
+++ b/src/integer/poly_over_z/arithmetic/modulo.rs
@@ -126,7 +126,7 @@ impl<Mod: Into<ModulusPolynomialRingZq>> Rem<Mod> for PolyOverZ {
     /// use std::str::FromStr;
     ///
     /// let a: PolyOverZ = PolyOverZ::from_str("2  -2 42").unwrap();
-    /// let b = ModulusPolynomialRingZq::from(24);
+    /// let b = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
     ///
     /// let c: PolyOverZ = a % b;
     /// ```

--- a/src/integer/z/arithmetic/modulo.rs
+++ b/src/integer/z/arithmetic/modulo.rs
@@ -68,7 +68,7 @@ impl Rem<&Modulus> for &Z {
     /// use qfall_math::integer_mod_q::Modulus;
     ///
     /// let a: Z = Z::from(42);
-    /// let b: Z = Modulus::from(24);
+    /// let b = Modulus::from(24);
     ///
     /// let c: Z = a % &b;
     /// ```

--- a/src/integer/z/arithmetic/modulo.rs
+++ b/src/integer/z/arithmetic/modulo.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //
@@ -8,12 +8,15 @@
 
 //! Implementation of the [`Rem`] trait for [`Z`] values.
 
-use flint_sys::fmpz::fmpz_mod;
+use flint_sys::{fmpz::fmpz_mod, fmpz_mod::fmpz_mod_set_fmpz};
 
 use super::super::Z;
-use crate::macros::arithmetics::{
-    arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
-    arithmetic_trait_mixed_borrowed_owned,
+use crate::{
+    integer_mod_q::Modulus,
+    macros::arithmetics::{
+        arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
+        arithmetic_trait_mixed_borrowed_owned,
+    },
 };
 use std::ops::Rem;
 
@@ -48,48 +51,93 @@ impl Rem for &Z {
     }
 }
 
+impl Rem<&Modulus> for &Z {
+    type Output = Z;
+    /// Computes `self` mod `modulus` as long as `modulus` is greater than 1.
+    /// For negative values of `self`, the smallest positive representative is returned.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the positive remainder is computed
+    ///
+    /// Returns `self` mod `modulus` as a [`Z`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::Z;
+    /// use qfall_math::integer_mod_q::Modulus;
+    ///
+    /// let a: Z = Z::from(42);
+    /// let b: Z = Modulus::from(24);
+    ///
+    /// let c: Z = a % &b;
+    /// ```
+    fn rem(self, modulus: &Modulus) -> Self::Output {
+        let mut out = Z::default();
+        unsafe {
+            fmpz_mod_set_fmpz(
+                &mut out.value,
+                &self.value,
+                modulus.get_fmpz_mod_ctx_struct(),
+            )
+        };
+        out
+    }
+}
+
 arithmetic_trait_borrowed_to_owned!(Rem, rem, Z, Z, Z);
 arithmetic_trait_mixed_borrowed_owned!(Rem, rem, Z, Z, Z);
+arithmetic_trait_borrowed_to_owned!(Rem, rem, Z, Modulus, Z);
+arithmetic_trait_mixed_borrowed_owned!(Rem, rem, Z, Modulus, Z);
 arithmetic_between_types!(Rem, rem, Z, Z, i64 i32 i16 i8 u64 u32 u16 u8);
 
 #[cfg(test)]
 mod test_rem {
     use super::Z;
+    use crate::integer_mod_q::Modulus;
 
     /// Testing modulo for two [`Z`]
     #[test]
     fn rem() {
         let a: Z = Z::from(42);
         let b: Z = Z::from(24);
-        let c: Z = a % b;
-        assert_eq!(c, 18);
+        let c1: Z = a.clone() % b;
+        let c2: Z = a % Modulus::from(24);
+        assert_eq!(c1, 18);
+        assert_eq!(c2, 18);
     }
 
-    /// Testing modulo for two borrowed [`Z`]
+    /// Testing modulo for borrowed [`Z`]
     #[test]
     fn rem_borrow() {
         let a: Z = Z::from(42);
         let b: Z = Z::from(24);
-        let c: Z = &a % &b;
-        assert_eq!(c, 18);
+        let c1: Z = &a % &b;
+        let c2: Z = &a % &Modulus::from(24);
+        assert_eq!(c1, 18);
+        assert_eq!(c2, 18);
     }
 
-    /// Testing modulo for borrowed [`Z`] and [`Z`]
+    /// Testing modulo for borrowed and owned
     #[test]
     fn rem_first_borrowed() {
         let a: Z = Z::from(42);
         let b: Z = Z::from(24);
-        let c: Z = &a % b;
-        assert_eq!(c, 18);
+        let c1: Z = &a % b;
+        let c2: Z = &a % Modulus::from(24);
+        assert_eq!(c1, 18);
+        assert_eq!(c2, 18);
     }
 
-    /// Testing modulo for [`Z`] and borrowed [`Z`]
+    /// Testing modulo for owned and borrowed
     #[test]
     fn rem_second_borrowed() {
         let a: Z = Z::from(42);
         let b: Z = Z::from(24);
-        let c: Z = a % &b;
-        assert_eq!(c, 18);
+        let c1: Z = a.clone() % &b;
+        let c2: Z = a % &Modulus::from(24);
+        assert_eq!(c1, 18);
+        assert_eq!(c2, 18);
     }
 
     /// Testing modulo for negative values
@@ -97,8 +145,10 @@ mod test_rem {
     fn rem_negative_representation() {
         let a: Z = Z::from(-2);
         let b: Z = Z::from(24);
-        let c: Z = &a % &b;
-        assert_eq!(c, 22);
+        let c1: Z = a.clone() % &b;
+        let c2: Z = &a % &Modulus::from(24);
+        assert_eq!(c1, 22);
+        assert_eq!(c2, 22);
     }
 
     /// Testing modulo for large numbers
@@ -107,9 +157,10 @@ mod test_rem {
         let a: Z = Z::from(u64::MAX);
         let b: Z = Z::from(u64::MAX - 2);
 
-        let c: Z = &a % &b;
-
-        assert_eq!(c, 2);
+        let c1: Z = a.clone() % &b;
+        let c2: Z = a % &Modulus::from(u64::MAX - 2);
+        assert_eq!(c1, 2);
+        assert_eq!(c2, 2);
     }
 
     /// Ensures that computing modulo a negative number results in a panic
@@ -128,7 +179,7 @@ mod test_rem {
         _ = Z::from(15) % 0;
     }
 
-    /// Ensures that `modulo` is available for several types implementing [`Into<Z>`].
+    /// Ensures that `modulo` is available for several types.
     #[test]
     fn availability() {
         let _ = Z::ONE % 2u8;
@@ -140,6 +191,7 @@ mod test_rem {
         let _ = Z::ONE % 2i32;
         let _ = Z::ONE % 2i64;
         let _ = Z::ONE % Z::from(2);
+        let _ = Z::ONE % Modulus::from(2);
 
         let _ = &Z::ONE % 2u8;
         let _ = 1u8 % Z::from(2);

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -265,8 +265,9 @@ impl MatrixSwaps for MatPolynomialRingZq {
     /// ```
     /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
     /// use qfall_math::traits::MatrixSwaps;
+    /// use std::str::FromStr;
     ///
-    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from_str("3  1 0 1 mod 17").unwrap());
     /// matrix.swap_entries(0, 0, 2, 1);
     /// ```
     ///
@@ -297,10 +298,11 @@ impl MatrixSwaps for MatPolynomialRingZq {
     ///
     /// # Examples
     /// ```
-    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
     /// use qfall_math::traits::MatrixSwaps;
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
     ///
-    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from_str("3  1 0 1 mod 17").unwrap());
     /// matrix.swap_columns(0, 2);
     /// ```
     ///
@@ -331,8 +333,9 @@ impl MatrixSwaps for MatPolynomialRingZq {
     /// ```
     /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
     /// use qfall_math::traits::MatrixSwaps;
+    /// use std::str::FromStr;
     ///
-    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from_str("3  1 0 1 mod 17").unwrap());
     /// matrix.swap_rows(0, 2);
     /// ```
     ///
@@ -355,8 +358,9 @@ impl MatPolynomialRingZq {
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
     ///
-    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from_str("3  1 0 1 mod 17").unwrap());
     /// matrix.reverse_columns();
     /// ```
     pub fn reverse_columns(&mut self) {
@@ -369,8 +373,9 @@ impl MatPolynomialRingZq {
     /// # Examples
     /// ```
     /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
     ///
-    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from((3, 17)));
+    /// let mut matrix = MatPolynomialRingZq::new(4, 3, ModulusPolynomialRingZq::from_str("3  1 0 1 mod 17").unwrap());
     /// matrix.reverse_rows();
     /// ```
     pub fn reverse_rows(&mut self) {

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -781,7 +781,8 @@ mod test_swaps {
     /// Ensures that `swap_entries` returns an error if one of the specified entries is out of bounds
     #[test]
     fn entries_out_of_bounds() {
-        let mut matrix = MatPolynomialRingZq::new(5, 2, ModulusPolynomialRingZq::from((3, 17)));
+        let modulus = ModulusPolynomialRingZq::from_str("3  3 0 1 mod 17").unwrap();
+        let mut matrix = MatPolynomialRingZq::new(5, 2, modulus);
 
         assert!(matrix.swap_entries(-6, 0, 0, 0).is_err());
         assert!(matrix.swap_entries(0, -3, 0, 0).is_err());
@@ -823,7 +824,8 @@ mod test_swaps {
     /// Ensures that `swap_columns` returns an error if one of the specified columns is out of bounds
     #[test]
     fn column_out_of_bounds() {
-        let mut matrix = MatPolynomialRingZq::new(5, 2, ModulusPolynomialRingZq::from((3, 17)));
+        let modulus = ModulusPolynomialRingZq::from_str("3  3 0 1 mod 17").unwrap();
+        let mut matrix = MatPolynomialRingZq::new(5, 2, modulus);
 
         assert!(matrix.swap_columns(-6, 0).is_err());
         assert!(matrix.swap_columns(0, -6).is_err());
@@ -850,7 +852,8 @@ mod test_swaps {
     /// Ensures that `swap_rows` returns an error if one of the specified rows is out of bounds
     #[test]
     fn row_out_of_bounds() {
-        let mut matrix = MatPolynomialRingZq::new(2, 4, ModulusPolynomialRingZq::from((3, 17)));
+        let modulus = ModulusPolynomialRingZq::from_str("3  3 0 1 mod 17").unwrap();
+        let mut matrix = MatPolynomialRingZq::new(2, 4, modulus);
 
         assert!(matrix.swap_rows(-3, 0).is_err());
         assert!(matrix.swap_rows(0, -3).is_err());

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
@@ -173,9 +173,9 @@ mod test_partial_eq {
     /// Test equal with small positive and negative constant polynomials.
     #[test]
     fn equal_small() {
-        let small_1 = ModulusPolynomialRingZq::from_str("1  10 mod 17").unwrap();
-        let small_2 = ModulusPolynomialRingZq::from_str("1  10 mod 17").unwrap();
-        let negative = ModulusPolynomialRingZq::from_str("1  -2 mod 17").unwrap();
+        let small_1 = ModulusPolynomialRingZq::from_str("2  1 10 mod 17").unwrap();
+        let small_2 = ModulusPolynomialRingZq::from_str("2  1 10 mod 17").unwrap();
+        let negative = ModulusPolynomialRingZq::from_str("2  1 -2 mod 17").unwrap();
 
         assert!(small_1 == small_2);
         assert!(small_2 == small_1);
@@ -187,9 +187,9 @@ mod test_partial_eq {
     /// Test not equal with small positive and negative constant polynomials.
     #[test]
     fn not_equal_small() {
-        let small_1 = ModulusPolynomialRingZq::from_str("1  10 mod 17").unwrap();
-        let small_2 = ModulusPolynomialRingZq::from_str("1  10 mod 17").unwrap();
-        let negative = ModulusPolynomialRingZq::from_str("1  -1 mod 17").unwrap();
+        let small_1 = ModulusPolynomialRingZq::from_str("2  1 10 mod 17").unwrap();
+        let small_2 = ModulusPolynomialRingZq::from_str("2  1 10 mod 17").unwrap();
+        let negative = ModulusPolynomialRingZq::from_str("2  1 -1 mod 17").unwrap();
 
         assert!(!(small_1 != small_2));
         assert!(!(small_2 != small_1));
@@ -202,8 +202,8 @@ mod test_partial_eq {
     /// (uses FLINT's pointer representation)
     #[test]
     fn equal_large() {
-        let max_str = format!("1  {} mod {LARGE_PRIME}", u64::MAX);
-        let min_str = format!("1  {} mod {LARGE_PRIME}", i64::MIN);
+        let max_str = format!("2  1 {} mod {LARGE_PRIME}", u64::MAX);
+        let min_str = format!("2  1 {} mod {LARGE_PRIME}", i64::MIN);
 
         let max_1 = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let max_2 = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
@@ -221,8 +221,8 @@ mod test_partial_eq {
     /// (uses FLINT's pointer representation)
     #[test]
     fn not_equal_large() {
-        let max_str = format!("1  {} mod {LARGE_PRIME}", u64::MAX);
-        let min_str = format!("1  {} mod {LARGE_PRIME}", i64::MIN);
+        let max_str = format!("2  1 {} mod {LARGE_PRIME}", u64::MAX);
+        let min_str = format!("2  1 {} mod {LARGE_PRIME}", i64::MIN);
 
         let max_1 = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let max_2 = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
@@ -240,14 +240,14 @@ mod test_partial_eq {
     /// and small polynomial with a small [`ModulusPolynomialRingZq`] (no pointer representation).
     #[test]
     fn equal_large_small() {
-        let max_str = format!("1  {} mod {LARGE_PRIME}", u64::MAX);
-        let min_str = format!("1  {} mod {LARGE_PRIME}", i64::MIN);
+        let max_str = format!("2  1 {} mod {LARGE_PRIME}", u64::MAX);
+        let min_str = format!("2  1 {} mod {LARGE_PRIME}", i64::MIN);
 
         let max = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let min = ModulusPolynomialRingZq::from_str(&min_str).unwrap();
 
-        let small_positive = ModulusPolynomialRingZq::from_str("1  2 mod 17").unwrap();
-        let small_negative = ModulusPolynomialRingZq::from_str("1  -2 mod 17").unwrap();
+        let small_positive = ModulusPolynomialRingZq::from_str("2  1 2 mod 17").unwrap();
+        let small_negative = ModulusPolynomialRingZq::from_str("2  1 -2 mod 17").unwrap();
 
         assert!(!(max == small_negative));
         assert!(!(small_negative == max));
@@ -264,14 +264,14 @@ mod test_partial_eq {
     /// and small [`ModulusPolynomialRingZq`] (no pointer representation).
     #[test]
     fn not_equal_large_small() {
-        let max_str = format!("1  {} mod {LARGE_PRIME}", u64::MAX);
-        let min_str = format!("1  {} mod {LARGE_PRIME}", i64::MIN);
+        let max_str = format!("2  1 {} mod {LARGE_PRIME}", u64::MAX);
+        let min_str = format!("2  1 {} mod {LARGE_PRIME}", i64::MIN);
 
         let max = ModulusPolynomialRingZq::from_str(&max_str).unwrap();
         let min = ModulusPolynomialRingZq::from_str(&min_str).unwrap();
 
-        let small_positive = ModulusPolynomialRingZq::from_str("1  2 mod 17").unwrap();
-        let small_negative = ModulusPolynomialRingZq::from_str("1  -2 mod 17").unwrap();
+        let small_positive = ModulusPolynomialRingZq::from_str("2  1 2 mod 17").unwrap();
+        let small_negative = ModulusPolynomialRingZq::from_str("2  1 -2 mod 17").unwrap();
 
         assert!(max != small_negative);
         assert!(small_negative != max);
@@ -287,8 +287,8 @@ mod test_partial_eq {
     /// Test not equal for the same polynomial but with a different modulus
     #[test]
     fn different_modulus() {
-        let first_str = "1  2 mod 17";
-        let second_str = "1  2 mod 19";
+        let first_str = "2  1 2 mod 17";
+        let second_str = "2  1 2 mod 19";
 
         let first = ModulusPolynomialRingZq::from_str(first_str).unwrap();
         let second = ModulusPolynomialRingZq::from_str(second_str).unwrap();

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
@@ -13,39 +13,12 @@
 use super::ModulusPolynomialRingZq;
 use crate::{
     error::MathError,
-    integer::{PolyOverZ, Z},
-    integer_mod_q::{Modulus, PolyOverZq, Zq},
+    integer::PolyOverZ,
+    integer_mod_q::{Modulus, PolyOverZq},
     macros::for_others::implement_for_owned,
 };
 use flint_sys::fq::fq_ctx_init_modulus;
 use std::{ffi::CString, mem::MaybeUninit, rc::Rc, str::FromStr};
-
-impl From<&Zq> for ModulusPolynomialRingZq {
-    /// Creates a constant [`ModulusPolynomialRingZq`], i.e. the polynomial `x mod q`,
-    /// where `x` is the value of the given [`Zq`] value and `q` its modulus.
-    ///
-    /// Parameters:
-    /// - `value`: the constant value the polynomial will have.
-    ///   
-    /// Returns a new constant [`ModulusPolynomialRingZq`] with the specified
-    /// `value` and `modulus` of the [`Zq`] value.
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::{integer_mod_q::*, traits::*};
-    ///
-    /// let zq = Zq::from((2, 10));
-    ///
-    /// let mod_poly = ModulusPolynomialRingZq::from(&zq);
-    /// ```
-    fn from(value: &Zq) -> Self {
-        let poly_zq = PolyOverZq::from(value);
-
-        Self::from(poly_zq)
-    }
-}
-
-implement_for_owned!(Zq, ModulusPolynomialRingZq, From);
 
 impl<Mod: Into<Modulus>> From<(&PolyOverZ, Mod)> for ModulusPolynomialRingZq {
     /// Creates a [`ModulusPolynomialRingZq`] from a [`PolyOverZ`] and a value that implements [`Into<Modulus>`].
@@ -73,7 +46,7 @@ impl<Mod: Into<Modulus>> From<(&PolyOverZ, Mod)> for ModulusPolynomialRingZq {
     ///
     /// # Panics ...
     /// - if `modulus` is smaller than `2`, or
-    /// - if the modulus polynomial is `0`.
+    /// - if the degree of the polynomial is smaller than `1`.
     fn from((poly, modulus): (&PolyOverZ, Mod)) -> Self {
         let poly_zq = PolyOverZq::from((poly, modulus));
 
@@ -109,42 +82,9 @@ impl<Mod: Into<Modulus>> From<(PolyOverZ, Mod)> for ModulusPolynomialRingZq {
     ///
     /// # Panics ...
     /// - if `modulus` is smaller than `2`, or
-    /// - if the modulus polynomial is `0`.
+    /// - if the modulus polynomial is of degree smaller than `1`.
     fn from((poly, modulus): (PolyOverZ, Mod)) -> Self {
         let poly_zq = PolyOverZq::from((poly, modulus));
-
-        check_poly_mod(&poly_zq).unwrap();
-
-        Self::from(poly_zq)
-    }
-}
-
-impl<Integer: Into<Z>, Mod: Into<Modulus>> From<(Integer, Mod)> for ModulusPolynomialRingZq {
-    /// Creates a [`ModulusPolynomialRingZq`] from any values that implement [`Into<Z>`] and [`Into<Modulus>`],
-    /// where the second value must be larger than `1`.
-    ///
-    /// Parameters:
-    /// - `z`: the single, constant coefficient of the polynomial.
-    /// - `modulus`: the modulus by which each entry is reduced.
-    ///
-    /// Returns a new constant [`ModulusPolynomialRingZq`] with the specified `z` and `modulus` value.
-    ///
-    /// # Examples
-    /// ```
-    /// use qfall_math::integer_mod_q::PolyOverZq;
-    /// use std::str::FromStr;
-    ///
-    /// let mod_poly = PolyOverZq::from((5, 42));
-    ///
-    /// let poly_cmp = PolyOverZq::from_str("1  5 mod 42").unwrap();
-    /// assert_eq!(poly_cmp, mod_poly);
-    /// ```
-    ///
-    /// # Panics ...
-    /// - if `modulus` is smaller than `2`, or
-    /// - if the modulus polynomial is `0`.
-    fn from((z, modulus): (Integer, Mod)) -> Self {
-        let poly_zq = PolyOverZq::from((z, modulus));
 
         check_poly_mod(&poly_zq).unwrap();
 
@@ -174,7 +114,7 @@ impl From<&PolyOverZq> for ModulusPolynomialRingZq {
     ///
     /// # Panics ...
     /// - if `modulus` is smaller than `2`, or
-    /// - if the modulus polynomial is `0`.
+    /// - if the modulus polynomial is of degree smaller than `1`.
     fn from(poly: &PolyOverZq) -> Self {
         check_poly_mod(poly).unwrap();
 
@@ -250,7 +190,7 @@ impl FromStr for ModulusPolynomialRingZq {
     /// - Returns a [`MathError`] of type
     ///   [`InvalidModulus`](MathError::InvalidModulus)
     ///     - if `modulus` is smaller than `2`, or
-    ///     - if the modulus polynomial is `0`.
+    ///     - if the modulus polynomial is of degree smaller than `1`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let poly_zq = PolyOverZq::from_str(s)?;
 
@@ -280,9 +220,9 @@ impl FromStr for ModulusPolynomialRingZq {
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type
 ///   [`InvalidModulus`](MathError::InvalidModulus)
-///   if the modulus polynomial is `0`.
+///   if the modulus polynomial is of degree less than `1`.
 pub(crate) fn check_poly_mod(poly_zq: &PolyOverZq) -> Result<(), MathError> {
-    if poly_zq == &PolyOverZq::from((0, &poly_zq.modulus)) {
+    if poly_zq.get_degree() < 1 {
         return Err(MathError::InvalidModulus(poly_zq.to_string()));
     }
 
@@ -294,33 +234,17 @@ pub(crate) fn check_poly_mod(poly_zq: &PolyOverZq) -> Result<(), MathError> {
 #[cfg(test)]
 mod test_availability {
     use super::*;
-    use crate::{integer::Z, integer_mod_q::Zq};
-    use crate::{integer_mod_q::ModulusPolynomialRingZq, integer_mod_q::PolyOverZq};
+    use crate::integer_mod_q::PolyOverZq;
     use std::str::FromStr;
 
     /// Ensure that the from function can be called with several types.
     #[test]
     fn availability() {
-        let z = Z::from(4);
-        let modulus = Modulus::from(3);
-        let zq = Zq::from((2, 3));
         let poly = PolyOverZ::from_str("2  1 1").unwrap();
         let poly_zq = PolyOverZq::from_str("4  1 0 0 1 mod 17").unwrap();
 
-        let _ = ModulusPolynomialRingZq::from(&zq);
-        let _ = ModulusPolynomialRingZq::from(zq.clone());
-
-        let _ = ModulusPolynomialRingZq::from((2, 5));
-        let _ = ModulusPolynomialRingZq::from((&z, 5));
-        let _ = ModulusPolynomialRingZq::from((z.clone(), 5));
-        let _ = ModulusPolynomialRingZq::from((&modulus, 5));
-        let _ = ModulusPolynomialRingZq::from((modulus.clone(), 5));
         let _ = ModulusPolynomialRingZq::from((&poly, 5));
         let _ = ModulusPolynomialRingZq::from((poly.clone(), 5));
-        let _ = ModulusPolynomialRingZq::from((3, &z));
-        let _ = ModulusPolynomialRingZq::from((3, z.clone()));
-        let _ = ModulusPolynomialRingZq::from((2, &modulus));
-        let _ = ModulusPolynomialRingZq::from((2, modulus));
 
         let _ = ModulusPolynomialRingZq::from(&poly_zq);
         let _ = ModulusPolynomialRingZq::from(poly_zq);
@@ -357,20 +281,23 @@ mod test_try_from_poly_z {
 /// since the format is reused, we omit some tests
 #[cfg(test)]
 mod test_try_from_integer_mod {
-    use crate::integer_mod_q::ModulusPolynomialRingZq;
+    use std::str::FromStr;
+
+    use crate::{integer::PolyOverZ, integer_mod_q::ModulusPolynomialRingZq};
 
     /// Ensure that primes and non-primes work as modulus
     #[test]
     fn mod_primes() {
-        let _ = ModulusPolynomialRingZq::from((5, 10));
-        let _ = ModulusPolynomialRingZq::from((5, 11));
+        let _ = ModulusPolynomialRingZq::from_str("3  3 0 1 mod 17").unwrap();
+        let _ = ModulusPolynomialRingZq::from_str("3  3 0 1 mod 18").unwrap();
     }
 
     /// Ensure that the function panics if the modulus polynomial is 0
     #[test]
     #[should_panic]
-    fn panic_0() {
-        let _ = ModulusPolynomialRingZq::from((0, 17));
+    fn panic_degree_1() {
+        let poly = PolyOverZ::from_str("1 5").unwrap();
+        let _ = ModulusPolynomialRingZq::from((poly, 17));
     }
 }
 

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -257,7 +257,7 @@ mod test_get_degree {
     /// Ensures that degree is working for constant polynomials.
     #[test]
     fn degree_constant() {
-        let degrees = [0, 1, 3, 7, 15, 32, 120];
+        let degrees = [1, 3, 7, 15, 32, 120];
         for degree in degrees {
             let modulus_ring = ModulusPolynomialRingZq::from_str(&format!(
                 "{}  {}2 mod 17",
@@ -273,11 +273,11 @@ mod test_get_degree {
     /// Ensure that degree is working for polynomials with leading 0 coefficients.
     #[test]
     fn degree_leading_zeros() {
-        let poly = ModulusPolynomialRingZq::from_str("4  2 0 0 0 mod 199").unwrap();
+        let poly = ModulusPolynomialRingZq::from_str("4  2 1 0 0 mod 199").unwrap();
 
         let deg = poly.get_degree();
 
-        assert_eq!(0, deg);
+        assert_eq!(1, deg);
     }
 
     /// Ensure that degree is working for polynomials with many coefficients

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/unsafe_functions.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/unsafe_functions.rs
@@ -18,17 +18,15 @@ unsafe_getter_mod!(ModulusPolynomialRingZq, modulus, fq_ctx_struct);
 #[cfg(test)]
 mod test_get_fq_ctx_struct {
     use super::ModulusPolynomialRingZq;
-    use crate::integer_mod_q::Zq;
+    use std::str::FromStr;
 
     /// Checks availability of the getter for [`ModulusPolynomialRingZq::modulus`]
     /// and its ability to be modified.
     #[test]
     #[allow(unused_mut)]
     fn availability_and_modification() {
-        let zq = Zq::from((3, 7));
-        let mut modulus = ModulusPolynomialRingZq::from(zq);
-        let cmp_zq = Zq::from((3, 5));
-        let cmp_mod = ModulusPolynomialRingZq::from(cmp_zq);
+        let mut modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 7").unwrap();
+        let cmp_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 5").unwrap();
 
         let mut fmpz_mod = unsafe { modulus.get_fq_ctx_struct() };
 


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR extends the current remainder trait to also capture the modulus.
Furthermore, it removes an error in the ModulusPolynomialRingZq, where it was possible to instantiate it with a polynomial of degree 0.

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
