### PR TITLE
Matrix Norms for `MatPolyOverZ` and `MatPolynomialRingZq`

### DIFF
--- a/src/integer/mat_poly_over_z.rs
+++ b/src/integer/mat_poly_over_z.rs
@@ -19,6 +19,7 @@ mod default;
 mod evaluate;
 mod from;
 mod get;
+mod norm;
 mod ownership;
 mod properties;
 mod reduce;

--- a/src/integer/mat_poly_over_z/norm.rs
+++ b/src/integer/mat_poly_over_z/norm.rs
@@ -35,7 +35,7 @@ impl MatPolyOverZ {
     pub fn norm_l_2_infty_sqrd(&self) -> Z {
         let mut max_sqrd_norm = Z::ZERO;
         for i in 0..self.get_num_columns() {
-            let column = self.get_column(i).unwrap();
+            let column = unsafe { self.get_column_unchecked(i) };
             let sqrd_norm = column.norm_eucl_sqrd().unwrap();
             if sqrd_norm > max_sqrd_norm {
                 max_sqrd_norm = sqrd_norm;
@@ -81,7 +81,7 @@ impl MatPolyOverZ {
     pub fn norm_l_infty_infty(&self) -> Z {
         let mut max_norm = Z::ZERO;
         for i in 0..self.get_num_columns() {
-            let column = self.get_column(i).unwrap();
+            let column = unsafe { self.get_column_unchecked(i) };
             let norm = column.norm_infty().unwrap();
             if norm > max_norm {
                 max_norm = norm;

--- a/src/integer/mat_poly_over_z/norm.rs
+++ b/src/integer/mat_poly_over_z/norm.rs
@@ -25,9 +25,9 @@ impl MatPolyOverZ {
     /// use qfall_math::integer::{MatPolyOverZ, Z};
     /// use std::str::FromStr;
     ///
-    /// let vec = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
+    /// let mat = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
     ///
-    /// let eucl_norm = vec.norm_l_2_infty_sqrd();
+    /// let eucl_norm = mat.norm_l_2_infty_sqrd();
     ///
     /// // 3^2 + 0^2 = 9
     /// assert_eq!(Z::from(9), eucl_norm);
@@ -52,9 +52,9 @@ impl MatPolyOverZ {
     /// use qfall_math::{integer::MatPolyOverZ, rational::Q};
     /// use std::str::FromStr;
     ///
-    /// let vec = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
+    /// let mat = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
     ///
-    /// let eucl_norm = vec.norm_l_2_infty();
+    /// let eucl_norm = mat.norm_l_2_infty();
     ///
     /// // sqrt(3^2 + 0^2) = 3
     /// assert_eq!(Q::from(3), eucl_norm);
@@ -71,9 +71,9 @@ impl MatPolyOverZ {
     /// use qfall_math::integer::{MatPolyOverZ, Z};
     /// use std::str::FromStr;
     ///
-    /// let vec = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
+    /// let mat = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
     ///
-    /// let eucl_norm = vec.norm_l_infty_infty();
+    /// let eucl_norm = mat.norm_l_infty_infty();
     ///
     /// // max{2, 3} = 3
     /// assert_eq!(Z::from(3), eucl_norm);

--- a/src/integer/mat_poly_over_z/norm.rs
+++ b/src/integer/mat_poly_over_z/norm.rs
@@ -1,0 +1,133 @@
+// Copyright © 2025 Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module includes functionality to compute several norms
+//! defined on matrices.
+
+use super::MatPolyOverZ;
+use crate::{
+    integer::Z,
+    rational::Q,
+    traits::{MatrixDimensions, MatrixGetSubmatrix},
+};
+
+impl MatPolyOverZ {
+    /// Outputs the squared l_{2, ∞}-norm, i.e. it computes the squared Euclidean
+    /// norm of each column of the matrix and returns the largest one.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::{MatPolyOverZ, Z};
+    /// use std::str::FromStr;
+    ///
+    /// let vec = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
+    ///
+    /// let eucl_norm = vec.norm_l_2_infty_sqrd();
+    ///
+    /// // 3^2 + 0^2 = 9
+    /// assert_eq!(Z::from(9), eucl_norm);
+    /// ```
+    pub fn norm_l_2_infty_sqrd(&self) -> Z {
+        let mut max_sqrd_norm = Z::ZERO;
+        for i in 0..self.get_num_columns() {
+            let column = self.get_column(i).unwrap();
+            let sqrd_norm = column.norm_eucl_sqrd().unwrap();
+            if sqrd_norm > max_sqrd_norm {
+                max_sqrd_norm = sqrd_norm;
+            }
+        }
+        max_sqrd_norm
+    }
+
+    /// Outputs the l_{2, ∞}-norm, i.e. it computes the Euclidean
+    /// norm of each column of the matrix and returns the largest one.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer::MatPolyOverZ, rational::Q};
+    /// use std::str::FromStr;
+    ///
+    /// let vec = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
+    ///
+    /// let eucl_norm = vec.norm_l_2_infty();
+    ///
+    /// // sqrt(3^2 + 0^2) = 3
+    /// assert_eq!(Q::from(3), eucl_norm);
+    /// ```
+    pub fn norm_l_2_infty(&self) -> Q {
+        self.norm_l_2_infty_sqrd().sqrt()
+    }
+
+    /// Outputs the l_{∞, ∞}-norm, i.e. it computes the ∞-norm
+    /// of each column of the matrix and returns the largest one.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::{MatPolyOverZ, Z};
+    /// use std::str::FromStr;
+    ///
+    /// let vec = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
+    ///
+    /// let eucl_norm = vec.norm_l_infty_infty();
+    ///
+    /// // max{2, 3} = 3
+    /// assert_eq!(Z::from(3), eucl_norm);
+    /// ```
+    pub fn norm_l_infty_infty(&self) -> Z {
+        let mut max_norm = Z::ZERO;
+        for i in 0..self.get_num_columns() {
+            let column = self.get_column(i).unwrap();
+            let norm = column.norm_infty().unwrap();
+            if norm > max_norm {
+                max_norm = norm;
+            }
+        }
+        max_norm
+    }
+}
+
+#[cfg(test)]
+mod test_matrix_norms {
+    use super::{MatPolyOverZ, Q, Z};
+    use std::str::FromStr;
+
+    /// Ensures that the squared l_{2, ∞}-norm is correctly computed.
+    #[test]
+    fn norm_sqrd_l_2_infty() {
+        let mat = MatPolyOverZ::from_str(
+            "[[1  3, 1  -2, 1  5],[1  -5, 1  -6, 2  2 1],[1  -4, 0, 0],[1  2, 0, 1  1]]",
+        )
+        .unwrap();
+
+        let sqrd_norm = mat.norm_l_2_infty_sqrd();
+
+        assert_eq!(Z::from(54), sqrd_norm);
+    }
+
+    /// Ensures that the l_{2, ∞}-norm is correctly computed.
+    #[test]
+    fn norm_l_2_infty() {
+        let mat =
+            MatPolyOverZ::from_str("[[1  -2, 3  -2 1 1],[1  -2, 1  -3],[1  -2, 0],[1  2, 0]]")
+                .unwrap();
+
+        let norm = mat.norm_l_2_infty();
+
+        assert_eq!(Q::from(4), norm);
+    }
+
+    /// Ensures that the l_{∞, ∞}-norm is correctly computed.
+    #[test]
+    fn norm_l_infty_infty() {
+        let mat = MatPolyOverZ::from_str("[[2  -2 1, 1  3],[1  2, 1  -5],[1  -2, 0]]").unwrap();
+
+        let infty_norm = mat.norm_l_infty_infty();
+
+        assert_eq!(Z::from(5), infty_norm);
+    }
+}

--- a/src/integer/mat_poly_over_z/vector/norm.rs
+++ b/src/integer/mat_poly_over_z/vector/norm.rs
@@ -13,6 +13,7 @@ use super::super::MatPolyOverZ;
 use crate::{
     error::MathError,
     integer::Z,
+    rational::Q,
     traits::{MatrixDimensions, MatrixGetEntry},
 };
 
@@ -57,6 +58,28 @@ impl MatPolyOverZ {
         }
 
         Ok(result)
+    }
+
+    /// Returns the Euclidean norm or 2-norm of the given (row or column) vector
+    /// or an error if the given [`MatPolyOverZ`] instance is not a (row or column) vector.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let vec = MatPolyOverZ::from_str("[[1  2],[2  2 2],[1  2]]").unwrap();
+    ///
+    /// let eucl_norm = vec.norm_eucl().unwrap();
+    ///
+    /// assert_eq!(4, eucl_norm);
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
+    ///   the given [`MatPolyOverZ`] instance is not a (row or column) vector.
+    pub fn norm_eucl(&self) -> Result<Q, MathError> {
+        Ok(self.norm_eucl_sqrd()?.sqrt())
     }
 
     /// Returns the infinity norm or ∞-norm of the given (row or column) vector

--- a/src/integer/mat_z/norm.rs
+++ b/src/integer/mat_z/norm.rs
@@ -35,7 +35,7 @@ impl MatZ {
     pub fn norm_l_2_infty_sqrd(&self) -> Z {
         let mut max_sqrd_norm = Z::ZERO;
         for i in 0..self.get_num_columns() {
-            let column = self.get_column(i).unwrap();
+            let column = unsafe { self.get_column_unchecked(i) };
             let sqrd_norm = column.norm_eucl_sqrd().unwrap();
             if sqrd_norm > max_sqrd_norm {
                 max_sqrd_norm = sqrd_norm;
@@ -81,7 +81,7 @@ impl MatZ {
     pub fn norm_l_infty_infty(&self) -> Z {
         let mut max_norm = Z::ZERO;
         for i in 0..self.get_num_columns() {
-            let column = self.get_column(i).unwrap();
+            let column = unsafe { self.get_column_unchecked(i) };
             let norm = column.norm_infty().unwrap();
             if norm > max_norm {
                 max_norm = norm;

--- a/src/integer/mat_z/norm.rs
+++ b/src/integer/mat_z/norm.rs
@@ -25,9 +25,9 @@ impl MatZ {
     /// use qfall_math::integer::{MatZ, Z};
     /// use std::str::FromStr;
     ///
-    /// let vec = MatZ::from_str("[[2, 3],[2, 0]]").unwrap();
+    /// let mat = MatZ::from_str("[[2, 3],[2, 0]]").unwrap();
     ///
-    /// let eucl_norm = vec.norm_l_2_infty_sqrd();
+    /// let eucl_norm = mat.norm_l_2_infty_sqrd();
     ///
     /// // 3^2 + 0^2 = 9
     /// assert_eq!(Z::from(9), eucl_norm);
@@ -52,9 +52,9 @@ impl MatZ {
     /// use qfall_math::{integer::MatZ, rational::Q};
     /// use std::str::FromStr;
     ///
-    /// let vec = MatZ::from_str("[[2, 3],[2, 0]]").unwrap();
+    /// let mat = MatZ::from_str("[[2, 3],[2, 0]]").unwrap();
     ///
-    /// let eucl_norm = vec.norm_l_2_infty();
+    /// let eucl_norm = mat.norm_l_2_infty();
     ///
     /// // sqrt(3^2 + 0^2) = 3
     /// assert_eq!(Q::from(3), eucl_norm);
@@ -71,9 +71,9 @@ impl MatZ {
     /// use qfall_math::integer::{MatZ, Z};
     /// use std::str::FromStr;
     ///
-    /// let vec = MatZ::from_str("[[2, 3],[2, 0]]").unwrap();
+    /// let mat = MatZ::from_str("[[2, 3],[2, 0]]").unwrap();
     ///
-    /// let eucl_norm = vec.norm_l_infty_infty();
+    /// let eucl_norm = mat.norm_l_infty_infty();
     ///
     /// // max{2, 3} = 3
     /// assert_eq!(Z::from(3), eucl_norm);

--- a/src/integer_mod_q/mat_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq.rs
@@ -21,6 +21,7 @@ mod concat;
 mod default;
 mod from;
 mod get;
+mod norm;
 mod properties;
 mod reduce;
 mod sample;

--- a/src/integer_mod_q/mat_polynomial_ring_zq/norm.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/norm.rs
@@ -9,23 +9,25 @@
 //! This module includes functionality to compute several norms
 //! defined on matrices.
 
-use super::MatZq;
+use super::MatPolynomialRingZq;
 use crate::{
     integer::Z,
     rational::Q,
     traits::{MatrixDimensions, MatrixGetSubmatrix},
 };
 
-impl MatZq {
+impl MatPolynomialRingZq {
     /// Outputs the squared l_{2, ∞}-norm, i.e. it computes the squared Euclidean
     /// norm of each column of the matrix and returns the largest one.
     ///
     /// # Examples
     /// ```
-    /// use qfall_math::{integer_mod_q::MatZq, integer::Z};
+    /// use qfall_math::{integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq}, integer::{Z, MatPolyOverZ}};
     /// use std::str::FromStr;
     ///
-    /// let mat = MatZq::from_str("[[2, 3],[2, 0]] mod 7").unwrap();
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 7").unwrap();
+    /// let mat = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 0]]").unwrap();
+    /// let mat = MatPolynomialRingZq::from((&mat, &modulus));
     ///
     /// let eucl_norm = mat.norm_l_2_infty_sqrd();
     ///
@@ -49,10 +51,13 @@ impl MatZq {
     ///
     /// # Examples
     /// ```
-    /// use qfall_math::{integer_mod_q::MatZq, rational::Q};
+    /// use qfall_math::{integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq}, integer::{Z, MatPolyOverZ}};
     /// use std::str::FromStr;
+    /// # use qfall_math::rational::Q;
     ///
-    /// let mat = MatZq::from_str("[[2, 3],[2, 0],[3, 4],[3, 4]] mod 5").unwrap();
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 5").unwrap();
+    /// let mat = MatPolyOverZ::from_str("[[1  2, 1  3],[1  2, 1  0],[1  3, 1  4],[1  3, 1  4]]").unwrap();
+    /// let mat = MatPolynomialRingZq::from((&mat, &modulus));
     ///
     /// let eucl_norm = mat.norm_l_2_infty();
     ///
@@ -68,10 +73,12 @@ impl MatZq {
     ///
     /// # Examples
     /// ```
-    /// use qfall_math::{integer_mod_q::MatZq, integer::Z};
+    /// use qfall_math::{integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq}, integer::{Z, MatPolyOverZ}};
     /// use std::str::FromStr;
     ///
-    /// let mat = MatZq::from_str("[[2, 4],[2, 0]] mod 7").unwrap();
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 7").unwrap();
+    /// let mat = MatPolyOverZ::from_str("[[1  2, 1  4],[1  2, 0]]").unwrap();
+    /// let mat = MatPolynomialRingZq::from((&mat, &modulus));
     ///
     /// let eucl_norm = mat.norm_l_infty_infty();
     ///
@@ -93,13 +100,19 @@ impl MatZq {
 
 #[cfg(test)]
 mod test_matrix_norms {
-    use super::{MatZq, Q, Z};
+    use super::{MatPolynomialRingZq, Q, Z};
+    use crate::{integer::MatPolyOverZ, integer_mod_q::ModulusPolynomialRingZq};
     use std::str::FromStr;
 
     /// Ensures that the squared l_{2, ∞}-norm is correctly computed.
     #[test]
     fn norm_sqrd_l_2_infty() {
-        let mat = MatZq::from_str("[[3, -2, 5],[-5, -6, 2],[-4, 0, 0],[2, 0, 1]] mod 9").unwrap();
+        let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 9").unwrap();
+        let mat = MatPolyOverZ::from_str(
+            "[[1  3, 1  -2, 1  5],[1  -5, 1  -6, 2  1 1],[1  -4, 0, 0],[1  2, 0, 3  1 1 1]]",
+        )
+        .unwrap();
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
 
         let sqrd_norm = mat.norm_l_2_infty_sqrd();
 
@@ -109,7 +122,11 @@ mod test_matrix_norms {
     /// Ensures that the l_{2, ∞}-norm is correctly computed.
     #[test]
     fn norm_l_2_infty() {
-        let mat = MatZq::from_str("[[-2, -2],[-2, -3],[-2, 0],[2, 0]] mod 5").unwrap();
+        let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 5").unwrap();
+        let mat =
+            MatPolyOverZ::from_str("[[1  -2, 4  -2 0 0 1],[1  -2, 1  -3],[1  -2, 0],[1  2, 0]]")
+                .unwrap();
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
 
         let norm = mat.norm_l_2_infty();
 
@@ -119,7 +136,9 @@ mod test_matrix_norms {
     /// Ensures that the l_{∞, ∞}-norm is correctly computed.
     #[test]
     fn norm_l_infty_infty() {
-        let mat = MatZq::from_str("[[-2, 3],[2, -5],[-2, 0]] mod 8").unwrap();
+        let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 8").unwrap();
+        let mat = MatPolyOverZ::from_str("[[2  -2 1, 1  3],[1  2, 1  -5],[1  -2, 0]]").unwrap();
+        let mat = MatPolynomialRingZq::from((&mat, &modulus));
 
         let infty_norm = mat.norm_l_infty_infty();
 

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector/norm.rs
@@ -14,6 +14,7 @@ use crate::{
     error::MathError,
     integer::Z,
     integer_mod_q::PolynomialRingZq,
+    rational::Q,
     traits::{MatrixDimensions, MatrixGetEntry},
 };
 
@@ -63,6 +64,28 @@ impl MatPolynomialRingZq {
         }
 
         Ok(result)
+    }
+
+    /// Returns the Euclidean norm or 2-norm of the given (row or column) vector
+    /// or an error if the given [`MatPolynomialRingZq`] instance is not a (row or column) vector.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::MatPolynomialRingZq;
+    /// use std::str::FromStr;
+    ///
+    /// let vec = MatPolynomialRingZq::from_str("[[1  2],[2  2 2],[1  2]] / 3  1 2 3 mod 11").unwrap();
+    ///
+    /// let sqrd_2_norm = vec.norm_eucl().unwrap();
+    ///
+    /// assert_eq!(4, sqrd_2_norm);
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`MathError::VectorFunctionCalledOnNonVector`] if
+    ///   the given [`MatPolynomialRingZq`] instance is not a (row or column) vector.
+    pub fn norm_eucl(&self) -> Result<Q, MathError> {
+        Ok(self.norm_eucl_sqrd()?.sqrt())
     }
 
     /// Returns the infinity norm or ∞-norm of the given (row or column) vector

--- a/src/rational/mat_q/norm.rs
+++ b/src/rational/mat_q/norm.rs
@@ -24,9 +24,9 @@ impl MatQ {
     /// use qfall_math::rational::{MatQ, Q};
     /// use std::str::FromStr;
     ///
-    /// let vec = MatQ::from_str("[[2, 3],[-2/1, 0]]").unwrap();
+    /// let mat = MatQ::from_str("[[2, 3],[-2/1, 0]]").unwrap();
     ///
-    /// let eucl_norm = vec.norm_l_2_infty_sqrd();
+    /// let eucl_norm = mat.norm_l_2_infty_sqrd();
     ///
     /// // 3^2 + 0^2 = 9
     /// assert_eq!(Q::from(9), eucl_norm);
@@ -51,9 +51,9 @@ impl MatQ {
     /// use qfall_math::rational::{Q, MatQ};
     /// use std::str::FromStr;
     ///
-    /// let vec = MatQ::from_str("[[4/2, 3],[2, 0]]").unwrap();
+    /// let mat = MatQ::from_str("[[4/2, 3],[2, 0]]").unwrap();
     ///
-    /// let eucl_norm = vec.norm_l_2_infty();
+    /// let eucl_norm = mat.norm_l_2_infty();
     ///
     /// // sqrt(3^2 + 0^2) = 3
     /// assert_eq!(Q::from(3), eucl_norm);
@@ -70,9 +70,9 @@ impl MatQ {
     /// use qfall_math::rational::{MatQ, Q};
     /// use std::str::FromStr;
     ///
-    /// let vec = MatQ::from_str("[[2, 6/2],[2, 0]]").unwrap();
+    /// let mat = MatQ::from_str("[[2, 6/2],[2, 0]]").unwrap();
     ///
-    /// let eucl_norm = vec.norm_l_infty_infty();
+    /// let eucl_norm = mat.norm_l_infty_infty();
     ///
     /// // max{2, 3} = 3
     /// assert_eq!(Q::from(3), eucl_norm);


### PR DESCRIPTION
**Description**

This PR implements...
- [x] `norm_l_2_infty_sqrd`
- [x] `norm_l_2_infty`
- [x] `norm_l_infty_infty`

for MatPolyOverZ and MatPolynomialRingZq.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)

No additional tests required as they are based on well-tested functions - the vector norms and just iterate over each column.

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide