### PR TITLE
Add Modulo centered around `0`

### DIFF
--- a/src/integer/mat_poly_over_z/arithmetic/modulo.rs
+++ b/src/integer/mat_poly_over_z/arithmetic/modulo.rs
@@ -16,7 +16,7 @@ use crate::{
         arithmetics::{arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned},
         for_others::implement_for_others,
     },
-    traits::{MatrixDimensions, MatrixGetEntry, MatrixSetEntry},
+    traits::{GetCoefficient, MatrixDimensions, MatrixGetEntry, MatrixSetEntry, SetCoefficient},
 };
 use std::ops::Rem;
 
@@ -160,6 +160,54 @@ arithmetic_trait_borrowed_to_owned!(Rem, rem, MatPolyOverZ, Modulus, MatPolyOver
 arithmetic_trait_mixed_borrowed_owned!(Rem, rem, MatPolyOverZ, Modulus, MatPolyOverZ);
 
 implement_for_others!(Z, MatPolyOverZ, Rem for i8 i16 i32 i64 u8 u16 u32 u64);
+
+impl MatPolyOverZ {
+    /// Computes `self` mod± `modulus` as long as `modulus` is greater than 1, i.e.
+    /// it returns a matrix containing polynomials with coefficients in `[-⌈q/2⌉, ⌈q/2⌉]`.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the remainder closest to `0` is computed
+    ///
+    /// Returns `self` mod± `modulus` as a [`MatPolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatPolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatPolyOverZ::from_str("[[1  -2],[1  42]]").unwrap();
+    ///
+    /// let c = a.mod_pm(24);
+    ///
+    /// assert_eq!(MatPolyOverZ::from_str("[[1  -2],[1  -6]]").unwrap(), c);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`.
+    pub fn mod_pm(&self, modulus: impl Into<Z>) -> Self {
+        let modulus = modulus.into();
+        assert!(modulus > 1, "Modulus can not be smaller than 2.");
+
+        let mut mat = self.rem(&modulus);
+
+        for row in 0..mat.get_num_rows() {
+            for col in 0..mat.get_num_columns() {
+                let mut entry = unsafe { mat.get_entry_unchecked(row, col) };
+                for i in 0..=entry.get_degree() {
+                    let mut coeff = unsafe { entry.get_coeff_unchecked(i) };
+                    if coeff > modulus.div_floor(2) {
+                        coeff -= &modulus;
+                    }
+                    unsafe { entry.set_coeff_unchecked(i, coeff) };
+                }
+                unsafe { mat.set_entry_unchecked(row, col, entry) };
+            }
+        }
+
+        mat
+    }
+}
 
 #[cfg(test)]
 mod test_rem {
@@ -316,5 +364,89 @@ mod test_rem {
             % PolyOverZq::from_str("4  1 0 0 1 mod 24").unwrap();
         let _ = &MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap()
             % &PolyOverZq::from_str("4  1 0 0 1 mod 24").unwrap();
+    }
+}
+
+#[cfg(test)]
+mod test_mod_pm {
+    use super::Z;
+    use crate::{integer::MatPolyOverZ, integer_mod_q::Modulus};
+    use std::str::FromStr;
+
+    /// Testing mod± for two owned
+    #[test]
+    fn mod_pm() {
+        let a = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap();
+        let b = Z::from(25);
+        let modulus = Modulus::from(25);
+        let c1 = a.clone().mod_pm(b);
+        let c2 = a.clone().mod_pm(modulus);
+        let cmp = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 -8, 1  -1]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Testing mod± for large numbers
+    #[test]
+    fn mod_pm_large_numbers() {
+        let a =
+            MatPolyOverZ::from_str(&format!("[[1  2, 1  {}],[2  3 42, 1  24]]", u64::MAX)).unwrap();
+        let b = Z::from(u64::MAX - 2);
+        let modulus = Modulus::from(u64::MAX - 2);
+        let c1 = a.clone().mod_pm(&b);
+        let c2 = a.clone().mod_pm(&modulus);
+        let cmp = MatPolyOverZ::from_str("[[1  2, 1  2],[2  3 42, 1  24]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Ensures that computing mod± a negative number results in a panic
+    #[test]
+    #[should_panic]
+    fn mod_pm_negative_error() {
+        let a = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap();
+        let b = Z::from(-24);
+        _ = a.mod_pm(&b);
+    }
+
+    /// Ensures that computing mod± 0 results in a panic
+    #[test]
+    #[should_panic]
+    fn zero_modulus() {
+        _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(0);
+    }
+
+    /// Ensures that `mod±` is available for several types implementing [`Into<Z>`].
+    #[test]
+    fn availability() {
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(2u8);
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(2u16);
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(2u32);
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(2u64);
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(2i8);
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(2i16);
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(2i32);
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(2i64);
+        let _ = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]")
+            .unwrap()
+            .mod_pm(Z::from(2));
     }
 }

--- a/src/integer/mat_z/arithmetic/modulo.rs
+++ b/src/integer/mat_z/arithmetic/modulo.rs
@@ -16,7 +16,7 @@ use crate::{
         arithmetics::{arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned},
         for_others::implement_for_others,
     },
-    traits::MatrixDimensions,
+    traits::{MatrixDimensions, MatrixGetEntry, MatrixSetEntry},
 };
 use flint_sys::{fmpz::fmpz_mod, fmpz_mat::fmpz_mat_entry, fmpz_mod::fmpz_mod_set_fmpz};
 use std::ops::Rem;
@@ -103,6 +103,50 @@ arithmetic_trait_borrowed_to_owned!(Rem, rem, MatZ, Modulus, MatZ);
 arithmetic_trait_mixed_borrowed_owned!(Rem, rem, MatZ, Modulus, MatZ);
 
 implement_for_others!(Z, MatZ, Rem for i8 i16 i32 i64 u8 u16 u32 u64);
+
+impl MatZ {
+    /// Computes `self` mod± `modulus` as long as `modulus` is greater than 1, i.e.
+    /// it returns a matrix with entries in `[-⌈q/2⌉, ⌈q/2⌉]`.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the remainder closest to `0` is computed
+    ///
+    /// Returns `self` mod± `modulus` as a [`MatZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::MatZ;
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatZ::from_str("[[-2],[42]]").unwrap();
+    ///
+    /// let c = a.mod_pm(24);
+    ///
+    /// assert_eq!(MatZ::from_str("[[-2],[-6]]").unwrap(), c);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`.
+    pub fn mod_pm(&self, modulus: impl Into<Z>) -> Self {
+        let modulus = modulus.into();
+        assert!(modulus > 1, "Modulus can not be smaller than 2.");
+
+        let mut mat = self.rem(&modulus);
+
+        for row in 0..mat.get_num_rows() {
+            for col in 0..mat.get_num_columns() {
+                let mut entry = unsafe { mat.get_entry_unchecked(row, col) };
+                if entry > modulus.div_floor(2) {
+                    entry -= &modulus;
+                }
+                unsafe { mat.set_entry_unchecked(row, col, entry) };
+            }
+        }
+
+        mat
+    }
+}
 
 #[cfg(test)]
 mod test_rem {
@@ -209,5 +253,69 @@ mod test_rem {
         let _ = &MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % 2u8;
         let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % &Z::from(2);
         let _ = &MatZ::from_str("[[2, 3],[42, 24]]").unwrap() % &Z::from(2);
+    }
+}
+
+#[cfg(test)]
+mod test_mod_pm {
+    use super::Z;
+    use crate::{integer::MatZ, integer_mod_q::Modulus};
+    use std::str::FromStr;
+
+    /// Testing mod± for two owned
+    #[test]
+    fn mod_pm() {
+        let a = MatZ::from_str("[[2, 3],[42, 24]]").unwrap();
+        let b = Z::from(25);
+        let c1 = a.clone().mod_pm(b);
+        let c2 = a.mod_pm(Modulus::from(25));
+        assert_eq!(c1, MatZ::from_str("[[2, 3],[-8, -1]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[2, 3],[-8, -1]]").unwrap());
+    }
+
+    /// Testing mod± for large numbers
+    #[test]
+    fn mod_pm_large_numbers() {
+        let a = MatZ::from_str(&format!("[[2, 3],[{}, 24]]", u64::MAX)).unwrap();
+        let b = Z::from(u64::MAX - 2);
+        let c1 = a.mod_pm(&b);
+        let c2 = a.mod_pm(&Modulus::from(u64::MAX - 2));
+        assert_eq!(c1, MatZ::from_str("[[2, 3],[2, 24]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[2, 3],[2, 24]]").unwrap());
+    }
+
+    /// Ensures that computing mod± a negative number results in a panic
+    #[test]
+    #[should_panic]
+    fn mod_pm_negative_error() {
+        let a = MatZ::from_str("[[2, 3],[42, 24]]").unwrap();
+        let b = Z::from(-24);
+        _ = &a.mod_pm(&b);
+    }
+
+    /// Ensures that computing mod± 0 results in a panic
+    #[test]
+    #[should_panic]
+    fn zero_modulus() {
+        _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap().mod_pm(0);
+    }
+
+    /// Ensures that `mod±` is available for several types.
+    #[test]
+    fn availability() {
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap().mod_pm(2u8);
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap().mod_pm(2u16);
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap().mod_pm(2u32);
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap().mod_pm(2u64);
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap().mod_pm(2i8);
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap().mod_pm(2i16);
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap().mod_pm(2i32);
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]").unwrap().mod_pm(2i64);
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]")
+            .unwrap()
+            .mod_pm(Z::from(2));
+        let _ = MatZ::from_str("[[2, 3],[42, 24]]")
+            .unwrap()
+            .mod_pm(Modulus::from(2));
     }
 }

--- a/src/integer/poly_over_z/arithmetic/modulo.rs
+++ b/src/integer/poly_over_z/arithmetic/modulo.rs
@@ -16,6 +16,7 @@ use crate::{
         arithmetics::{arithmetic_trait_borrowed_to_owned, arithmetic_trait_mixed_borrowed_owned},
         for_others::implement_for_others,
     },
+    traits::{GetCoefficient, SetCoefficient},
 };
 use flint_sys::fmpz_poly::fmpz_poly_scalar_mod_fmpz;
 use std::ops::Rem;
@@ -141,6 +142,47 @@ arithmetic_trait_borrowed_to_owned!(Rem, rem, PolyOverZ, Z, PolyOverZ);
 arithmetic_trait_mixed_borrowed_owned!(Rem, rem, PolyOverZ, Z, PolyOverZ);
 
 implement_for_others!(Z, PolyOverZ, Rem for i8 i16 i32 i64 u8 u16 u32 u64);
+
+impl PolyOverZ {
+    /// Computes `self` mod± `modulus` as long as `modulus` is greater than 1, i.e.
+    /// it returns a polynomial with coefficients in `[-⌈q/2⌉, ⌈q/2⌉]`.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the remainder closest to `0` is computed
+    ///
+    /// Returns `self` mod± `modulus` as a [`PolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::PolyOverZ;
+    ///
+    /// let a = PolyOverZ::from(42);
+    ///
+    /// let c = a.mod_pm(24);
+    ///
+    /// assert_eq!(PolyOverZ::from(-6), c);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`.
+    pub fn mod_pm(&self, modulus: impl Into<Z>) -> Self {
+        let modulus = modulus.into();
+        assert!(modulus > 1, "Modulus can not be smaller than 2.");
+
+        let mut poly = self.rem(&modulus);
+
+        for i in 0..=poly.get_degree() {
+            let mut coeff = unsafe { poly.get_coeff_unchecked(i) };
+            if coeff > modulus.div_floor(2) {
+                coeff -= &modulus;
+            }
+            unsafe { poly.set_coeff_unchecked(i, coeff) };
+        }
+
+        poly
+    }
+}
 
 #[cfg(test)]
 mod test_rem {
@@ -297,5 +339,71 @@ mod test_rem {
             % PolyOverZq::from_str("4  1 0 0 1 mod 24").unwrap();
         let _ = PolyOverZ::from_str("2  2 42").unwrap()
             % &PolyOverZq::from_str("4  1 0 0 1 mod 24").unwrap();
+    }
+}
+
+#[cfg(test)]
+mod test_mod_pm {
+    use super::Z;
+    use crate::{integer::PolyOverZ, integer_mod_q::Modulus};
+    use std::str::FromStr;
+
+    /// Testing mod± for two owned
+    #[test]
+    fn mod_pm() {
+        let a = PolyOverZ::from_str("2  2 42").unwrap();
+        let b = Z::from(25);
+        let modulus = Modulus::from(25);
+        let c1 = a.clone().mod_pm(b);
+        let c2 = a.clone().mod_pm(modulus);
+        let cmp = PolyOverZ::from_str("2  2 -8").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Testing mod± for large numbers
+    #[test]
+    fn mod_pm_large_numbers() {
+        let a = PolyOverZ::from_str(&format!("2  2 {}", u64::MAX)).unwrap();
+        let b = Z::from(u64::MAX - 2);
+        let modulus = Modulus::from(u64::MAX - 2);
+        let c1 = a.clone().mod_pm(&b);
+        let c2 = a.clone().mod_pm(&modulus);
+        let cmp = PolyOverZ::from_str("2  2 2").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Ensures that computing mod± a negative number results in a panic
+    #[test]
+    #[should_panic]
+    fn mod_pm_negative_error() {
+        let a = PolyOverZ::from_str("2  2 42").unwrap();
+        let b = Z::from(-24);
+        _ = &a.mod_pm(&b);
+    }
+
+    /// Ensures that computing mod± 0 results in a panic
+    #[test]
+    #[should_panic]
+    fn zero_modulus() {
+        _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(0);
+    }
+
+    /// Ensures that `mod±` is available for several types
+    #[test]
+    fn availability() {
+        let _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(2u8);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(2u16);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(2u32);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(2u64);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(2i8);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(2i16);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(2i32);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(2i64);
+        let _ = PolyOverZ::from_str("2  2 42").unwrap().mod_pm(Z::from(2));
+        let _ = PolyOverZ::from_str("2  2 42")
+            .unwrap()
+            .mod_pm(Modulus::from(2));
     }
 }

--- a/src/integer/z/arithmetic/modulo.rs
+++ b/src/integer/z/arithmetic/modulo.rs
@@ -8,8 +8,6 @@
 
 //! Implementation of the [`Rem`] trait for [`Z`] values.
 
-use flint_sys::{fmpz::fmpz_mod, fmpz_mod::fmpz_mod_set_fmpz};
-
 use super::super::Z;
 use crate::{
     integer_mod_q::Modulus,
@@ -18,6 +16,7 @@ use crate::{
         arithmetic_trait_mixed_borrowed_owned,
     },
 };
+use flint_sys::{fmpz::fmpz_mod, fmpz_mod::fmpz_mod_set_fmpz};
 use std::ops::Rem;
 
 impl Rem for &Z {
@@ -90,6 +89,43 @@ arithmetic_trait_mixed_borrowed_owned!(Rem, rem, Z, Z, Z);
 arithmetic_trait_borrowed_to_owned!(Rem, rem, Z, Modulus, Z);
 arithmetic_trait_mixed_borrowed_owned!(Rem, rem, Z, Modulus, Z);
 arithmetic_between_types!(Rem, rem, Z, Z, i64 i32 i16 i8 u64 u32 u16 u8);
+
+impl Z {
+    /// Computes `self` mod± `modulus` as long as `modulus` is greater than 1, i.e.
+    /// it returns a value in `[-⌈q/2⌉, ⌈q/2⌉]`.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the remainder closest to `0` is computed
+    ///
+    /// Returns `self` mod± `modulus` as a [`Z`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer::Z;
+    ///
+    /// let a = Z::from(42);
+    /// let b = 24;
+    ///
+    /// let c = a.mod_pm(b);
+    ///
+    /// assert_eq!(-6, c);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`.
+    pub fn mod_pm(&self, modulus: impl Into<Z>) -> Self {
+        let modulus = modulus.into();
+        assert!(modulus > 1, "Modulus can not be smaller than 2.");
+
+        let mut value = self.rem(&modulus);
+
+        if value > modulus.div_floor(2) {
+            value -= modulus;
+        }
+        value
+    }
+}
 
 #[cfg(test)]
 mod test_rem {
@@ -196,5 +232,66 @@ mod test_rem {
         let _ = &Z::ONE % 2u8;
         let _ = 1u8 % Z::from(2);
         let _ = 1u8 % &Z::from(2);
+    }
+}
+
+#[cfg(test)]
+mod test_mod_pm {
+    use super::Z;
+    use crate::integer_mod_q::Modulus;
+
+    /// Testing mod± for two [`Z`]
+    #[test]
+    fn mod_pm() {
+        let a: Z = Z::from(42);
+        let b: Z = Z::from(25);
+
+        let c1 = a.mod_pm(b);
+        let c2 = a.mod_pm(25);
+
+        assert_eq!(c1, -8);
+        assert_eq!(c2, -8);
+    }
+
+    /// Testing mod± for large numbers
+    #[test]
+    fn mod_pm_large_numbers() {
+        let a: Z = Z::from(u64::MAX);
+        let b: Z = Z::from(u64::MAX - 2);
+
+        let c1: Z = a.clone().mod_pm(&b);
+        let c2: Z = a.mod_pm(&Z::from(u64::MAX - 2));
+
+        assert_eq!(c1, 2);
+        assert_eq!(c2, 2);
+    }
+
+    /// Ensures that computing mod± a negative number results in a panic
+    #[test]
+    #[should_panic]
+    fn mod_pm_negative_error() {
+        _ = Z::from(42).mod_pm(-24);
+    }
+
+    /// Ensures that computing mod± 0 results in a panic
+    #[test]
+    #[should_panic]
+    fn zero_modulus() {
+        _ = Z::from(15).mod_pm(0);
+    }
+
+    /// Ensures that `mod±` is available for several types.
+    #[test]
+    fn availability() {
+        let _ = Z::ONE.mod_pm(2u8);
+        let _ = Z::ONE.mod_pm(2u16);
+        let _ = Z::ONE.mod_pm(2u32);
+        let _ = Z::ONE.mod_pm(2u64);
+        let _ = Z::ONE.mod_pm(2i8);
+        let _ = Z::ONE.mod_pm(2i16);
+        let _ = Z::ONE.mod_pm(2i32);
+        let _ = Z::ONE.mod_pm(2i64);
+        let _ = Z::ONE.mod_pm(Z::from(2));
+        let _ = Z::ONE.mod_pm(Modulus::from(2));
     }
 }

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic.rs
@@ -10,6 +10,7 @@
 //! such as addition or subtraction.
 
 mod add;
+mod modulo;
 mod mul;
 mod mul_scalar;
 mod sub;

--- a/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/modulo.rs
+++ b/src/integer_mod_q/mat_polynomial_ring_zq/arithmetic/modulo.rs
@@ -1,0 +1,170 @@
+// Copyright 2026 Jan Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Implementation of the `mod±` function for [`MatPolynomialRingZq`] values.
+
+use crate::{
+    integer::{MatPolyOverZ, Z},
+    integer_mod_q::MatPolynomialRingZq,
+    traits::{GetCoefficient, MatrixDimensions, MatrixGetEntry, MatrixSetEntry, SetCoefficient},
+};
+use std::ops::Rem;
+
+impl MatPolynomialRingZq {
+    /// Computes `self` mod± `modulus` as long as `modulus` is greater than 1, i.e.
+    /// it returns a matrix containing polynomials with coefficients in `[-⌈q/2⌉, ⌈q/2⌉]`.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the remainder closest to `0` is computed
+    ///
+    /// Returns `self` mod± `modulus` as a [`MatPolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer::MatPolyOverZ, integer_mod_q::{MatPolynomialRingZq, ModulusPolynomialRingZq}};
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+    /// let a = MatPolyOverZ::from_str("[[1  2],[1  42]]").unwrap();
+    /// let mut a = MatPolynomialRingZq::from((a, &modulus));
+    ///
+    /// let c = a.mod_pm(24);
+    ///
+    /// assert_eq!(MatPolyOverZ::from_str("[[1  2],[1  -6]]").unwrap(), c);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`.
+    pub fn mod_pm(&self, modulus: impl Into<Z>) -> MatPolyOverZ {
+        let modulus = modulus.into();
+        assert!(modulus > 1, "Modulus can not be smaller than 2.");
+
+        let mut mat = (&self.matrix).rem(&modulus);
+
+        for row in 0..mat.get_num_rows() {
+            for col in 0..mat.get_num_columns() {
+                let mut entry = unsafe { mat.get_entry_unchecked(row, col) };
+                for i in 0..=entry.get_degree() {
+                    let mut coeff = unsafe { entry.get_coeff_unchecked(i) };
+                    if coeff > modulus.div_floor(2) {
+                        coeff -= &modulus;
+                    }
+                    unsafe { entry.set_coeff_unchecked(i, coeff) };
+                }
+                unsafe { mat.set_entry_unchecked(row, col, entry) };
+            }
+        }
+
+        mat
+    }
+}
+
+#[cfg(test)]
+mod test_mod_pm {
+    use super::Z;
+    use crate::{
+        integer::MatPolyOverZ,
+        integer_mod_q::{MatPolynomialRingZq, Modulus, ModulusPolynomialRingZq},
+    };
+    use std::str::FromStr;
+
+    /// Testing mod± for two owned
+    #[test]
+    fn mod_pm() {
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 257").unwrap();
+        let a = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap();
+        let a = MatPolynomialRingZq::from((a, &poly_mod));
+        let b = Z::from(25);
+        let modulus = Modulus::from(25);
+        let c1 = a.clone().mod_pm(b);
+        let c2 = a.clone().mod_pm(modulus);
+        let cmp = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 -8, 1  -1]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Testing mod± for large numbers
+    #[test]
+    fn mod_pm_large_numbers() {
+        let poly_mod =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let a = MatPolyOverZ::from_str(&format!("[[1  2, 1  {}],[2  3 42, 1  24]]", u64::MAX - 1))
+            .unwrap();
+        let a = MatPolynomialRingZq::from((a, &poly_mod));
+        let b = Z::from(u64::MAX - 2);
+        let modulus = Modulus::from(u64::MAX - 2);
+        let c1 = a.clone().mod_pm(&b);
+        let c2 = a.clone().mod_pm(&modulus);
+        let cmp = MatPolyOverZ::from_str("[[1  2, 1  1],[2  3 42, 1  24]]").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Ensures that computing mod± a negative number results in a panic
+    #[test]
+    #[should_panic]
+    fn mod_pm_negative_error() {
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 257").unwrap();
+        let a = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap();
+        let a = MatPolynomialRingZq::from((a, &poly_mod));
+        let b = Z::from(-24);
+        _ = a.mod_pm(&b);
+    }
+
+    /// Ensures that computing mod± 0 results in a panic
+    #[test]
+    #[should_panic]
+    fn zero_modulus() {
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 257").unwrap();
+        let a = MatPolyOverZ::from_str("[[1  2, 1  3],[2  3 42, 1  24]]").unwrap();
+        let a = MatPolynomialRingZq::from((a, &poly_mod));
+        _ = a.mod_pm(0);
+    }
+
+    /// Ensures that `mod±` is available for several types implementing [`Into<Z>`].
+    #[test]
+    fn availability() {
+        let _ =
+            MatPolynomialRingZq::from_str("[[1  2, 1  3],[2  3 42, 1  24]] / 4  1 0 0 1 mod 24")
+                .unwrap()
+                .mod_pm(2u8);
+        let _ =
+            MatPolynomialRingZq::from_str("[[1  2, 1  3],[2  3 42, 1  24]] / 4  1 0 0 1 mod 24")
+                .unwrap()
+                .mod_pm(2u16);
+        let _ =
+            MatPolynomialRingZq::from_str("[[1  2, 1  3],[2  3 42, 1  24]] / 4  1 0 0 1 mod 24")
+                .unwrap()
+                .mod_pm(2u32);
+        let _ =
+            MatPolynomialRingZq::from_str("[[1  2, 1  3],[2  3 42, 1  24]] / 4  1 0 0 1 mod 24")
+                .unwrap()
+                .mod_pm(2u64);
+        let _ =
+            MatPolynomialRingZq::from_str("[[1  2, 1  3],[2  3 42, 1  24]] / 4  1 0 0 1 mod 24")
+                .unwrap()
+                .mod_pm(2i8);
+        let _ =
+            MatPolynomialRingZq::from_str("[[1  2, 1  3],[2  3 42, 1  24]] / 4  1 0 0 1 mod 24")
+                .unwrap()
+                .mod_pm(2i16);
+        let _ =
+            MatPolynomialRingZq::from_str("[[1  2, 1  3],[2  3 42, 1  24]] / 4  1 0 0 1 mod 24")
+                .unwrap()
+                .mod_pm(2i32);
+        let _ =
+            MatPolynomialRingZq::from_str("[[1  2, 1  3],[2  3 42, 1  24]] / 4  1 0 0 1 mod 24")
+                .unwrap()
+                .mod_pm(2i64);
+        let _ =
+            MatPolynomialRingZq::from_str("[[1  2, 1  3],[2  3 42, 1  24]] / 4  1 0 0 1 mod 24")
+                .unwrap()
+                .mod_pm(Z::from(2));
+    }
+}

--- a/src/integer_mod_q/mat_zq/arithmetic.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic.rs
@@ -10,6 +10,7 @@
 //! such as addition or subtraction.
 
 mod add;
+mod modulo;
 mod mul;
 mod mul_scalar;
 mod sub;

--- a/src/integer_mod_q/mat_zq/arithmetic/modulo.rs
+++ b/src/integer_mod_q/mat_zq/arithmetic/modulo.rs
@@ -1,0 +1,148 @@
+// Copyright 2026 Jan Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Implementation of the `mod±` function for [`MatZq`] values.
+
+use crate::{
+    integer::{MatZ, Z},
+    integer_mod_q::MatZq,
+    traits::{MatrixDimensions, MatrixGetEntry, MatrixSetEntry},
+};
+use std::ops::Rem;
+
+impl MatZq {
+    /// Computes `self` mod± `modulus` as long as `modulus` is greater than 1, i.e.
+    /// it returns a matrix with entries in `[-⌈q/2⌉, ⌈q/2⌉]`.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the remainder closest to `0` is computed
+    ///
+    /// Returns `self` mod± `modulus` as a [`MatZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::{integer_mod_q::MatZq, integer::MatZ};
+    /// use std::str::FromStr;
+    ///
+    /// let a = MatZq::from_str("[[2],[42]] mod 24").unwrap();
+    ///
+    /// let c = a.mod_pm(24);
+    ///
+    /// assert_eq!(MatZ::from_str("[[2],[-6]]").unwrap(), c);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`.
+    pub fn mod_pm(&self, modulus: impl Into<Z>) -> MatZ {
+        let modulus = modulus.into();
+        assert!(modulus > 1, "Modulus can not be smaller than 2.");
+
+        let mut mat = self
+            .get_representative_least_nonnegative_residue()
+            .rem(&modulus);
+
+        for row in 0..mat.get_num_rows() {
+            for col in 0..mat.get_num_columns() {
+                let mut entry = unsafe { mat.get_entry_unchecked(row, col) };
+                if entry > modulus.div_floor(2) {
+                    entry -= &modulus;
+                }
+                unsafe { mat.set_entry_unchecked(row, col, entry) };
+            }
+        }
+
+        mat
+    }
+}
+
+#[cfg(test)]
+mod test_mod_pm {
+    use super::Z;
+    use crate::{
+        integer::MatZ,
+        integer_mod_q::{MatZq, Modulus},
+    };
+    use std::str::FromStr;
+
+    /// Testing mod± for two owned
+    #[test]
+    fn mod_pm() {
+        let a = MatZq::from_str("[[2, 3],[42, 24]] mod 257").unwrap();
+        let b = Z::from(25);
+        let c1 = a.clone().mod_pm(b);
+        let c2 = a.mod_pm(Modulus::from(25));
+        assert_eq!(c1, MatZ::from_str("[[2, 3],[-8, -1]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[2, 3],[-8, -1]]").unwrap());
+    }
+
+    /// Testing mod± for large numbers
+    #[test]
+    fn mod_pm_large_numbers() {
+        let a =
+            MatZq::from_str(&format!("[[2, 3],[{}, 24]] mod {}", u64::MAX - 1, u64::MAX)).unwrap();
+        let b = Z::from(u64::MAX - 2);
+        let c1 = a.mod_pm(&b);
+        let c2 = a.mod_pm(&Modulus::from(u64::MAX - 2));
+        assert_eq!(c1, MatZ::from_str("[[2, 3],[1, 24]]").unwrap());
+        assert_eq!(c2, MatZ::from_str("[[2, 3],[1, 24]]").unwrap());
+    }
+
+    /// Ensures that computing mod± a negative number results in a panic
+    #[test]
+    #[should_panic]
+    fn mod_pm_negative_error() {
+        let a = MatZq::from_str("[[2, 3],[42, 24]] mod 25").unwrap();
+        let b = Z::from(-24);
+        _ = &a.mod_pm(&b);
+    }
+
+    /// Ensures that computing mod± 0 results in a panic
+    #[test]
+    #[should_panic]
+    fn zero_modulus() {
+        _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(0);
+    }
+
+    /// Ensures that `mod±` is available for several types.
+    #[test]
+    fn availability() {
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(2u8);
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(2u16);
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(2u32);
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(2u64);
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(2i8);
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(2i16);
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(2i32);
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(2i64);
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(Z::from(2));
+        let _ = MatZq::from_str("[[2, 3],[42, 24]] mod 25")
+            .unwrap()
+            .mod_pm(Modulus::from(2));
+    }
+}

--- a/src/integer_mod_q/poly_over_zq/arithmetic.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic.rs
@@ -10,6 +10,7 @@
 //! such as addition or subtraction.
 
 mod add;
+mod modulo;
 mod mul;
 mod mul_scalar;
 mod sub;

--- a/src/integer_mod_q/poly_over_zq/arithmetic/modulo.rs
+++ b/src/integer_mod_q/poly_over_zq/arithmetic/modulo.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 Jan Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Implementation of the `mod±` function for [`PolyOverZq`] values.
+
+use super::super::PolyOverZq;
+use crate::{
+    integer::{PolyOverZ, Z},
+    traits::{GetCoefficient, SetCoefficient},
+};
+use std::ops::Rem;
+
+impl PolyOverZq {
+    /// Computes `self` mod± `modulus` as long as `modulus` is greater than 1, i.e.
+    /// it returns a polynomial with coefficients in `[-⌈q/2⌉, ⌈q/2⌉]`.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the remainder closest to `0` is computed
+    ///
+    /// Returns `self` mod± `modulus` as a [`PolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::PolyOverZq;
+    /// use qfall_math::integer::PolyOverZ;
+    ///
+    /// let a = PolyOverZq::from((42, 24));
+    ///
+    /// let c = a.mod_pm(24);
+    ///
+    /// assert_eq!(PolyOverZ::from(-6), c);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`.
+    pub fn mod_pm(&self, modulus: impl Into<Z>) -> PolyOverZ {
+        let modulus = modulus.into();
+        assert!(modulus > 1, "Modulus can not be smaller than 2.");
+
+        let mut poly = self
+            .get_representative_least_nonnegative_residue()
+            .rem(&modulus);
+
+        for i in 0..=poly.get_degree() {
+            let mut coeff = unsafe { poly.get_coeff_unchecked(i) };
+            if coeff > modulus.div_floor(2) {
+                coeff -= &modulus;
+            }
+            unsafe { poly.set_coeff_unchecked(i, coeff) };
+        }
+
+        poly
+    }
+}
+
+#[cfg(test)]
+mod test_mod_pm {
+    use super::Z;
+    use crate::{
+        integer::PolyOverZ,
+        integer_mod_q::{Modulus, PolyOverZq},
+    };
+    use std::str::FromStr;
+
+    /// Testing mod± for two owned
+    #[test]
+    fn mod_pm() {
+        let a = PolyOverZq::from_str("2  2 42 mod 257").unwrap();
+        let b = Z::from(25);
+        let modulus = Modulus::from(25);
+        let c1 = a.clone().mod_pm(b);
+        let c2 = a.clone().mod_pm(modulus);
+        let cmp = PolyOverZ::from_str("2  2 -8").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Testing mod± for large numbers
+    #[test]
+    fn mod_pm_large_numbers() {
+        let a = PolyOverZq::from_str(&format!("2  2 {}  mod {}", u64::MAX - 1, u64::MAX)).unwrap();
+        let b = Z::from(u64::MAX - 2);
+        let modulus = Modulus::from(u64::MAX - 2);
+        let c1 = a.clone().mod_pm(&b);
+        let c2 = a.clone().mod_pm(&modulus);
+        let cmp = PolyOverZ::from_str("2  2 1").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Ensures that computing mod± a negative number results in a panic
+    #[test]
+    #[should_panic]
+    fn mod_pm_negative_error() {
+        let a = PolyOverZq::from_str("2  2 42 mod 7").unwrap();
+        let b = Z::from(-24);
+        _ = &a.mod_pm(&b);
+    }
+
+    /// Ensures that computing mod± 0 results in a panic
+    #[test]
+    #[should_panic]
+    fn zero_modulus() {
+        let a = PolyOverZq::from_str("2  2 42 mod 7").unwrap();
+        _ = a.mod_pm(0);
+    }
+
+    /// Ensures that `mod±` is available for several types
+    #[test]
+    fn availability() {
+        let _ = PolyOverZq::from_str("2  2 42 mod 7").unwrap().mod_pm(2u8);
+        let _ = PolyOverZq::from_str("2  2 42 mod 7").unwrap().mod_pm(2u16);
+        let _ = PolyOverZq::from_str("2  2 42 mod 7").unwrap().mod_pm(2u32);
+        let _ = PolyOverZq::from_str("2  2 42 mod 7").unwrap().mod_pm(2u64);
+        let _ = PolyOverZq::from_str("2  2 42 mod 7").unwrap().mod_pm(2i8);
+        let _ = PolyOverZq::from_str("2  2 42 mod 7").unwrap().mod_pm(2i16);
+        let _ = PolyOverZq::from_str("2  2 42 mod 7").unwrap().mod_pm(2i32);
+        let _ = PolyOverZq::from_str("2  2 42 mod 7").unwrap().mod_pm(2i64);
+        let _ = PolyOverZq::from_str("2  2 42 mod 7")
+            .unwrap()
+            .mod_pm(Z::from(2));
+        let _ = PolyOverZq::from_str("2  2 42 mod 7")
+            .unwrap()
+            .mod_pm(Modulus::from(2));
+    }
+}

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic.rs
@@ -10,6 +10,7 @@
 //! such as addition or subtraction.
 
 mod add;
+mod modulo;
 mod mul;
 mod mul_scalar;
 mod sub;

--- a/src/integer_mod_q/polynomial_ring_zq/arithmetic/modulo.rs
+++ b/src/integer_mod_q/polynomial_ring_zq/arithmetic/modulo.rs
@@ -1,0 +1,158 @@
+// Copyright 2026 Jan Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Implementation of the `mod±` function for [`PolynomialRingZq`] values.
+
+use super::super::PolynomialRingZq;
+use crate::{
+    integer::{PolyOverZ, Z},
+    traits::{GetCoefficient, SetCoefficient},
+};
+use std::ops::Rem;
+
+impl PolynomialRingZq {
+    /// Computes `self` mod± `modulus` as long as `modulus` is greater than 1, i.e.
+    /// it returns a polynomial with coefficients in `[-⌈q/2⌉, ⌈q/2⌉]`.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the remainder closest to `0` is computed
+    ///
+    /// Returns `self` mod± `modulus` as a [`PolyOverZ`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::{PolynomialRingZq, ModulusPolynomialRingZq};
+    /// use qfall_math::integer::PolyOverZ;
+    /// use std::str::FromStr;
+    ///
+    /// let modulus = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+    /// let poly_1 = PolyOverZ::from(42);
+    /// let mut a = PolynomialRingZq::from((&poly_1, &modulus));
+    ///
+    /// let c = a.mod_pm(24);
+    ///
+    /// assert_eq!(PolyOverZ::from(-6), c);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`.
+    pub fn mod_pm(&self, modulus: impl Into<Z>) -> PolyOverZ {
+        let modulus = modulus.into();
+        assert!(modulus > 1, "Modulus can not be smaller than 2.");
+
+        let mut poly = (&self.poly).rem(&modulus);
+
+        for i in 0..=poly.get_degree() {
+            let mut coeff = unsafe { poly.get_coeff_unchecked(i) };
+            if coeff > modulus.div_floor(2) {
+                coeff -= &modulus;
+            }
+            unsafe { poly.set_coeff_unchecked(i, coeff) };
+        }
+
+        poly
+    }
+}
+
+#[cfg(test)]
+mod test_mod_pm {
+    use super::Z;
+    use crate::{
+        integer::PolyOverZ,
+        integer_mod_q::{Modulus, ModulusPolynomialRingZq, PolynomialRingZq},
+    };
+    use std::str::FromStr;
+
+    /// Testing mod± for two owned
+    #[test]
+    fn mod_pm() {
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 257").unwrap();
+        let a = PolyOverZ::from_str("2  2 42").unwrap();
+        let a = PolynomialRingZq::from((a, &poly_mod));
+        let b = Z::from(25);
+        let modulus = Modulus::from(25);
+        let c1 = a.clone().mod_pm(b);
+        let c2 = a.clone().mod_pm(modulus);
+        let cmp = PolyOverZ::from_str("2  2 -8").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Testing mod± for large numbers
+    #[test]
+    fn mod_pm_large_numbers() {
+        let poly_mod =
+            ModulusPolynomialRingZq::from_str(&format!("4  1 0 0 1 mod {}", u64::MAX)).unwrap();
+        let a = PolyOverZ::from_str(&format!("2  2 {}", u64::MAX - 1)).unwrap();
+        let a = PolynomialRingZq::from((a, &poly_mod));
+        let b = Z::from(u64::MAX - 2);
+        let modulus = Modulus::from(u64::MAX - 2);
+        let c1 = a.clone().mod_pm(&b);
+        let c2 = a.clone().mod_pm(&modulus);
+        let cmp = PolyOverZ::from_str("2  2 1").unwrap();
+        assert_eq!(c1, cmp);
+        assert_eq!(c2, cmp);
+    }
+
+    /// Ensures that computing mod± a negative number results in a panic
+    #[test]
+    #[should_panic]
+    fn mod_pm_negative_error() {
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let a = PolyOverZ::from_str("2  2 42").unwrap();
+        let a = PolynomialRingZq::from((a, &poly_mod));
+        let b = Z::from(-24);
+        _ = &a.mod_pm(&b);
+    }
+
+    /// Ensures that computing mod± 0 results in a panic
+    #[test]
+    #[should_panic]
+    fn zero_modulus() {
+        let poly_mod = ModulusPolynomialRingZq::from_str("4  1 0 0 1 mod 24").unwrap();
+        let a = PolyOverZ::from_str("2  2 42").unwrap();
+        let a = PolynomialRingZq::from((a, &poly_mod));
+        _ = a.mod_pm(0);
+    }
+
+    /// Ensures that `mod±` is available for several types
+    #[test]
+    fn availability() {
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(2u8);
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(2u16);
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(2u32);
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(2u64);
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(2i8);
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(2i16);
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(2i32);
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(2i64);
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(Z::from(2));
+        let _ = PolynomialRingZq::from_str("2  2 42 / 4  1 0 0 1 mod 7")
+            .unwrap()
+            .mod_pm(Modulus::from(2));
+    }
+}

--- a/src/integer_mod_q/z_q/arithmetic.rs
+++ b/src/integer_mod_q/z_q/arithmetic.rs
@@ -10,6 +10,7 @@
 //! such as addition or subtraction.
 
 mod add;
+mod modulo;
 mod mul;
 mod pow;
 mod sub;

--- a/src/integer_mod_q/z_q/arithmetic/modulo.rs
+++ b/src/integer_mod_q/z_q/arithmetic/modulo.rs
@@ -1,0 +1,111 @@
+// Copyright 2026 Jan Niklas Siemer
+//
+// This file is part of qFALL-math.
+//
+// qFALL-math is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! Implementation of the `mod±` function for [`Zq`] values.
+
+use super::super::Zq;
+use crate::integer::Z;
+use std::ops::Rem;
+
+impl Zq {
+    /// Computes `self` mod± `modulus` as long as `modulus` is greater than 1, i.e.
+    /// it returns a value in `[-⌈q/2⌉, ⌈q/2⌉]`.
+    ///
+    /// Parameters:
+    /// - `modulus`: specifies a non-zero integer
+    ///   over which the remainder closest to `0` is computed
+    ///
+    /// Returns `self` mod± `modulus` as a [`Z`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// use qfall_math::integer_mod_q::Zq;
+    ///
+    /// let a = Zq::from((42, 24));
+    /// let b = 24;
+    ///
+    /// let c = a.mod_pm(b);
+    ///
+    /// assert_eq!(-6, c);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus` is smaller than `2`.
+    pub fn mod_pm(&self, modulus: impl Into<Z>) -> Z {
+        let modulus = modulus.into();
+        assert!(modulus > 1, "Modulus can not be smaller than 2.");
+
+        let mut value = (&self.value).rem(&modulus);
+
+        if value > modulus.div_floor(2) {
+            value -= modulus;
+        }
+        value
+    }
+}
+
+#[cfg(test)]
+mod test_mod_pm {
+    use super::{Z, Zq};
+    use crate::integer_mod_q::Modulus;
+
+    /// Testing mod± for two [`Zq`]
+    #[test]
+    fn mod_pm() {
+        let a = Zq::from((42, 257));
+        let b = Z::from(25);
+
+        let c1 = a.mod_pm(b);
+        let c2 = a.mod_pm(25);
+
+        assert_eq!(c1, -8);
+        assert_eq!(c2, -8);
+    }
+
+    /// Testing mod± for large numbers
+    #[test]
+    fn mod_pm_large_numbers() {
+        let a = Zq::from((u64::MAX - 1, u64::MAX));
+        let b = Z::from(u64::MAX - 2);
+
+        let c1 = a.clone().mod_pm(&b);
+        let c2 = a.mod_pm(&Z::from(u64::MAX - 2));
+
+        assert_eq!(c1, 1);
+        assert_eq!(c2, 1);
+    }
+
+    /// Ensures that computing mod± a negative number results in a panic
+    #[test]
+    #[should_panic]
+    fn mod_pm_negative_error() {
+        _ = Zq::from(42).mod_pm(-24);
+    }
+
+    /// Ensures that computing mod± 0 results in a panic
+    #[test]
+    #[should_panic]
+    fn zero_modulus() {
+        _ = Zq::from(15).mod_pm(0);
+    }
+
+    /// Ensures that `mod±` is available for several types.
+    #[test]
+    fn availability() {
+        let _ = Zq::from((0, 7)).mod_pm(2u8);
+        let _ = Zq::from((0, 7)).mod_pm(2u16);
+        let _ = Zq::from((0, 7)).mod_pm(2u32);
+        let _ = Zq::from((0, 7)).mod_pm(2u64);
+        let _ = Zq::from((0, 7)).mod_pm(2i8);
+        let _ = Zq::from((0, 7)).mod_pm(2i16);
+        let _ = Zq::from((0, 7)).mod_pm(2i32);
+        let _ = Zq::from((0, 7)).mod_pm(2i64);
+        let _ = Zq::from((0, 7)).mod_pm(Z::from(2));
+        let _ = Zq::from((0, 7)).mod_pm(Modulus::from(2));
+    }
+}


### PR DESCRIPTION
**Description**

This PR implements...
- [x] `mod_pm` for all `integer` and `integer_mod_q` datatypes except for NTT datatypes.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)
- [x] I added tests for large (pointer representation) values
- [x] I triggered all possible errors in my test in every possible way
- [x] I included tests for all reasonable edge cases

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide