### PR TITLE
Remove overprotective measures from samplers

### DIFF
--- a/benches/classic_crypto.rs
+++ b/benches/classic_crypto.rs
@@ -49,7 +49,7 @@ pub fn gen_prime_order_group_plus_generator(security_lvl: u32) -> (Modulus, Zq) 
     }
 
     // choose generator s.t. `g^2 != 1 mod p` and `g^q != 1 mod p`
-    let mut generator = Zq::sample_uniform(&modulus).unwrap();
+    let mut generator = Zq::sample_uniform(&modulus);
     while generator
         .pow(&two)
         .unwrap()
@@ -65,7 +65,7 @@ pub fn gen_prime_order_group_plus_generator(security_lvl: u32) -> (Modulus, Zq) 
             .get_representative_least_nonnegative_residue()
             == Z::ZERO
     {
-        generator = Zq::sample_uniform(&modulus).unwrap();
+        generator = Zq::sample_uniform(&modulus);
     }
 
     (Modulus::from(modulus), generator)

--- a/src/integer/mat_poly_over_z/sample/binomial.rs
+++ b/src/integer/mat_poly_over_z/sample/binomial.rs
@@ -32,7 +32,7 @@ impl MatPolyOverZ {
     ///
     /// Returns a new [`MatPolyOverZ`] instance with entries chosen
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or the dimensions of the matrix were chosen too small.
     ///
     /// # Examples
@@ -44,7 +44,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1` or `p ∉ (0,1)`.
+    ///   if `n < 0` or `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
     ///   if `n` does not fit into an [`i64`].
     ///
@@ -76,7 +76,7 @@ impl MatPolyOverZ {
     ///
     /// Returns a new [`MatPolyOverZ`] instance with entries chosen
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or the dimensions of the matrix were chosen too small.
     ///
     /// # Examples
@@ -88,7 +88,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1` or `p ∉ (0,1)`.
+    ///   if `n < 0` or `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
     ///   if `n` does not fit into an [`i64`].
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if

--- a/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
@@ -10,12 +10,79 @@
 
 use crate::{
     error::MathError,
-    integer::{MatPolyOverZ, MatZ, Z},
+    integer::{MatPolyOverZ, MatZ, PolyOverZ, Z},
     rational::{PolyOverQ, Q},
-    traits::{Concatenate, FromCoefficientEmbedding, IntoCoefficientEmbedding},
+    traits::{
+        Concatenate, FromCoefficientEmbedding, IntoCoefficientEmbedding, MatrixDimensions,
+        MatrixSetEntry, SetCoefficient,
+    },
+    utils::{index::evaluate_index, sample::discrete_gauss::DiscreteGaussianIntegerSampler},
 };
+use std::fmt::Display;
 
 impl MatPolyOverZ {
+    /// Initializes a new matrix with dimensions `num_rows` x `num_columns` and with each entry
+    /// sampled independently according to the discrete Gaussian distribution,
+    /// using [`PolyOverZ::sample_discrete_gauss`].
+    ///
+    /// Parameters:
+    /// - `num_rows`: specifies the number of rows the new matrix should have
+    /// - `num_cols`: specifies the number of columns the new matrix should have
+    /// - `max_degree`: specifies the included maximal degree the created [`PolyOverZ`] should have
+    /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
+    /// - `center`: specifies the positions of the center with peak probability
+    /// - `s`: specifies the Gaussian parameter, which is proportional
+    ///   to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///
+    /// Returns a [`MatPolyOverZ`] with each entry sampled independently from the
+    /// specified discrete Gaussian distribution or an error if `n <= 1` or `s <= 0`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    ///
+    /// let matrix = MatPolyOverZ::sample_discrete_gauss(3, 1, 5, 1024, 0, 1.25f32).unwrap();
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
+    ///   if `n <= 1` or `s <= 0`.
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    ///   For further information see [`MatPolyOverZ::new`].
+    /// - if `max_degree` is negative, or does not fit into an [`i64`].
+    pub fn sample_discrete_gauss(
+        num_rows: impl TryInto<i64> + Display,
+        num_cols: impl TryInto<i64> + Display,
+        max_degree: impl TryInto<i64> + Display,
+        n: impl Into<Z>,
+        center: impl Into<Q>,
+        s: impl Into<Q>,
+    ) -> Result<MatPolyOverZ, MathError> {
+        let n = n.into();
+        let center = center.into();
+        let s = s.into();
+        let max_degree = evaluate_index(max_degree).unwrap();
+        let mut matrix = MatPolyOverZ::new(num_rows, num_cols);
+
+        let mut dgis = DiscreteGaussianIntegerSampler::init(&n, &center, &s)?;
+
+        for row in 0..matrix.get_num_rows() {
+            for col in 0..matrix.get_num_columns() {
+                let mut entry = PolyOverZ::default();
+                for index in 0..=max_degree {
+                    let sample = dgis.sample_z();
+                    unsafe { entry.set_coeff_unchecked(index, &sample) };
+                }
+
+                unsafe { matrix.set_entry_unchecked(row, col, entry) };
+            }
+        }
+
+        Ok(matrix)
+    }
+
     /// SampleD samples a discrete Gaussian from the lattice with a provided `basis`.
     ///
     /// We do not check whether `basis` is actually a basis. Hence, the callee is
@@ -41,14 +108,15 @@ impl MatPolyOverZ {
     /// };
     /// use std::str::FromStr;
     ///
-    /// let base = MatPolyOverZ::from_str("[[1  1, 3  0 1 -1, 2  2 2]]").unwrap();
+    /// let basis = MatPolyOverZ::from_str("[[1  1, 3  0 1 -1, 2  2 2]]").unwrap();
     /// let center = vec![PolyOverQ::default()];
     ///
-    /// let sample = MatPolyOverZ::sample_d(&base, 3, 100, &center, 10.5_f64).unwrap();
+    /// let sample = MatPolyOverZ::sample_d(&basis, 3, 100, &center, 10.5_f64).unwrap();
     /// ```
     ///
     /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`VectorFunctionCalledOnNonVector`](MathError::VectorFunctionCalledOnNonVector), if the basis is not a row vector
+    /// - Returns a [`MathError`] of type [`VectorFunctionCalledOnNonVector`](MathError::VectorFunctionCalledOnNonVector),
+    ///   if the basis is not a row vector.
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
     ///   if `n <= 1` or `s <= 0`.
     /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
@@ -63,7 +131,7 @@ impl MatPolyOverZ {
     /// # Panics ...
     /// - if the polynomials have higher length than the provided upper bound `k`
     pub fn sample_d(
-        base: &Self,
+        basis: &Self,
         k: impl Into<i64>,
         n: impl Into<Z>,
         center: &[PolyOverQ],
@@ -71,7 +139,7 @@ impl MatPolyOverZ {
     ) -> Result<MatPolyOverZ, MathError> {
         let k = k.into();
         // use coefficient embedding and then call sampleD for the matrix representation
-        let base_embedded = base.into_coefficient_embedding(k);
+        let basis_embedded = basis.into_coefficient_embedding(k);
 
         // use coefficient embedding to get center
         let mut center_embedded = center[0].into_coefficient_embedding(k);
@@ -80,9 +148,56 @@ impl MatPolyOverZ {
             center_embedded = center_embedded.concat_vertical(&c_row)?;
         }
 
-        let sample = MatZ::sample_d(&base_embedded, n, &center_embedded, s)?;
+        let sample = MatZ::sample_d(&basis_embedded, n, &center_embedded, s)?;
 
         Ok(MatPolyOverZ::from_coefficient_embedding((&sample, k - 1)))
+    }
+}
+
+#[cfg(test)]
+mod test_sample_discrete_gauss {
+    use crate::{integer::MatPolyOverZ, traits::MatrixGetEntry};
+
+    /// Checks whether `sample_discrete_gauss` is available for all types
+    /// implementing [`Into<Z>`], i.e. u8, u16, u32, u64, i8, ...
+    /// or [`Into<Q>`], i.e. u8, i16, f32, Z, Q, ...
+    #[test]
+    fn availability() {
+        let _ = MatPolyOverZ::sample_discrete_gauss(2, 3, 16u16, 128, 1u16, 2);
+        let _ = MatPolyOverZ::sample_discrete_gauss(1, 3, 2u32, 128, 1u8, 2.0);
+        let _ = MatPolyOverZ::sample_discrete_gauss(2_i64, 3, 2u64, 128, 1u32, 2.0_f64);
+        let _ = MatPolyOverZ::sample_discrete_gauss(2_i32, 3, 2i8, 128, 1u64, 1);
+        let _ = MatPolyOverZ::sample_discrete_gauss(2_i16, 3, 2i16, 128, 1i64, 3_u64);
+        let _ = MatPolyOverZ::sample_discrete_gauss(2_i8, 3, 2i32, 128, 1i32, 1);
+        let _ = MatPolyOverZ::sample_discrete_gauss(2_u64, 3, 2i64, 128, 1i16, 1);
+        let _ = MatPolyOverZ::sample_discrete_gauss(2_u32, 3, 4, 128, 1i8, 1);
+        let _ = MatPolyOverZ::sample_discrete_gauss(2_u16, 3, 2u8, 128, 1i64, 2);
+        let _ = MatPolyOverZ::sample_discrete_gauss(2_u8, 3, 2, 128, -2, 3);
+        let _ = MatPolyOverZ::sample_discrete_gauss(1, 3, 2, 128, 4, 3);
+        let _ = MatPolyOverZ::sample_discrete_gauss(3, 3, 2, 128, 1.25f64, 3);
+        let _ = MatPolyOverZ::sample_discrete_gauss(4, 3, 2, 128, 15.75f32, 3);
+    }
+
+    /// Ensures that the resulting entries have correct degree.
+    #[test]
+    fn correct_degree_entries() {
+        let degrees = [1, 3, 7, 15, 32, 120];
+        for degree in degrees {
+            let res = MatPolyOverZ::sample_discrete_gauss(1, 1, degree, 1024, i64::MAX, 1).unwrap();
+
+            assert_eq!(
+                res.get_entry(0, 0).unwrap().get_degree(),
+                degree,
+                "Could fail with negligible probability."
+            );
+        }
+    }
+
+    /// Checks whether the maximum degree needs to be at least 0.
+    #[test]
+    #[should_panic]
+    fn invalid_max_degree() {
+        let _ = MatPolyOverZ::sample_discrete_gauss(2, 2, -1, 1024, 0, 1).unwrap();
     }
 }
 

--- a/src/integer/mat_poly_over_z/sample/uniform.rs
+++ b/src/integer/mat_poly_over_z/sample/uniform.rs
@@ -49,8 +49,7 @@ impl MatPolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    ///   if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    ///   i.e. the interval size is at most `1`.
+    ///   if the given `upper_bound` isn't at least larger than `lower_bound`.
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
     ///   the `max_degree` is negative or it does not fit into an [`i64`].
     ///

--- a/src/integer/mat_poly_over_z/sample/uniform.rs
+++ b/src/integer/mat_poly_over_z/sample/uniform.rs
@@ -143,7 +143,7 @@ mod test_sample_uniform {
     /// Checks whether providing an invalid interval results in an error.
     #[test]
     fn invalid_interval() {
-        let lb_0 = Z::from(i64::MIN) - Z::ONE;
+        let lb_0 = Z::from(i64::MIN);
         let lb_1 = Z::from(i64::MIN);
         let lb_2 = Z::ZERO;
         let upper_bound = Z::from(i64::MIN);

--- a/src/integer/mat_z/sample/binomial.rs
+++ b/src/integer/mat_z/sample/binomial.rs
@@ -30,7 +30,7 @@ impl MatZ {
     ///
     /// Returns a new [`MatZ`] instance with entries chosen
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or the dimensions of the matrix were chosen too small.
     ///
     /// # Examples
@@ -42,7 +42,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
@@ -73,7 +73,7 @@ impl MatZ {
     ///
     /// Returns a new [`MatZ`] instance with entries chosen
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or the dimensions of the matrix were chosen too small.
     ///
     /// # Examples
@@ -85,7 +85,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -33,7 +33,7 @@ impl MatZ {
     ///   to the standard deviation `sigma * sqrt(2 * pi) = s`
     ///
     /// Returns a matrix with each entry sampled independently from the
-    /// specified discrete Gaussian distribution or an error if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
+    /// specified discrete Gaussian distribution or an error if `n <= 1` or `s <= 0`.
     ///
     /// # Examples
     /// ```

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -121,7 +121,7 @@ mod test_sample_uniform {
     /// Checks whether providing an invalid interval results in an error.
     #[test]
     fn invalid_interval() {
-        let lb_0 = Z::from(i64::MIN) - Z::ONE;
+        let lb_0 = Z::from(i64::MIN);
         let lb_1 = Z::from(i64::MIN);
         let lb_2 = Z::ZERO;
         let upper_bound = Z::from(i64::MIN);

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -45,8 +45,7 @@ impl MatZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    ///   if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    ///   i.e. the interval size is at most `1`.
+    ///   if the given `upper_bound` isn't at least larger than `lower_bound`.
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns are not suited to create a matrix.

--- a/src/integer/poly_over_z/sample/binomial.rs
+++ b/src/integer/poly_over_z/sample/binomial.rs
@@ -31,7 +31,7 @@ impl PolyOverZ {
     ///
     /// Returns a fresh [`PolyOverZ`] instance with each value sampled
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or `max_degree` is negative or does not into an [`i64`].
     ///
     /// # Examples
@@ -43,7 +43,7 @@ impl PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
@@ -72,7 +72,7 @@ impl PolyOverZ {
     ///
     /// Returns a fresh [`PolyOverZ`] instance with each value sampled
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or `max_degree` is negative or does not into an [`i64`].
     ///
     /// # Examples
@@ -84,7 +84,7 @@ impl PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)

--- a/src/integer/poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/poly_over_z/sample/discrete_gauss.rs
@@ -43,7 +43,7 @@ impl PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
+    ///   if `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if `max_degree` is negative, or does not fit into an [`i64`].

--- a/src/integer/poly_over_z/sample/uniform.rs
+++ b/src/integer/poly_over_z/sample/uniform.rs
@@ -120,7 +120,7 @@ mod test_sample_uniform {
     /// Checks whether providing an invalid interval results in an error.
     #[test]
     fn invalid_interval() {
-        let lb_0 = Z::from(i64::MIN) - Z::ONE;
+        let lb_0 = Z::from(i64::MIN);
         let lb_1 = Z::from(i64::MIN);
         let lb_2 = Z::ZERO;
         let upper_bound = Z::from(i64::MIN);

--- a/src/integer/poly_over_z/sample/uniform.rs
+++ b/src/integer/poly_over_z/sample/uniform.rs
@@ -45,8 +45,7 @@ impl PolyOverZ {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    ///   if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    ///   i.e. the interval size is at most `1`.
+    ///   if the given `upper_bound` isn't at least larger than `lower_bound`.
     /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
     ///   the `max_degree` is negative or it does not fit into an [`i64`].
     pub fn sample_uniform(

--- a/src/integer/z/sample/binomial.rs
+++ b/src/integer/z/sample/binomial.rs
@@ -21,7 +21,7 @@ impl Z {
     ///
     /// Returns a fresh [`Z`] instance with a value sampled
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, or `n` does not fit into an [`i64`].
+    /// if `n < 0`, `p ∉ (0,1)`, or `n` does not fit into an [`i64`].
     ///
     /// # Examples
     /// ```
@@ -32,7 +32,7 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)

--- a/src/integer/z/sample/discrete_gauss.rs
+++ b/src/integer/z/sample/discrete_gauss.rs
@@ -39,7 +39,7 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
+    ///   if `n <= 1` or `s <= 0`.
     ///
     /// This function implements SampleZ according to:
     /// - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).

--- a/src/integer/z/sample/uniform.rs
+++ b/src/integer/z/sample/uniform.rs
@@ -37,8 +37,7 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    ///   if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    ///   i.e. the interval size is at most `1`.
+    ///   if the given `upper_bound` isn't at least larger than `lower_bound`.
     pub fn sample_uniform(
         lower_bound: impl Into<Z>,
         upper_bound: impl Into<Z>,
@@ -81,8 +80,8 @@ impl Z {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    ///   if the given `upper_bound` isn't at least larger than `lower_bound + 1`,
-    ///   i.e. the interval size is at most `1`, or if no prime could be found in the specified interval.
+    ///   if the given `upper_bound` isn't at least larger than `lower_bound`
+    ///   , or if no prime could be found in the specified interval.
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
     ///   if `lower_bound` is negative as primes are always positive.
     pub fn sample_prime_uniform(
@@ -151,7 +150,7 @@ mod test_sample_uniform {
     /// Checks whether providing an invalid interval results in an error.
     #[test]
     fn invalid_interval() {
-        let lb_0 = Z::from(i64::MIN) - Z::ONE;
+        let lb_0 = Z::from(i64::MIN);
         let lb_1 = Z::from(i64::MIN);
         let lb_2 = Z::ZERO;
         let upper_bound = Z::from(i64::MIN);

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/binomial.rs
@@ -31,7 +31,7 @@ impl MatPolynomialRingZq {
     ///
     /// Returns a new [`MatPolynomialRingZq`] instance with entries chosen
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or the dimensions of the matrix were chosen too small.
     ///
     /// # Examples
@@ -45,7 +45,7 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1` or `p ∉ (0,1)`.
+    ///   if `n < 0` or `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
     ///   if `n` does not fit into an [`i64`].
     ///
@@ -78,7 +78,7 @@ impl MatPolynomialRingZq {
     ///
     /// Returns a new [`MatPolynomialRingZq`] instance with entries chosen
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or the dimensions of the matrix were chosen too small.
     ///
     /// # Examples
@@ -92,7 +92,7 @@ impl MatPolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1` or `p ∉ (0,1)`.
+    ///   if `n < 0` or `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
     ///   if `n` does not fit into an [`i64`].
     ///

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
@@ -11,11 +11,67 @@
 use crate::{
     error::MathError,
     integer::{MatPolyOverZ, Z},
-    integer_mod_q::MatPolynomialRingZq,
+    integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq},
     rational::{PolyOverQ, Q},
 };
+use std::fmt::Display;
 
 impl MatPolynomialRingZq {
+    /// Initializes a new matrix with dimensions `num_rows` x `num_columns` and with each entry
+    /// sampled independently according to the discrete Gaussian distribution,
+    /// using [`PolynomialRingZq::sample_discrete_gauss`](crate::integer_mod_q::PolynomialRingZq::sample_discrete_gauss).
+    ///
+    /// Parameters:
+    /// - `num_rows`: specifies the number of rows the new matrix should have
+    /// - `num_cols`: specifies the number of columns the new matrix should have
+    /// - `modulus`: specifies the Modulus for the matrix and the maximum degree
+    ///   any discrete Gaussian polynomial can have
+    /// - `n`: specifies the range from which [`Z::sample_discrete_gauss`] samples
+    /// - `center`: specifies the positions of the center with peak probability
+    /// - `s`: specifies the Gaussian parameter, which is proportional
+    ///   to the standard deviation `sigma * sqrt(2 * pi) = s`
+    ///
+    /// Returns a [`MatPolynomialRingZq`] with each entry sampled independently from the
+    /// specified discrete Gaussian distribution or an error if `n <= 1` or `s <= 0`.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq};
+    /// use std::str::FromStr;
+    /// let modulus = ModulusPolynomialRingZq::from_str("3  1 0 1 mod 17").unwrap();
+    ///
+    /// let matrix = MatPolynomialRingZq::sample_discrete_gauss(3, 1, &modulus, 128, 0, 1.25f32).unwrap();
+    /// ```
+    ///
+    /// # Errors and Failures
+    /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
+    ///   if `n <= 1` or `s <= 0`.
+    ///
+    /// # Panics ...
+    /// - if the provided number of rows and columns are not suited to create a matrix.
+    ///   For further information see [`MatPolynomialRingZq::new`].
+    /// - if `modulus` is not a valid choice for a [`ModulusPolynomialRingZq`], see
+    ///   [`ModulusPolynomialRingZq::from`] for further information.
+    pub fn sample_discrete_gauss(
+        num_rows: impl TryInto<i64> + Display,
+        num_cols: impl TryInto<i64> + Display,
+        modulus: impl Into<ModulusPolynomialRingZq>,
+        n: impl Into<Z>,
+        center: impl Into<Q>,
+        s: impl Into<Q>,
+    ) -> Result<MatPolynomialRingZq, MathError> {
+        let modulus: ModulusPolynomialRingZq = modulus.into();
+        let sample = MatPolyOverZ::sample_discrete_gauss(
+            num_rows,
+            num_cols,
+            modulus.get_degree() - 1,
+            n,
+            center,
+            s,
+        )?;
+        Ok(MatPolynomialRingZq::from((&sample, modulus)))
+    }
+
     /// SampleD samples a discrete Gaussian from the lattice with a provided `basis`.
     ///
     /// We do not check whether `basis` is actually a basis. Hence, the callee is
@@ -79,6 +135,36 @@ impl MatPolynomialRingZq {
     ) -> Result<MatPolynomialRingZq, MathError> {
         let sample = MatPolyOverZ::sample_d(&basis.matrix, k, n, center, s)?;
         Ok(MatPolynomialRingZq::from((&sample, &basis.get_mod())))
+    }
+}
+
+#[cfg(test)]
+mod test_sample_discrete_gauss {
+    use crate::{
+        integer::PolyOverZ,
+        integer_mod_q::{MatPolynomialRingZq, MatZq, ModulusPolynomialRingZq},
+        traits::{FromCoefficientEmbedding, MatrixGetEntry, MatrixSetEntry},
+    };
+
+    /// Ensures that the resulting entries have correct degree.
+    #[test]
+    fn correct_degree_entries() {
+        let degrees = [1, 2, 3, 7, 15, 32, 120];
+        for degree in degrees {
+            let mut coeff_emb_mod = MatZq::new(degree + 1, 1, i64::MAX);
+            coeff_emb_mod.set_entry(0, 0, 1).unwrap();
+            coeff_emb_mod.set_entry(degree, 0, 1).unwrap();
+            let modulus = ModulusPolynomialRingZq::from_coefficient_embedding(&coeff_emb_mod);
+            let res = MatPolynomialRingZq::sample_discrete_gauss(1, 1, modulus, 1024, i32::MAX, 1)
+                .unwrap();
+
+            let entry: PolyOverZ = res.get_entry(0, 0).unwrap();
+            assert_eq!(
+                entry.get_degree(),
+                degree - 1,
+                "Could fail with negligible probability."
+            );
+        }
     }
 }
 

--- a/src/integer_mod_q/mat_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_zq/sample/binomial.rs
@@ -32,7 +32,7 @@ impl MatZq {
     ///
     /// Returns a new [`MatZq`] instance with entries chosen
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or the dimensions of the matrix were chosen too small.
     ///
     /// # Examples
@@ -44,7 +44,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
@@ -78,7 +78,7 @@ impl MatZq {
     ///
     /// Returns a new [`MatZq`] instance with entries chosen
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or the dimensions of the matrix were chosen too small.
     ///
     /// # Examples
@@ -90,7 +90,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -45,7 +45,7 @@ impl MatZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n <= 1` or `s <= 0` or `s * log_2(n) < 1` or `s * log_2(n) < 1`.
+    ///   if `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if the provided number of rows and columns or the modulus are not suited to create a matrix.

--- a/src/integer_mod_q/poly_over_zq/sample/binomial.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/binomial.rs
@@ -33,7 +33,7 @@ impl PolyOverZq {
     ///
     /// Returns a fresh [`PolyOverZq`] instance with each value sampled
     ///     according to the binomial distribution or a [`MathError`]
-    ///     if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    ///     if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     ///     or `max_degree` is negative or does not into an [`i64`].
     ///
     /// # Examples
@@ -45,7 +45,7 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
@@ -76,7 +76,7 @@ impl PolyOverZq {
     ///
     /// Returns a fresh [`PolyOverZq`] instance with each value sampled
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`],
     /// or `max_degree` is negative or does not into an [`i64`].
     ///
     /// # Examples
@@ -88,7 +88,7 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)

--- a/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
@@ -45,7 +45,7 @@ impl PolyOverZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
+    ///   if `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if `max_degree` is negative, or does not fit into an [`i64`].

--- a/src/integer_mod_q/polynomial_ring_zq/sample/binomial.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/binomial.rs
@@ -29,7 +29,7 @@ impl PolynomialRingZq {
     ///
     /// Returns a fresh [`PolynomialRingZq`] instance of length `modulus.get_degree() - 1`
     /// with coefficients chosen according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`].
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`].
     ///
     /// # Examples
     /// ```
@@ -42,7 +42,7 @@ impl PolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
@@ -72,7 +72,7 @@ impl PolynomialRingZq {
     ///
     /// Returns a fresh [`PolynomialRingZq`] instance of length `modulus.get_degree() - 1`
     /// with coefficients chosen according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, `n` does not fit into an [`i64`].
+    /// if `n < 0`, `p ∉ (0,1)`, `n` does not fit into an [`i64`].
     ///
     /// # Examples
     /// ```
@@ -85,7 +85,7 @@ impl PolynomialRingZq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)

--- a/src/integer_mod_q/z_q/sample/binomial.rs
+++ b/src/integer_mod_q/z_q/sample/binomial.rs
@@ -28,7 +28,7 @@ impl Zq {
     ///
     /// Returns a fresh [`Zq`] instance with a value sampled
     /// according to the binomial distribution or a [`MathError`]
-    /// if `n < 1`, `p ∉ (0,1)`, or `n` does not fit into an [`i64`].
+    /// if `n < 0`, `p ∉ (0,1)`, or `n` does not fit into an [`i64`].
     ///
     /// # Examples
     /// ```
@@ -39,7 +39,7 @@ impl Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n < 1`.
+    ///   if `n < 0`.
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
     ///   if `p ∉ (0,1)`.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)

--- a/src/integer_mod_q/z_q/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/z_q/sample/discrete_gauss.rs
@@ -43,7 +43,7 @@ impl Zq {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
+    ///   if `n <= 1` or `s <= 0`.
     ///
     /// # Panics ...
     /// - if `modulus` is smaller than `2`.

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -8,9 +8,7 @@
 
 //! This module contains sampling algorithms for uniform random sampling.
 
-use crate::{
-    error::MathError, integer::Z, integer_mod_q::Zq, utils::sample::uniform::UniformIntegerSampler,
-};
+use crate::{integer::Z, integer_mod_q::Zq, utils::sample::uniform::UniformIntegerSampler};
 
 impl Zq {
     /// Chooses a [`Zq`] instance uniformly at random in `[0, modulus)`.
@@ -24,8 +22,7 @@ impl Zq {
     ///   of the new [`Zq`] instance and thus the size of the interval over which is sampled
     ///
     /// Returns a new [`Zq`] instance with a value chosen
-    /// uniformly at random in `[0, modulus)` or a [`MathError`]
-    /// if the provided modulus was too small.
+    /// uniformly at random in `[0, modulus)`.
     ///
     /// # Examples
     /// ```
@@ -34,15 +31,14 @@ impl Zq {
     /// let sample = Zq::sample_uniform(17).unwrap();
     /// ```
     ///
-    /// # Errors and Failures
-    /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    ///   if the given modulus is smaller than or equal to `1`.
-    pub fn sample_uniform(modulus: impl Into<Z>) -> Result<Self, MathError> {
+    /// # Panics
+    /// - if the given modulus is smaller than or equal to `1`.
+    pub fn sample_uniform(modulus: impl Into<Z>) -> Self {
         let modulus: Z = modulus.into();
-        let mut uis = UniformIntegerSampler::init(&modulus)?;
+        let mut uis = UniformIntegerSampler::init(&modulus).unwrap();
 
         let random = uis.sample();
-        Ok(Zq::from((random, modulus)))
+        Zq::from((random, modulus))
     }
 }
 
@@ -59,7 +55,7 @@ mod test_sample_uniform {
     fn boundaries_kept_small() {
         let modulus = Z::from(17);
         for _ in 0..32 {
-            let sample = Zq::sample_uniform(&modulus).unwrap();
+            let sample = Zq::sample_uniform(&modulus);
             assert!(Z::ZERO <= sample.value);
             assert!(sample.value < modulus);
         }
@@ -71,7 +67,7 @@ mod test_sample_uniform {
     fn boundaries_kept_large() {
         let modulus = Z::from(u64::MAX);
         for _ in 0..256 {
-            let sample = Zq::sample_uniform(&modulus).unwrap();
+            let sample = Zq::sample_uniform(&modulus);
             assert!(Z::ZERO <= sample.value);
             assert!(sample.value < modulus);
         }
@@ -79,18 +75,11 @@ mod test_sample_uniform {
 
     /// Checks whether providing an invalid interval results in an error.
     #[test]
+    #[should_panic]
     fn invalid_interval() {
-        let mod_0 = Z::from(i64::MIN);
-        let mod_1 = Z::ONE;
-        let mod_2 = Z::ZERO;
+        let modulus = Z::ZERO;
 
-        let res_0 = Zq::sample_uniform(&mod_0);
-        let res_1 = Zq::sample_uniform(&mod_1);
-        let res_2 = Zq::sample_uniform(&mod_2);
-
-        assert!(res_0.is_err());
-        assert!(res_1.is_err());
-        assert!(res_2.is_err());
+        let _ = Zq::sample_uniform(&modulus);
     }
 
     /// Checks whether `sample_uniform` is available for all types
@@ -121,7 +110,7 @@ mod test_sample_uniform {
         let mut counts = [0; 5];
         // count sampled instances
         for _ in 0..1000 {
-            let sample_z = Zq::sample_uniform(&modulus).unwrap();
+            let sample_z = Zq::sample_uniform(&modulus);
             let sample_int = i64::try_from(&sample_z.value).unwrap() as usize;
             counts[sample_int] += 1;
         }

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -28,7 +28,7 @@ impl Zq {
     /// ```
     /// use qfall_math::integer_mod_q::Zq;
     ///
-    /// let sample = Zq::sample_uniform(17).unwrap();
+    /// let sample = Zq::sample_uniform(17);
     /// ```
     ///
     /// # Panics

--- a/src/utils/sample/binomial.rs
+++ b/src/utils/sample/binomial.rs
@@ -19,7 +19,7 @@ use rand_distr::{Binomial, Distribution};
 /// - `p`: specifies the probability of success
 ///
 /// Returns a sample as a [`u64`] chosen from the specified binomial distribution
-/// or a [`MathError`] if `n < 1`, `p ∉ (0,1)`, or `n` does not fit into an [`i64`].
+/// or a [`MathError`] if `n < 0`, `p ∉ (0,1)`, or `n` does not fit into an [`i64`].
 ///
 /// # Examples
 /// ```compile_fail
@@ -33,7 +33,7 @@ use rand_distr::{Binomial, Distribution};
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-///   if `n < 1`.
+///   if `n < 0`.
 /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
 ///   if `p ∉ (0,1)`.
 /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
@@ -46,9 +46,9 @@ pub(crate) fn sample_binomial(n: &Z, p: &Q) -> Result<u64, MathError> {
             Hence, the interval to sample from is invalid and contains only exactly one number."
         )));
     }
-    if n <= &Z::ZERO {
+    if n < &Z::ZERO {
         return Err(MathError::InvalidIntegerInput(format!(
-            "n (the number of trials for binomial sampling) must be larger than 0. Currently it is {n}."
+            "n (the number of trials for binomial sampling) must be no smaller than 0. Currently it is {n}."
         )));
     }
 
@@ -123,7 +123,6 @@ mod test_sample_binomial {
     fn invalid_n() {
         let p = Q::from((1, 2));
 
-        assert!(sample_binomial(&Z::ZERO, &p).is_err());
         assert!(sample_binomial(&Z::MINUS_ONE, &p).is_err());
         assert!(sample_binomial(&Z::from(i64::MIN), &p).is_err());
     }

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -81,7 +81,7 @@ impl DiscreteGaussianIntegerSampler {
     ///
     /// Returns a sample chosen according to the specified discrete Gaussian distribution or
     /// a [`MathError`] if the specified parameters were not chosen appropriately,
-    /// i.e. `n > 1` or `s > 0` or `s * log_2(n) < 1`.
+    /// i.e. `n > 1` or `s > 0`.
     ///
     /// # Examples
     /// ```
@@ -96,7 +96,7 @@ impl DiscreteGaussianIntegerSampler {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    ///   if `n <= 1` or `s <= 0` or `s * log_2(n) < 1`.
+    ///   if `n <= 1` or `s <= 0`.
     pub fn init(n: &Z, center: &Q, s: &Q) -> Result<Self, MathError> {
         if n <= &Z::ONE {
             return Err(MathError::InvalidIntegerInput(format!(
@@ -108,13 +108,6 @@ impl DiscreteGaussianIntegerSampler {
             return Err(MathError::InvalidIntegerInput(format!(
                 "The value {s} was provided for parameter s of the function sample_z.
                 This function expects this input to be larger than 0."
-            )));
-        }
-        if s * n.log(2).unwrap() < Q::ONE {
-            return Err(MathError::InvalidIntegerInput(format!(
-                "The size {s} * log_2({n}) is smaller than 1.
-                Hence, the interval to sample from is of size 1.
-                Please provide larger parameters to sample discrete Gaussian."
             )));
         }
 

--- a/src/utils/sample/uniform.rs
+++ b/src/utils/sample/uniform.rs
@@ -72,9 +72,9 @@ impl UniformIntegerSampler {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidInterval`](MathError::InvalidInterval)
-    ///   if the interval is chosen smaller than or equal to `1`.
+    ///   if the interval is chosen smaller than `1`.
     pub fn init(interval_size: &Z) -> Result<Self, MathError> {
-        if interval_size <= &Z::ONE {
+        if interval_size < &Z::ONE {
             return Err(MathError::InvalidInterval(format!(
                 "An invalid interval size {interval_size} was provided."
             )));
@@ -122,6 +122,10 @@ impl UniformIntegerSampler {
     /// assert!(sample < interval_size);
     /// ```
     pub fn sample(&mut self) -> Z {
+        if self.interval_size.is_one() {
+            return Z::ZERO;
+        }
+
         let mut sample = self.sample_bits_uniform();
         while sample >= self.interval_size {
             sample = self.sample_bits_uniform();
@@ -240,7 +244,6 @@ mod test_uis {
     /// Checks whether interval sizes smaller than 2 result in an error.
     #[test]
     fn invalid_interval() {
-        assert!(UniformIntegerSampler::init(&Z::ONE).is_err());
         assert!(UniformIntegerSampler::init(&Z::ZERO).is_err());
         assert!(UniformIntegerSampler::init(&Z::MINUS_ONE).is_err());
     }


### PR DESCRIPTION
**Description**

This PR removes the following "overprotective" measures from samplers...
- [x] uniform sampling now also works over intervals of size 1, which will always output this single element
- [x] discrete Gaussian sampling adapts the change from uniform sampling (just some changes on the doc-comments)
- [x] binomial sampling now also works for 0 tries, i.e. always with output 0, which is well-defined

Furthermore, this PR implements the more efficient discrete Gaussian sampler (for sampling with static Gaussian parameters across all entries) for matrices over polynomials, i.e.
- [x] `MatPolyOverZ::sample_discrete_gauss`
- [x] `MatPolynomialRingZq::sample_discrete_gauss`


**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide