### PR TITLE
Avoid zip issues

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2023 Sven Moog
+Copyright 2023 Sven Moog
 
 This file is part of qFALL-math.
 

--- a/benches/basis_reductions.rs
+++ b/benches/basis_reductions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/basis_reductions.rs
+++ b/benches/basis_reductions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/benches/cholesky_decomposition.rs
+++ b/benches/cholesky_decomposition.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/cholesky_decomposition.rs
+++ b/benches/cholesky_decomposition.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/classic_crypto.rs
+++ b/benches/classic_crypto.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/classic_crypto.rs
+++ b/benches/classic_crypto.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/integer.rs
+++ b/benches/integer.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/benches/matrix_arith.rs
+++ b/benches/matrix_arith.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/matrix_arith.rs
+++ b/benches/matrix_arith.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/ntt_multiplication.rs
+++ b/benches/ntt_multiplication.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/benches/sample_z.rs
+++ b/benches/sample_z.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/sample_z.rs
+++ b/benches/sample_z.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/sampling.rs
+++ b/benches/sampling.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/benches/solve.rs
+++ b/benches/solve.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/benches/uniform.rs
+++ b/benches/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/benches/uniform.rs
+++ b/benches/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z.rs
+++ b/src/integer/mat_poly_over_z.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/arithmetic.rs
+++ b/src/integer/mat_poly_over_z/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/arithmetic/add.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/arithmetic/modulo.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/modulo.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/arithmetic/mul.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/arithmetic/mul_scalar.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/mul_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/arithmetic/sub.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/cmp.rs
+++ b/src/integer/mat_poly_over_z/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/coefficient_embedding.rs
+++ b/src/integer/mat_poly_over_z/coefficient_embedding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/concat.rs
+++ b/src/integer/mat_poly_over_z/concat.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/default.rs
+++ b/src/integer/mat_poly_over_z/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/from.rs
+++ b/src/integer/mat_poly_over_z/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann, Sven Moog
+// Copyright 2023 Marvin Beckmann, Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/get.rs
+++ b/src/integer/mat_poly_over_z/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/norm.rs
+++ b/src/integer/mat_poly_over_z/norm.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/norm.rs
+++ b/src/integer/mat_poly_over_z/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/ownership.rs
+++ b/src/integer/mat_poly_over_z/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/ownership.rs
+++ b/src/integer/mat_poly_over_z/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/properties.rs
+++ b/src/integer/mat_poly_over_z/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/reduce.rs
+++ b/src/integer/mat_poly_over_z/reduce.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/sample.rs
+++ b/src/integer/mat_poly_over_z/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/sample/binomial.rs
+++ b/src/integer/mat_poly_over_z/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/sample/binomial.rs
+++ b/src/integer/mat_poly_over_z/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_poly_over_z/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/sample/uniform.rs
+++ b/src/integer/mat_poly_over_z/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/sample/uniform.rs
+++ b/src/integer/mat_poly_over_z/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/serialize.rs
+++ b/src/integer/mat_poly_over_z/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/set.rs
+++ b/src/integer/mat_poly_over_z/set.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann, Niklas Siemer
+// Copyright 2023 Marvin Beckmann, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/set.rs
+++ b/src/integer/mat_poly_over_z/set.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marvin Beckmann, Niklas Siemer
+// Copyright 2023 Marvin Beckmann, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/sort.rs
+++ b/src/integer/mat_poly_over_z/sort.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright 2025 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/tensor.rs
+++ b/src/integer/mat_poly_over_z/tensor.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/to_string.rs
+++ b/src/integer/mat_poly_over_z/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/trace.rs
+++ b/src/integer/mat_poly_over_z/trace.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/transpose.rs
+++ b/src/integer/mat_poly_over_z/transpose.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/unsafe_functions.rs
+++ b/src/integer/mat_poly_over_z/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/unsafe_functions.rs
+++ b/src/integer/mat_poly_over_z/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/vector.rs
+++ b/src/integer/mat_poly_over_z/vector.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/vector.rs
+++ b/src/integer/mat_poly_over_z/vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/vector/dot_product.rs
+++ b/src/integer/mat_poly_over_z/vector/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/vector/is_vector.rs
+++ b/src/integer/mat_poly_over_z/vector/is_vector.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/vector/is_vector.rs
+++ b/src/integer/mat_poly_over_z/vector/is_vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_poly_over_z/vector/norm.rs
+++ b/src/integer/mat_poly_over_z/vector/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marcel Luca Schmidt
+// Copyright 2024 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z.rs
+++ b/src/integer/mat_z.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z.rs
+++ b/src/integer/mat_z.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/arithmetic.rs
+++ b/src/integer/mat_z/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/arithmetic/add.rs
+++ b/src/integer/mat_z/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/arithmetic/div.rs
+++ b/src/integer/mat_z/arithmetic/div.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Sven Moog
+// Copyright 2023 Marcel Luca Schmidt, Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/arithmetic/modulo.rs
+++ b/src/integer/mat_z/arithmetic/modulo.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/arithmetic/mul.rs
+++ b/src/integer/mat_z/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer, Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Jan Niklas Siemer, Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/arithmetic/mul.rs
+++ b/src/integer/mat_z/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer, Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Niklas Siemer, Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/arithmetic/mul_scalar.rs
+++ b/src/integer/mat_z/arithmetic/mul_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/arithmetic/sub.rs
+++ b/src/integer/mat_z/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/basis_reductions.rs
+++ b/src/integer/mat_z/basis_reductions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/basis_reductions.rs
+++ b/src/integer/mat_z/basis_reductions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/cmp.rs
+++ b/src/integer/mat_z/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/cmp.rs
+++ b/src/integer/mat_z/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/concat.rs
+++ b/src/integer/mat_z/concat.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/default.rs
+++ b/src/integer/mat_z/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/determinant.rs
+++ b/src/integer/mat_z/determinant.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/forms.rs
+++ b/src/integer/mat_z/forms.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/forms.rs
+++ b/src/integer/mat_z/forms.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/from.rs
+++ b/src/integer/mat_z/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/get.rs
+++ b/src/integer/mat_z/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/inverse.rs
+++ b/src/integer/mat_z/inverse.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/norm.rs
+++ b/src/integer/mat_z/norm.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/norm.rs
+++ b/src/integer/mat_z/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/ownership.rs
+++ b/src/integer/mat_z/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/ownership.rs
+++ b/src/integer/mat_z/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/properties.rs
+++ b/src/integer/mat_z/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sample.rs
+++ b/src/integer/mat_z/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sample.rs
+++ b/src/integer/mat_z/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sample/binomial.rs
+++ b/src/integer/mat_z/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sample/binomial.rs
+++ b/src/integer/mat_z/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sample/discrete_gauss.rs
+++ b/src/integer/mat_z/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sample/uniform.rs
+++ b/src/integer/mat_z/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/serialize.rs
+++ b/src/integer/mat_z/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/set.rs
+++ b/src/integer/mat_z/set.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/set.rs
+++ b/src/integer/mat_z/set.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sort.rs
+++ b/src/integer/mat_z/sort.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/sort.rs
+++ b/src/integer/mat_z/sort.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/tensor.rs
+++ b/src/integer/mat_z/tensor.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/to_string.rs
+++ b/src/integer/mat_z/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/trace.rs
+++ b/src/integer/mat_z/trace.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/transpose.rs
+++ b/src/integer/mat_z/transpose.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/transpose.rs
+++ b/src/integer/mat_z/transpose.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/unsafe_functions.rs
+++ b/src/integer/mat_z/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/unsafe_functions.rs
+++ b/src/integer/mat_z/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/vector.rs
+++ b/src/integer/mat_z/vector.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/vector.rs
+++ b/src/integer/mat_z/vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/vector/dot_product.rs
+++ b/src/integer/mat_z/vector/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/vector/dot_product.rs
+++ b/src/integer/mat_z/vector/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/vector/is_vector.rs
+++ b/src/integer/mat_z/vector/is_vector.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/vector/is_vector.rs
+++ b/src/integer/mat_z/vector/is_vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/vector/norm.rs
+++ b/src/integer/mat_z/vector/norm.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/mat_z/vector/norm.rs
+++ b/src/integer/mat_z/vector/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z.rs
+++ b/src/integer/poly_over_z.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/arithmetic.rs
+++ b/src/integer/poly_over_z/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/arithmetic/add.rs
+++ b/src/integer/poly_over_z/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/arithmetic/modulo.rs
+++ b/src/integer/poly_over_z/arithmetic/modulo.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/arithmetic/mul.rs
+++ b/src/integer/poly_over_z/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/arithmetic/mul_scalar.rs
+++ b/src/integer/poly_over_z/arithmetic/mul_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright 2025 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/arithmetic/sub.rs
+++ b/src/integer/poly_over_z/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/cmp.rs
+++ b/src/integer/poly_over_z/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/coefficient_embedding.rs
+++ b/src/integer/poly_over_z/coefficient_embedding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/default.rs
+++ b/src/integer/poly_over_z/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/dot_product.rs
+++ b/src/integer/poly_over_z/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/evaluate.rs
+++ b/src/integer/poly_over_z/evaluate.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/fmpz_poly_helpers.rs
+++ b/src/integer/poly_over_z/fmpz_poly_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/from.rs
+++ b/src/integer/poly_over_z/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/get.rs
+++ b/src/integer/poly_over_z/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/norm.rs
+++ b/src/integer/poly_over_z/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/ownership.rs
+++ b/src/integer/poly_over_z/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/properties.rs
+++ b/src/integer/poly_over_z/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/reduce.rs
+++ b/src/integer/poly_over_z/reduce.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/sample.rs
+++ b/src/integer/poly_over_z/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/sample.rs
+++ b/src/integer/poly_over_z/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/sample/binomial.rs
+++ b/src/integer/poly_over_z/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/sample/binomial.rs
+++ b/src/integer/poly_over_z/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/poly_over_z/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/sample/discrete_gauss.rs
+++ b/src/integer/poly_over_z/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/sample/uniform.rs
+++ b/src/integer/poly_over_z/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/sample/uniform.rs
+++ b/src/integer/poly_over_z/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/serialize.rs
+++ b/src/integer/poly_over_z/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/set.rs
+++ b/src/integer/poly_over_z/set.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/to_string.rs
+++ b/src/integer/poly_over_z/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/unsafe_functions.rs
+++ b/src/integer/poly_over_z/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/poly_over_z/unsafe_functions.rs
+++ b/src/integer/poly_over_z/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z.rs
+++ b/src/integer/z.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic.rs
+++ b/src/integer/z/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/add.rs
+++ b/src/integer/z/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/div.rs
+++ b/src/integer/z/arithmetic/div.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer and Sven Moog
+// Copyright 2023 Niklas Siemer and Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/div.rs
+++ b/src/integer/z/arithmetic/div.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer and Sven Moog
+// Copyright 2023 Jan Niklas Siemer and Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/exp.rs
+++ b/src/integer/z/arithmetic/exp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/logarithm.rs
+++ b/src/integer/z/arithmetic/logarithm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/modulo.rs
+++ b/src/integer/z/arithmetic/modulo.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/mul.rs
+++ b/src/integer/z/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/pow.rs
+++ b/src/integer/z/arithmetic/pow.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/pow.rs
+++ b/src/integer/z/arithmetic/pow.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/root.rs
+++ b/src/integer/z/arithmetic/root.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/arithmetic/sub.rs
+++ b/src/integer/z/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/cmp.rs
+++ b/src/integer/z/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog, Marcel Luca Schmidt
+// Copyright 2023 Sven Moog, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/default.rs
+++ b/src/integer/z/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/distance.rs
+++ b/src/integer/z/distance.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/distance.rs
+++ b/src/integer/z/distance.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer, Sven Moog
+// Copyright 2023 Jan Niklas Siemer, Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/fmpz_helpers.rs
+++ b/src/integer/z/fmpz_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer, Sven Moog
+// Copyright 2023 Niklas Siemer, Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/from.rs
+++ b/src/integer/z/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog, Marcel Luca Schmidt
+// Copyright 2023 Sven Moog, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/gcd.rs
+++ b/src/integer/z/gcd.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/gcd.rs
+++ b/src/integer/z/gcd.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/hash.rs
+++ b/src/integer/z/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/hash.rs
+++ b/src/integer/z/hash.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/lcm.rs
+++ b/src/integer/z/lcm.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/lcm.rs
+++ b/src/integer/z/lcm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic.rs
+++ b/src/integer/z/logic.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic.rs
+++ b/src/integer/z/logic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic/bit_and.rs
+++ b/src/integer/z/logic/bit_and.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic/bit_and.rs
+++ b/src/integer/z/logic/bit_and.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic/bit_or.rs
+++ b/src/integer/z/logic/bit_or.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic/bit_or.rs
+++ b/src/integer/z/logic/bit_or.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic/bit_xor.rs
+++ b/src/integer/z/logic/bit_xor.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic/bit_xor.rs
+++ b/src/integer/z/logic/bit_xor.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic/complement.rs
+++ b/src/integer/z/logic/complement.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/logic/complement.rs
+++ b/src/integer/z/logic/complement.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/ownership.rs
+++ b/src/integer/z/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/ownership.rs
+++ b/src/integer/z/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/properties.rs
+++ b/src/integer/z/properties.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/properties.rs
+++ b/src/integer/z/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/sample.rs
+++ b/src/integer/z/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/sample.rs
+++ b/src/integer/z/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/sample/binomial.rs
+++ b/src/integer/z/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/sample/binomial.rs
+++ b/src/integer/z/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/sample/discrete_gauss.rs
+++ b/src/integer/z/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/sample/discrete_gauss.rs
+++ b/src/integer/z/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/sample/uniform.rs
+++ b/src/integer/z/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/sample/uniform.rs
+++ b/src/integer/z/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/serialize.rs
+++ b/src/integer/z/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/to_string.rs
+++ b/src/integer/z/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/unsafe_functions.rs
+++ b/src/integer/z/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer/z/unsafe_functions.rs
+++ b/src/integer/z/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q.rs
+++ b/src/integer_mod_q.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/sample.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/sample.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_ntt_polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_ntt_polynomial_ring_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/mul_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/coefficient_embedding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright 2025 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/concat.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/concat.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/norm.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/norm.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/norm.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/properties.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/reduce.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/reduce.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/set.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/sort.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/sort.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright 2025 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/tensor.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/tensor.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright 2025 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/to_string.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marcel Luca Schmidt
+// Copyright 2024 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/transpose.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/transpose.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/unsafe_functions.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/unsafe_functions.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector/is_vector.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector/is_vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_polynomial_ring_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/vector/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marcel Luca Schmidt
+// Copyright 2024 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq.rs
+++ b/src/integer_mod_q/mat_zq.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/arithmetic.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Phil Milewski
+// Copyright 2023 Marcel Luca Schmidt, Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/mul_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/cmp.rs
+++ b/src/integer_mod_q/mat_zq/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/concat.rs
+++ b/src/integer_mod_q/mat_zq/concat.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann, Niklas Siemer
+// Copyright 2023 Marvin Beckmann, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/concat.rs
+++ b/src/integer_mod_q/mat_zq/concat.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marvin Beckmann, Niklas Siemer
+// Copyright 2023 Marvin Beckmann, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/default.rs
+++ b/src/integer_mod_q/mat_zq/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/from.rs
+++ b/src/integer_mod_q/mat_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/get.rs
+++ b/src/integer_mod_q/mat_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Sven Moog
+// Copyright 2023 Marcel Luca Schmidt, Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/inverse.rs
+++ b/src/integer_mod_q/mat_zq/inverse.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/norm.rs
+++ b/src/integer_mod_q/mat_zq/norm.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/norm.rs
+++ b/src/integer_mod_q/mat_zq/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/ownership.rs
+++ b/src/integer_mod_q/mat_zq/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/ownership.rs
+++ b/src/integer_mod_q/mat_zq/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/properties.rs
+++ b/src/integer_mod_q/mat_zq/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sample.rs
+++ b/src/integer_mod_q/mat_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sample.rs
+++ b/src/integer_mod_q/mat_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_zq/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sample/binomial.rs
+++ b/src/integer_mod_q/mat_zq/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/mat_zq/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sample/uniform.rs
+++ b/src/integer_mod_q/mat_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/serialize.rs
+++ b/src/integer_mod_q/mat_zq/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/set.rs
+++ b/src/integer_mod_q/mat_zq/set.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/set.rs
+++ b/src/integer_mod_q/mat_zq/set.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/solve.rs
+++ b/src/integer_mod_q/mat_zq/solve.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sort.rs
+++ b/src/integer_mod_q/mat_zq/sort.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/sort.rs
+++ b/src/integer_mod_q/mat_zq/sort.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/tensor.rs
+++ b/src/integer_mod_q/mat_zq/tensor.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/to_string.rs
+++ b/src/integer_mod_q/mat_zq/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/trace.rs
+++ b/src/integer_mod_q/mat_zq/trace.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/transpose.rs
+++ b/src/integer_mod_q/mat_zq/transpose.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/unsafe_functions.rs
+++ b/src/integer_mod_q/mat_zq/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/unsafe_functions.rs
+++ b/src/integer_mod_q/mat_zq/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/vector.rs
+++ b/src/integer_mod_q/mat_zq/vector.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/vector.rs
+++ b/src/integer_mod_q/mat_zq/vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_zq/vector/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/vector/dot_product.rs
+++ b/src/integer_mod_q/mat_zq/vector/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/vector/is_vector.rs
+++ b/src/integer_mod_q/mat_zq/vector/is_vector.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/vector/is_vector.rs
+++ b/src/integer_mod_q/mat_zq/vector/is_vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_zq/vector/norm.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/mat_zq/vector/norm.rs
+++ b/src/integer_mod_q/mat_zq/vector/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus.rs
+++ b/src/integer_mod_q/modulus.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/cmp.rs
+++ b/src/integer_mod_q/modulus/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/cmp.rs
+++ b/src/integer_mod_q/modulus/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/distance.rs
+++ b/src/integer_mod_q/modulus/distance.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marcel Luca Schmidt
+// Copyright 2024 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/fmpz_helpers.rs
+++ b/src/integer_mod_q/modulus/fmpz_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/from.rs
+++ b/src/integer_mod_q/modulus/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann, Sven Moog
+// Copyright 2023 Marvin Beckmann, Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/get.rs
+++ b/src/integer_mod_q/modulus/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/ownership.rs
+++ b/src/integer_mod_q/modulus/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/ownership.rs
+++ b/src/integer_mod_q/modulus/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/properties.rs
+++ b/src/integer_mod_q/modulus/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/serialize.rs
+++ b/src/integer_mod_q/modulus/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/to_string.rs
+++ b/src/integer_mod_q/modulus/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/unsafe_functions.rs
+++ b/src/integer_mod_q/modulus/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus/unsafe_functions.rs
+++ b/src/integer_mod_q/modulus/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/coefficient_embedding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright 2025 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/norm.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marcel Luca Schmidt
+// Copyright 2024 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/ntt_basis.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/ntt_basis.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/ownership.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/ownership.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/serialize.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/modulus_polynomial_ring_zq/to_string.rs
+++ b/src/integer_mod_q/modulus_polynomial_ring_zq/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_basis_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/ntt_basis_polynomial_ring_zq.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_basis_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/ntt_basis_polynomial_ring_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_basis_polynomial_ring_zq/inv_ntt.rs
+++ b/src/integer_mod_q/ntt_basis_polynomial_ring_zq/inv_ntt.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_basis_polynomial_ring_zq/ntt.rs
+++ b/src/integer_mod_q/ntt_basis_polynomial_ring_zq/ntt.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/sample.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/sample.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/ntt_polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/ntt_polynomial_ring_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq.rs
+++ b/src/integer_mod_q/poly_over_zq.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/arithmetic.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/mul_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/cmp.rs
+++ b/src/integer_mod_q/poly_over_zq/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/poly_over_zq/coefficient_embedding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/dot_product.rs
+++ b/src/integer_mod_q/poly_over_zq/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/evaluate.rs
+++ b/src/integer_mod_q/poly_over_zq/evaluate.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/from.rs
+++ b/src/integer_mod_q/poly_over_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann and Sven Moog
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann and Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/get.rs
+++ b/src/integer_mod_q/poly_over_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/norm.rs
+++ b/src/integer_mod_q/poly_over_zq/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/ownership.rs
+++ b/src/integer_mod_q/poly_over_zq/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/ownership.rs
+++ b/src/integer_mod_q/poly_over_zq/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/properties.rs
+++ b/src/integer_mod_q/poly_over_zq/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/sample.rs
+++ b/src/integer_mod_q/poly_over_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/sample.rs
+++ b/src/integer_mod_q/poly_over_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/sample/binomial.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/sample/binomial.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/sample/uniform.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/sample/uniform.rs
+++ b/src/integer_mod_q/poly_over_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/serialize.rs
+++ b/src/integer_mod_q/poly_over_zq/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/set.rs
+++ b/src/integer_mod_q/poly_over_zq/set.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/to_string.rs
+++ b/src/integer_mod_q/poly_over_zq/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/unsafe_functions.rs
+++ b/src/integer_mod_q/poly_over_zq/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/poly_over_zq/unsafe_functions.rs
+++ b/src/integer_mod_q/poly_over_zq/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq.rs
+++ b/src/integer_mod_q/polynomial_ring_zq.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/add.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/mul.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/mul_scalar.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/mul_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/sub.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/cmp.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/coefficient_embedding.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/coefficient_embedding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright 2025 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/from.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/get.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/norm.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright 2025 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/properties.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marcel Luca Schmidt
+// Copyright 2024 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/reduce.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/reduce.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/sample.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/sample.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/sample/binomial.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/sample/binomial.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/sample/uniform.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/set.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/set.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/to_string.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/unsafe_functions.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/polynomial_ring_zq/unsafe_functions.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q.rs
+++ b/src/integer_mod_q/z_q.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q.rs
+++ b/src/integer_mod_q/z_q.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/arithmetic.rs
+++ b/src/integer_mod_q/z_q/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/arithmetic/add.rs
+++ b/src/integer_mod_q/z_q/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/arithmetic/mul.rs
+++ b/src/integer_mod_q/z_q/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/arithmetic/pow.rs
+++ b/src/integer_mod_q/z_q/arithmetic/pow.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/arithmetic/pow.rs
+++ b/src/integer_mod_q/z_q/arithmetic/pow.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/arithmetic/sub.rs
+++ b/src/integer_mod_q/z_q/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/cmp.rs
+++ b/src/integer_mod_q/z_q/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
+++ b/src/integer_mod_q/z_q/fmpz_mod_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog, Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Sven Moog, Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/from.rs
+++ b/src/integer_mod_q/z_q/from.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Sven Moog, Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Sven Moog, Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/get.rs
+++ b/src/integer_mod_q/z_q/get.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/get.rs
+++ b/src/integer_mod_q/z_q/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/properties.rs
+++ b/src/integer_mod_q/z_q/properties.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/properties.rs
+++ b/src/integer_mod_q/z_q/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/reduce.rs
+++ b/src/integer_mod_q/z_q/reduce.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/reduce.rs
+++ b/src/integer_mod_q/z_q/reduce.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/sample.rs
+++ b/src/integer_mod_q/z_q/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/sample.rs
+++ b/src/integer_mod_q/z_q/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/sample/binomial.rs
+++ b/src/integer_mod_q/z_q/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/sample/binomial.rs
+++ b/src/integer_mod_q/z_q/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/z_q/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/sample/discrete_gauss.rs
+++ b/src/integer_mod_q/z_q/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/sample/uniform.rs
+++ b/src/integer_mod_q/z_q/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/to_string.rs
+++ b/src/integer_mod_q/z_q/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/to_string.rs
+++ b/src/integer_mod_q/z_q/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/unsafe_functions.rs
+++ b/src/integer_mod_q/z_q/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/integer_mod_q/z_q/unsafe_functions.rs
+++ b/src/integer_mod_q/z_q/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/macros/arithmetics.rs
+++ b/src/macros/arithmetics.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/macros/compare_base.rs
+++ b/src/macros/compare_base.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/macros/for_others.rs
+++ b/src/macros/for_others.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann, Marcel Luca Schmidt
+// Copyright 2023 Marvin Beckmann, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/macros/from.rs
+++ b/src/macros/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/macros/serialize.rs
+++ b/src/macros/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/macros/unsafe_passthrough.rs
+++ b/src/macros/unsafe_passthrough.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/macros/unsafe_passthrough.rs
+++ b/src/macros/unsafe_passthrough.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q.rs
+++ b/src/rational/mat_q.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/arithmetic.rs
+++ b/src/rational/mat_q/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/arithmetic/add.rs
+++ b/src/rational/mat_q/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/arithmetic/div_scalar.rs
+++ b/src/rational/mat_q/arithmetic/div_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marvin Beckmann
+// Copyright 2025 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/arithmetic/mul.rs
+++ b/src/rational/mat_q/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Phil Milewski
+// Copyright 2023 Marcel Luca Schmidt, Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/arithmetic/mul_scalar.rs
+++ b/src/rational/mat_q/arithmetic/mul_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/arithmetic/sub.rs
+++ b/src/rational/mat_q/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/cholesky_decomp.rs
+++ b/src/rational/mat_q/cholesky_decomp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marvin Beckmann
+// Copyright 2024 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/cmp.rs
+++ b/src/rational/mat_q/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog, Marcel Luca Schmidt
+// Copyright 2023 Sven Moog, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/concat.rs
+++ b/src/rational/mat_q/concat.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/default.rs
+++ b/src/rational/mat_q/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/determinant.rs
+++ b/src/rational/mat_q/determinant.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/from.rs
+++ b/src/rational/mat_q/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/get.rs
+++ b/src/rational/mat_q/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/gso.rs
+++ b/src/rational/mat_q/gso.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/inverse.rs
+++ b/src/rational/mat_q/inverse.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/norm.rs
+++ b/src/rational/mat_q/norm.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/norm.rs
+++ b/src/rational/mat_q/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/ownership.rs
+++ b/src/rational/mat_q/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/ownership.rs
+++ b/src/rational/mat_q/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/properties.rs
+++ b/src/rational/mat_q/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marvin Beckmann
+// Copyright 2023 Phil Milewski, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/rounding.rs
+++ b/src/rational/mat_q/rounding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marvin Beckmann
+// Copyright 2024 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/sample.rs
+++ b/src/rational/mat_q/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marvin Beckmann
+// Copyright 2024 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/sample/gauss.rs
+++ b/src/rational/mat_q/sample/gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marvin Beckmann
+// Copyright 2024 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/serialize.rs
+++ b/src/rational/mat_q/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/set.rs
+++ b/src/rational/mat_q/set.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/set.rs
+++ b/src/rational/mat_q/set.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/sort.rs
+++ b/src/rational/mat_q/sort.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/sort.rs
+++ b/src/rational/mat_q/sort.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/tensor.rs
+++ b/src/rational/mat_q/tensor.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/to_string.rs
+++ b/src/rational/mat_q/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/trace.rs
+++ b/src/rational/mat_q/trace.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/transpose.rs
+++ b/src/rational/mat_q/transpose.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/unsafe_functions.rs
+++ b/src/rational/mat_q/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/unsafe_functions.rs
+++ b/src/rational/mat_q/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/vector.rs
+++ b/src/rational/mat_q/vector.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/vector.rs
+++ b/src/rational/mat_q/vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/vector/dot_product.rs
+++ b/src/rational/mat_q/vector/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/vector/is_vector.rs
+++ b/src/rational/mat_q/vector/is_vector.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/vector/is_vector.rs
+++ b/src/rational/mat_q/vector/is_vector.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/vector/norm.rs
+++ b/src/rational/mat_q/vector/norm.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/mat_q/vector/norm.rs
+++ b/src/rational/mat_q/vector/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q.rs
+++ b/src/rational/poly_over_q.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/arithmetic.rs
+++ b/src/rational/poly_over_q/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/arithmetic/add.rs
+++ b/src/rational/poly_over_q/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/arithmetic/div_scalar.rs
+++ b/src/rational/poly_over_q/arithmetic/div_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2025 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/arithmetic/exp.rs
+++ b/src/rational/poly_over_q/arithmetic/exp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/arithmetic/mul.rs
+++ b/src/rational/poly_over_q/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/arithmetic/mul_scalar.rs
+++ b/src/rational/poly_over_q/arithmetic/mul_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Marcel Luca Schmidt
+// Copyright 2025 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/arithmetic/sub.rs
+++ b/src/rational/poly_over_q/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski, Marcel Luca Schmidt
+// Copyright 2023 Phil Milewski, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/cmp.rs
+++ b/src/rational/poly_over_q/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann, Marcel Luca Schmidt
+// Copyright 2023 Marvin Beckmann, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/coefficient_embedding.rs
+++ b/src/rational/poly_over_q/coefficient_embedding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/default.rs
+++ b/src/rational/poly_over_q/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/dot_product.rs
+++ b/src/rational/poly_over_q/dot_product.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/evaluate.rs
+++ b/src/rational/poly_over_q/evaluate.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/from.rs
+++ b/src/rational/poly_over_q/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/get.rs
+++ b/src/rational/poly_over_q/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/norm.rs
+++ b/src/rational/poly_over_q/norm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/ownership.rs
+++ b/src/rational/poly_over_q/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/ownership.rs
+++ b/src/rational/poly_over_q/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/properties.rs
+++ b/src/rational/poly_over_q/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/rounding.rs
+++ b/src/rational/poly_over_q/rounding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marcel Luca Schmidt
+// Copyright 2024 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/sample.rs
+++ b/src/rational/poly_over_q/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marcel Luca Schmidt
+// Copyright 2024 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/sample/gauss.rs
+++ b/src/rational/poly_over_q/sample/gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marcel Luca Schmidt
+// Copyright 2024 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/serialize.rs
+++ b/src/rational/poly_over_q/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/set.rs
+++ b/src/rational/poly_over_q/set.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/to_string.rs
+++ b/src/rational/poly_over_q/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/unsafe_functions.rs
+++ b/src/rational/poly_over_q/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/poly_over_q/unsafe_functions.rs
+++ b/src/rational/poly_over_q/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q.rs
+++ b/src/rational/q.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic.rs
+++ b/src/rational/q/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/add.rs
+++ b/src/rational/q/arithmetic/add.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/div.rs
+++ b/src/rational/q/arithmetic/div.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/exp.rs
+++ b/src/rational/q/arithmetic/exp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann and Sven Moog
+// Copyright 2023 Marvin Beckmann and Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/logarithm.rs
+++ b/src/rational/q/arithmetic/logarithm.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/logarithm.rs
+++ b/src/rational/q/arithmetic/logarithm.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/mul.rs
+++ b/src/rational/q/arithmetic/mul.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/pow.rs
+++ b/src/rational/q/arithmetic/pow.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/pow.rs
+++ b/src/rational/q/arithmetic/pow.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/root.rs
+++ b/src/rational/q/arithmetic/root.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/arithmetic/sub.rs
+++ b/src/rational/q/arithmetic/sub.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Phil Milewski
+// Copyright 2023 Phil Milewski
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/cmp.rs
+++ b/src/rational/q/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Sven Moog, Niklas Siemer, Marcel Luca Schmidt
+// Copyright 2023 Sven Moog, Jan Niklas Siemer, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/cmp.rs
+++ b/src/rational/q/cmp.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog, Niklas Siemer, Marcel Luca Schmidt
+// Copyright 2023 Sven Moog, Niklas Siemer, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/default.rs
+++ b/src/rational/q/default.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/default.rs
+++ b/src/rational/q/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Niklas Siemer
+// Copyright 2023 Marcel Luca Schmidt, Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/distance.rs
+++ b/src/rational/q/distance.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/distance.rs
+++ b/src/rational/q/distance.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/from.rs
+++ b/src/rational/q/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Sven Moog
+// Copyright 2023 Marcel Luca Schmidt, Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/get.rs
+++ b/src/rational/q/get.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/ownership.rs
+++ b/src/rational/q/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/ownership.rs
+++ b/src/rational/q/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/properties.rs
+++ b/src/rational/q/properties.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/properties.rs
+++ b/src/rational/q/properties.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/rounding.rs
+++ b/src/rational/q/rounding.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/sample.rs
+++ b/src/rational/q/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marvin Beckmann
+// Copyright 2024 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/sample/gauss.rs
+++ b/src/rational/q/sample/gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Marvin Beckmann
+// Copyright 2024 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/serialize.rs
+++ b/src/rational/q/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/to_string.rs
+++ b/src/rational/q/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/unsafe_functions.rs
+++ b/src/rational/q/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/rational/q/unsafe_functions.rs
+++ b/src/rational/q/unsafe_functions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann, Marcel Luca Schmidt
+// Copyright 2023 Marvin Beckmann, Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/dimensions.rs
+++ b/src/utils/dimensions.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/factorization.rs
+++ b/src/utils/factorization.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/factorization/default.rs
+++ b/src/utils/factorization/default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/factorization/from.rs
+++ b/src/utils/factorization/from.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/factorization/ownership.rs
+++ b/src/utils/factorization/ownership.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/factorization/refine.rs
+++ b/src/utils/factorization/refine.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/factorization/to_string.rs
+++ b/src/utils/factorization/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/index.rs
+++ b/src/utils/index.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt
+// Copyright 2023 Marcel Luca Schmidt
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/sample.rs
+++ b/src/utils/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/sample.rs
+++ b/src/utils/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/sample/binomial.rs
+++ b/src/utils/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/sample/binomial.rs
+++ b/src/utils/sample/binomial.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/sample/discrete_gauss.rs
+++ b/src/utils/sample/discrete_gauss.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/sample/uniform.rs
+++ b/src/utils/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-math.
 //

--- a/src/utils/sample/uniform.rs
+++ b/src/utils/sample/uniform.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-math.
 //


### PR DESCRIPTION
**Description**

This PR resolves problems encountered when converting to `.zip` format. For some reason, the unicode symbol for copyright was a problem.