### PR TITLE
DivAssign for `Q`

### DIFF
--- a/src/rational/q/arithmetic/div.rs
+++ b/src/rational/q/arithmetic/div.rs
@@ -13,12 +13,86 @@ use crate::{
     error::MathError,
     integer::Z,
     macros::arithmetics::{
+        arithmetic_assign_between_types, arithmetic_assign_trait_borrowed_to_owned,
         arithmetic_between_types, arithmetic_trait_borrowed_to_owned,
         arithmetic_trait_mixed_borrowed_owned,
     },
 };
 use flint_sys::fmpq::{fmpq_div, fmpq_div_fmpz, fmpq_is_zero};
-use std::ops::Div;
+use std::ops::{Div, DivAssign};
+
+impl DivAssign<&Q> for Q {
+    /// Computes the division of `self` and `other` reusing
+    /// the memory of `self`.
+    /// [`DivAssign`] can be used on [`Q`] in combination with
+    /// [`Q`], [`Z`], [`f64`], [`f32`], [`i64`], [`i32`], [`i16`], [`i8`], [`u64`], [`u32`], [`u16`] and [`u8`].
+    ///
+    /// Parameters:
+    ///  - `other`: specifies the value to divide `self` by
+    ///
+    /// Returns the division of both rationals as a [`Q`].
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{rational::Q, integer::Z};
+    ///
+    /// let mut a: Q = Q::from(42);
+    /// let b: Q = Q::from((-42, 2));
+    /// let c: Z = Z::from(5);
+    ///
+    /// a /= &b;
+    /// a /= b;
+    /// a /= 5;
+    /// a /= c;
+    /// a /= 5.0;
+    /// ```
+    fn div_assign(&mut self, other: &Self) {
+        assert!(!other.is_zero(), "Tried to divide {self} by zero.");
+
+        unsafe { fmpq_div(&mut self.value, &self.value, &other.value) };
+    }
+}
+impl DivAssign<&Z> for Q {
+    /// Documentation at [`Q::div_assign`].
+    fn div_assign(&mut self, other: &Z) {
+        assert!(!other.is_zero(), "Tried to divide {self} by zero.");
+
+        unsafe { fmpq_div_fmpz(&mut self.value, &self.value, &other.value) };
+    }
+}
+impl DivAssign<i64> for Q {
+    /// Documentation at [`Q::div_assign`].
+    fn div_assign(&mut self, other: i64) {
+        assert!(other != 0, "Tried to divide {self} by zero.");
+
+        let other = Z::from(other);
+        unsafe { fmpq_div_fmpz(&mut self.value, &self.value, &other.value) };
+    }
+}
+impl DivAssign<u64> for Q {
+    /// Documentation at [`Q::div_assign`].
+    fn div_assign(&mut self, other: u64) {
+        assert!(other != 0, "Tried to divide {self} by zero.");
+
+        let other = Z::from(other);
+        unsafe { fmpq_div_fmpz(&mut self.value, &self.value, &other.value) };
+    }
+}
+impl DivAssign<f64> for Q {
+    /// Documentation at [`Q::div_assign`].
+    fn div_assign(&mut self, other: f64) {
+        assert!(other != 0.0, "Tried to divide {self} by zero.");
+        let other = Q::from(other);
+
+        unsafe { fmpq_div(&mut self.value, &self.value, &other.value) };
+    }
+}
+
+arithmetic_assign_trait_borrowed_to_owned!(DivAssign, div_assign, Q, Q);
+arithmetic_assign_trait_borrowed_to_owned!(DivAssign, div_assign, Q, Z);
+arithmetic_assign_between_types!(DivAssign, div_assign, Q, i64, i32 i16 i8);
+arithmetic_assign_between_types!(DivAssign, div_assign, Q, u64, u32 u16 u8);
+arithmetic_assign_between_types!(DivAssign, div_assign, Q, f64, f32);
 
 impl Div for &Q {
     type Output = Q;
@@ -127,6 +201,70 @@ impl Q {
             fmpq_div(&mut out.value, &self.value, &divisor.value);
         }
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod test_div_assign {
+    use crate::{integer::Z, rational::Q};
+
+    /// Ensure that `div_assign` works for small numbers.
+    #[test]
+    fn correct_small() {
+        let mut a = Q::from(2);
+        let b = Q::from((42, 2));
+
+        a /= b;
+
+        assert_eq!(a, Q::from((4, 42)));
+    }
+
+    /// Ensure that `div_assign` works for large numbers.
+    #[test]
+    fn correct_large() {
+        let mut a = Q::from(u64::MAX - 1);
+        let b = Q::from(2);
+        let mut c = Q::from((1, i32::MAX));
+        let d = Q::from((1, u32::MAX));
+
+        a /= &b;
+        c /= d;
+
+        assert_eq!(a, Q::from(i64::MAX));
+        assert_eq!(c, Q::from((u32::MAX, (u32::MAX - 1) / 2)));
+    }
+
+    /// Ensure that `div_assign` is available for all types.
+    #[test]
+    fn availability() {
+        let mut a = Q::from((1, 2));
+        let b = Q::from((4, 5));
+        let c = Z::ONE;
+
+        a /= &b;
+        a /= b;
+        a /= &c;
+        a /= c;
+        a /= 0.5_f64;
+        a /= 0.5_f32;
+        a /= 1_u8;
+        a /= 1_u16;
+        a /= 1_u32;
+        a /= 1_u64;
+        a /= 1_i8;
+        a /= 1_i16;
+        a /= 1_i32;
+        a /= 1_i64;
+    }
+
+    /// Testing division by `0` panics
+    #[test]
+    #[should_panic]
+    fn div_by_zero() {
+        let mut a = Q::from((2, 3));
+        let b = 0;
+
+        a /= b;
     }
 }
 


### PR DESCRIPTION
**Description**

Waiting for [PR 505](https://github.com/qfall/math/pull/505) to be merged s.t. this branch can be rebased and merged without issues.

This PR implements `div_assign` for `Q`. For PolyOverQ, we only implemented scalar div, which I explicitely removed from the scope of implementations for `Assign`-trait implementation so far. The argument proceeds similarly for MatQ.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
